### PR TITLE
[FIX] Add missing BUILD_BYPRODUCTS for ninja to build properly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env:
         - COMPILER_CC=clang
         - COMPILER_CXX=clang++
-        - CMAKE_GENERATOR=Unix Makefiles
+        - CMAKE_GENERATOR='Unix Makefiles'
     - compiler: clang
       env:
         - COMPILER_CC=clang
@@ -42,7 +42,7 @@ before_install:
   - cd /opt/ninja/bin
   - sudo wget https://github.com/ninja-build/ninja/releases/download/v1.7.1/ninja-linux.zip
   - sudo unzip ninja-linux.zip
-  - sudo chmod +x ninja
+  - sudo chmod 755 ninja
   - sudo rm ninja-linux.zip
   - export PATH="/opt/ninja/bin:${PATH}"
   - cd /opt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       name: "comphack/comp_hack"
       description: "Build submitted via Travis CI"
     notification_email: compomega@tutanota.com
-    build_command_prepend: "mkdir build && cd build && cmake -G '${GENERATOR' .."
+    build_command_prepend: "mkdir build && cd build && cmake -G \"${GENERATOR\" .."
     build_command: "cmake --build ."
     branch_pattern: coverity_scan
 
@@ -81,4 +81,4 @@ script:
   - sleep 10
   - nodetool status
   - cqlsh -e "SHOW HOST; SHOW VERSION;"
-  - mkdir -p build && cd build && cmake -G '${GENERATOR}' .. && cmake --build . && cmake --build . --target Experimental
+  - mkdir -p build && cd build && cmake -G "${GENERATOR}" .. && cmake --build . && cmake --build . --target Experimental

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
       name: "comphack/comp_hack"
       description: "Build submitted via Travis CI"
     notification_email: compomega@tutanota.com
-    build_command_prepend: "mkdir build && cd build && cmake .."
-    build_command: "make"
+    build_command_prepend: "mkdir build && cd build && cmake -G ${GENERATOR} .."
+    build_command: "cmake --build ."
     branch_pattern: coverity_scan
 
 matrix:
@@ -27,11 +27,24 @@ matrix:
       env:
         - COMPILER_CC=clang
         - COMPILER_CXX=clang++
+        - CMAKE_GENERATOR=Unix Makefiles
+    - compiler: clang
+      env:
+        - COMPILER_CC=clang
+        - COMPILER_CXX=clang++
+        - CMAKE_GENERATOR=Ninja
 
 before_install:
   - sudo apt-get update -q
-  - sudo apt-get install libssl-dev doxygen libsqlite3-dev sqlite3 libuv-dev -y
+  - sudo apt-get install libssl-dev doxygen libsqlite3-dev sqlite3 libuv-dev unzip -y
   - export cwd="`pwd`"
+  - sudo mkdir -p /opt/ninja/bin
+  - cd /opt/ninja/bin
+  - sudo wget https://github.com/ninja-build/ninja/releases/download/v1.7.1/ninja-linux.zip
+  - sudo unzip ninja-linux.zip
+  - sudo chmod +x ninja
+  - sudo rm ninja-linux.zip
+  - export PATH="/opt/ninja/bin:${PATH}"
   - cd /opt
   - sudo wget -q https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz
   - sudo tar xf cmake-3.6.1-Linux-x86_64.tar.gz
@@ -49,6 +62,7 @@ before_install:
   - if [ "$CXX" == "clang++" ]; then cd "$cwd"; fi
   - export CC="${COMPILER_CC}"
   - export CXX="${COMPILER_CXX}"
+  - export GENERATOR="${CMAKE_GENERATOR}"
 
 script:
   - jdk_switcher use oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
   - cd /opt
   - sudo wget -q https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz
   - sudo tar xf cmake-3.6.1-Linux-x86_64.tar.gz
-  - rm cmake-3.6.1-Linux-x86_64.tar.gz
+  - sudo rm cmake-3.6.1-Linux-x86_64.tar.gz
   - export PATH="/opt/cmake-3.6.1-Linux-x86_64/bin:${PATH}"
   - export LD_LIBRARY_PATH="/opt/cmake-3.6.1-Linux-x86_64/lib"
   - cd $cwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,4 @@ script:
   - sleep 10
   - nodetool status
   - cqlsh -e "SHOW HOST; SHOW VERSION;"
-  - mkdir -p build && cd build && cmake .. && make && make Experimental
+  - mkdir -p build && cd build && cmake -G ${GENERATOR} .. && cmake --build . && cmake --build . --target Experimental

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,22 @@ matrix:
 
 before_install:
   - sudo apt-get update -q
