### PR TITLE
Fix compilation errors on FreeBSD

### DIFF
--- a/libcomp/src/Exception.cpp
+++ b/libcomp/src/Exception.cpp
@@ -46,6 +46,12 @@ using namespace libcomp;
 /// If the module name should be stripped from the backtrace.
 #define EXCEPTION_STRIP_MODULE (0)
 
+#if __FreeBSD__
+typedef size_t  backtrace_size_t;
+#elif __linux__
+typedef int     backtrace_size_t;
+#endif
+
 /**
  * Length of the absolute path to the source directory to strip from backtrace
  * paths. Calculate the length of the path to the project so we may remove that
@@ -63,7 +69,7 @@ Exception::Exception(const String& msg, const String& f, int l) :
     void *backtraceAddresses[MAX_BACKTRACE_DEPTH];
 
     // Populate the array of backtrace addresses and get how many were added.
-    int backtraceSize = ::backtrace(backtraceAddresses, MAX_BACKTRACE_DEPTH);
+    backtrace_size_t backtraceSize = ::backtrace(backtraceAddresses, MAX_BACKTRACE_DEPTH);
 
     // If we have a valid array of backtraces, parse them.
     if(backtraceSize > 0)
@@ -78,7 +84,7 @@ Exception::Exception(const String& msg, const String& f, int l) :
             // For each symbol in the array, convert it to a String and add it
             // to the backtrace string list. Set i = 1 to skip over this
             // constructor function.
-            for(int i = 1; i < backtraceSize; i++)
+            for(backtrace_size_t i = 1; i < backtraceSize; i++)
             {
                 std::string symbol = backtraceSymbols[i];
                 std::string demangled;

--- a/libcomp/src/Packet.cpp
+++ b/libcomp/src/Packet.cpp
@@ -344,7 +344,7 @@ void Packet::WriteS16Big(int16_t value)
 void Packet::WriteS16Little(int16_t value)
 {
     // Convert the value to little endian byte order and then write it.
-    WriteS16(htole16(value));
+    WriteS16((int16_t)htole16(value));
 }
 
 void Packet::WriteU32(uint32_t value)
@@ -386,7 +386,7 @@ void Packet::WriteS32Big(int32_t value)
 void Packet::WriteS32Little(int32_t value)
 {
     // Convert the value to little endian byte order and then write it.
-    WriteS32(htole32(value));
+    WriteS32((int32_t)htole32(value));
 }
 
 void Packet::WriteU64(uint64_t value)
@@ -428,7 +428,7 @@ void Packet::WriteS64Big(int64_t value)
 void Packet::WriteS64Little(int64_t value)
 {
     // Convert the value to little endian byte order and then write it.
-    WriteS64(htole64(value));
+    WriteS64((int64_t)htole64(value));
 }
 
 void Packet::WriteFloat(float value)

--- a/libcomp/src/ReadOnlyPacket.cpp
+++ b/libcomp/src/ReadOnlyPacket.cpp
@@ -488,7 +488,7 @@ int16_t ReadOnlyPacket::ReadS16Big()
 int16_t ReadOnlyPacket::ReadS16Little()
 {
     // Return the value converted from little endian byte order.
-    return le16toh(ReadS16());
+    return (int16_t)le16toh(ReadS16());
 }
 
 uint32_t ReadOnlyPacket::ReadU32()
@@ -550,7 +550,7 @@ int32_t ReadOnlyPacket::ReadS32Big()
 int32_t ReadOnlyPacket::ReadS32Little()
 {
     // Return the value converted from little endian byte order.
-    return le32toh(ReadS32());
+    return (int32_t)le32toh(ReadS32());
 }
 
 uint64_t ReadOnlyPacket::ReadU64()
@@ -612,7 +612,7 @@ int64_t ReadOnlyPacket::ReadS64Big()
 int64_t ReadOnlyPacket::ReadS64Little()
 {
     // Return the value converted from little endian byte order.
-    return le64toh(ReadS64());
+    return (int64_t)le64toh(ReadS64());
 }
 
 float ReadOnlyPacket::ReadFloat()


### PR DESCRIPTION
This patch fixes a couple of compilation issues when building on FreeBSD
- Exceptions.cpp has been modified to use size_t instead of int for the backtrace routine (freebsd uses size_t). Without this change two errors are thrown: signed/unsigned conversion and 64/32 conversion.

- Packer.cpp and ReadOnlyPacket.cpp have been updated to ensure that various endianess conversion routines do not thrown signed/unsigned conversion errors.