-  - sudo apt-get install libssl-dev doxygen cmake cmake-data libsqlite3-dev sqlite3 libuv-dev -y
+  - sudo apt-get install libssl-dev doxygen libsqlite3-dev sqlite3 libuv-dev -y
+  - export cwd="`pwd`"
+  - cd /opt
+  - sudo wget -q https://cmake.org/files/v3.6/cmake-3.6.1-Linux-x86_64.tar.gz
+  - sudo tar xf cmake-3.6.1-Linux-x86_64.tar.gz
+  - rm cmake-3.6.1-Linux-x86_64.tar.gz
+  - export PATH="/opt/cmake-3.6.1-Linux-x86_64/bin:${PATH}"
+  - export LD_LIBRARY_PATH="/opt/cmake-3.6.1-Linux-x86_64/lib"
+  - cd $cwd
   - if [ "$CXX" == "clang++" ]; then export cwd="`pwd`"; fi
   - if [ "$CXX" == "clang++" ]; then cd /opt; fi
   - if [ "$CXX" == "clang++" ]; then sudo wget -q http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
   - if [ "$CXX" == "clang++" ]; then sudo tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
   - if [ "$CXX" == "clang++" ]; then sudo rm clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi
   - if [ "$CXX" == "clang++" ]; then export PATH="/opt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/bin:${PATH}"; fi
-  - if [ "$CXX" == "clang++" ]; then export LD_LIBRARY_PATH="/opt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/lib"; fi
+  - if [ "$CXX" == "clang++" ]; then export LD_LIBRARY_PATH="/opt/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-14.04/lib:${LD_LIBRARY_PATH}"; fi
   - if [ "$CXX" == "clang++" ]; then cd "$cwd"; fi
   - export CC="${COMPILER_CC}"
   - export CXX="${COMPILER_CXX}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
       name: "comphack/comp_hack"
       description: "Build submitted via Travis CI"
     notification_email: compomega@tutanota.com
-    build_command_prepend: "mkdir build && cd build && cmake -G ${GENERATOR} .."
+    build_command_prepend: "mkdir build && cd build && cmake -G '${GENERATOR' .."
     build_command: "cmake --build ."
     branch_pattern: coverity_scan
 
@@ -81,4 +81,4 @@ script:
   - sleep 10
   - nodetool status
   - cqlsh -e "SHOW HOST; SHOW VERSION;"
-  - mkdir -p build && cd build && cmake -G ${GENERATOR} .. && cmake --build . && cmake --build . --target Experimental
+  - mkdir -p build && cd build && cmake -G '${GENERATOR}' .. && cmake --build . && cmake --build . --target Experimental

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
 
 # http://stackoverflow.com/questions/14933172/
 IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.2)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.2.3)
 
 # http://stackoverflow.com/questions/14933172/
 IF("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/cmake/external.cmake
+++ b/cmake/external.cmake
@@ -211,7 +211,7 @@ ExternalProject_Add(
     LOG_BUILD ON
     LOG_INSTALL ON
 
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libtinyxml2.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libtinyxml2.a
 )
 
 ExternalProject_Get_Property(tinyxml2-ex INSTALL_DIR)
@@ -237,8 +237,9 @@ ExternalProject_Add(
     LOG_BUILD ON
     LOG_INSTALL ON
 
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libgtest.a <INSTALL_DIR>/lib/libgmock.a
-        <INSTALL_DIR>/lib/libgmock_main.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libgtest.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libgmock.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libgmock_main.a
 )
 
 ExternalProject_Get_Property(googletest INSTALL_DIR)

--- a/cmake/external.cmake
+++ b/cmake/external.cmake
@@ -32,6 +32,8 @@ ExternalProject_Add(
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
+
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcassandra_static.a
 )
 
 ExternalProject_Get_Property(cassandra-cpp INSTALL_DIR)
@@ -57,6 +59,10 @@ ExternalProject_Add(
     LOG_CONFIGURE ON
     LOG_BUILD ON
     LOG_INSTALL ON
+
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libttvfs.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libttvfs_cfileapi.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libttvfs_zip.a
 )
 
 ExternalProject_Get_Property(ttvfs-ex INSTALL_DIR)
@@ -115,8 +121,8 @@ ExternalProject_Add(
     LOG_BUILD ON
     LOG_INSTALL ON
 
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcivetweb.a
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcxx-library.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcivetweb.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libcxx-library.a
 )
 
 ExternalProject_Get_Property(civet INSTALL_DIR)
@@ -148,8 +154,8 @@ ExternalProject_Add(
     LOG_BUILD ON
     LOG_INSTALL ON
 
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libsquirrel.a
-    #BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libsqstdlib.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libsquirrel.a
+    BUILD_BYPRODUCTS <INSTALL_DIR>/lib/libsqstdlib.a
 )
 
 ExternalProject_Get_Property(squirrel3 INSTALL_DIR)


### PR DESCRIPTION
- Update required cmake version to 3.2.3 to support the ExternalProjects_Add's BUILD_BYPRODUCTS option. This option is needed for ninja to properly determine dependencies.
- Add/enable missing BUILD_BYPRODUCTS options to fix ninja builds.
- Update travis-ci to build with both Makefiles and ninja.