### PR TITLE
Multiple database support and sending connection information between servers

### DIFF
--- a/contrib/testing/channel.xml
+++ b/contrib/testing/channel.xml
@@ -5,19 +5,6 @@
         <member name="DiffieHellmanKeyPair">9C4169BBE8F535F7A7404D4EB3AE22CF63C0450FC2C7B2A5A03794D4CFA9F290FF5774267885E60B848280E3A07468366E62F040DAC3CB67E95E8F3DC4D97F94AD1D3D98F0B066F72B65CB391643A95BB96CF048ED5D60FB7AF7A969F38ABD2301F6A7EC4DB7DAFC2CFD1F417E0B634033FEE8B102D62A28EC03D95266E2B0B3</member>
         <member name="Port">14666</member>
         <member name="DatabaseType">CASSANDRA</member>    <!-- CASSANDRA/SQLITE3 -->
-        <member name="SQLite3Config">
-            <member name="IP">127.0.0.1</member>
-            <member name="DatabaseName">world</member>
-            <member name="DefaultDatabaseName">comp_hack</member>
-            <!--<member name="FileDirectory"/>-->
-        </member>
-        <member name="CassandraConfig">
-            <member name="IP">127.0.0.1</member>
-            <member name="Keyspace">world</member>
-            <member name="DefaultKeyspace">comp_hack</member>
-            <!--<member name="Username"/>-->
-            <!--<member name="Password"/>-->
-        </member>
         <member name="MultithreadMode">true</member>
         
         <!-- From ChannelConfig -->

--- a/libcomp/schema/serverconfig.xml
+++ b/libcomp/schema/serverconfig.xml
@@ -8,8 +8,6 @@
             <value>CASSANDRA</value>
             <value>SQLITE3</value>
         </member>
-        <member type="DatabaseConfigSQLite3*" name="SQLite3Config"/>
-        <member type="DatabaseConfigCassandra*" name="CassandraConfig"/>
         <member type="bool" name="MultithreadMode" default="true"/>
     </object>
 </objgen>

--- a/libcomp/src/BaseServer.h
+++ b/libcomp/src/BaseServer.h
@@ -29,6 +29,7 @@
 
 // libcomp Includes
 #include "Database.h"
+#include "DatabaseConfig.h"
 #include "EncryptedConnection.h"
 #include "ServerConfig.h"
 #include "TcpServer.h"
@@ -68,6 +69,17 @@ public:
      * @return true on success, false on failure
      */
     virtual bool Initialize(std::weak_ptr<BaseServer>& self);
+    
+    /**
+     * Get an open database connection of the database type associated to the
+     * server.
+     * @param configMap Map of the available database configs by type
+     * @param performSetup If true, @ref Database::Setup will be executed
+     * @return Pointer to the new database connection or nullptr on failure
+     */
+    std::shared_ptr<Database> GetDatabase(
+        const EnumMap<objects::ServerConfig::DatabaseType_t,
+            std::shared_ptr<objects::DatabaseConfig>>& configMap, bool performSetup);
 
     /**
      * Call the Shutdown function on each worker.  This should be called
@@ -148,9 +160,6 @@ protected:
 
     /// A shared pointer to the config used to set up the server.
     std::shared_ptr<objects::ServerConfig> mConfig;
-
-    /// A shared pointer to the database used by the server.
-    std::shared_ptr<libcomp::Database> mDatabase;
 
     /// Worker that blocks and runs in the main thread.
     libcomp::Worker mMainWorker;

--- a/libcomp/src/Database.cpp
+++ b/libcomp/src/Database.cpp
@@ -28,8 +28,6 @@
 
 using namespace libcomp;
 
-std::shared_ptr<Database> Database::sMain = nullptr;
-
 Database::Database(const std::shared_ptr<objects::DatabaseConfig>& config)
 {
     mConfig = config;
@@ -37,10 +35,6 @@ Database::Database(const std::shared_ptr<objects::DatabaseConfig>& config)
 
 Database::~Database()
 {
-    if(sMain.get() == this)
-    {
-        sMain = nullptr;
-    }
 }
 
 bool Database::Execute(const String& query)
@@ -51,16 +45,6 @@ bool Database::Execute(const String& query)
 String Database::GetLastError() const
 {
     return mError;
-}
-
-const std::shared_ptr<Database> Database::GetMainDatabase()
-{
-    return sMain;
-}
-
-void Database::SetMainDatabase(std::shared_ptr<Database> database)
-{
-    sMain = database;
 }
 
 std::shared_ptr<objects::DatabaseConfig> Database::GetConfig() const

--- a/libcomp/src/Database.cpp
+++ b/libcomp/src/Database.cpp
@@ -30,6 +30,11 @@ using namespace libcomp;
 
 std::shared_ptr<Database> Database::sMain = nullptr;
 
+Database::Database(const std::shared_ptr<objects::DatabaseConfig>& config)
+{
+    mConfig = config;
+}
+
 Database::~Database()
 {
     if(sMain.get() == this)
@@ -56,6 +61,11 @@ const std::shared_ptr<Database> Database::GetMainDatabase()
 void Database::SetMainDatabase(std::shared_ptr<Database> database)
 {
     sMain = database;
+}
+
+std::shared_ptr<objects::DatabaseConfig> Database::GetConfig() const
+{
+    return mConfig;
 }
 
 bool Database::TableHasRows(const String& table)

--- a/libcomp/src/Database.h
+++ b/libcomp/src/Database.h
@@ -29,6 +29,7 @@
 
 // libcomp Includes
 #include "CString.h"
+#include "DatabaseConfig.h"
 #include "DatabaseQuery.h"
 #include "PersistentObject.h"
 
@@ -48,6 +49,12 @@ class DatabaseBind;
 class Database
 {
 public:
+    /**
+     * Create a new Database connection.
+     * @param config Pointer to a database configuration
+     */
+    Database(const std::shared_ptr<objects::DatabaseConfig>& config);
+
     /**
      * Close and clean up the database connection.
      */
@@ -177,6 +184,12 @@ public:
      * @param database Pointer to the main database
      */
     static void SetMainDatabase(std::shared_ptr<Database> database);
+    
+    /**
+     * Get the database config.
+     * @return Pointer to the database config
+     */
+    std::shared_ptr<objects::DatabaseConfig> GetConfig() const;
 
 protected:
     /**
@@ -195,6 +208,9 @@ protected:
 
     /// Static pointer to the current main database
     static std::shared_ptr<Database> sMain;
+
+    /// Pointer to the config file used to configure the database connection
+    std::shared_ptr<objects::DatabaseConfig> mConfig;
 };
 
 } // namespace libcomp

--- a/libcomp/src/Database.h
+++ b/libcomp/src/Database.h
@@ -168,22 +168,6 @@ public:
      * @return The last error that occurred
      */
     String GetLastError() const;
-
-    /**
-     * Static accessor to get the current database configured as the
-     * "main" database in a server config.
-     * @sa Database::SetMainDatabase
-     * @return Pointer to the main database
-     */
-    static const std::shared_ptr<Database> GetMainDatabase();
-
-    /**
-     * Static modifier to set the current database configured as the
-     * "main" database in a server config.
-     * @sa Database::GetMainDatabase
-     * @param database Pointer to the main database
-     */
-    static void SetMainDatabase(std::shared_ptr<Database> database);
     
     /**
      * Get the database config.
@@ -205,9 +189,6 @@ protected:
 
     /// Last error raised by a database related action
     String mError;
-
-    /// Static pointer to the current main database
-    static std::shared_ptr<Database> sMain;
 
     /// Pointer to the config file used to configure the database connection
     std::shared_ptr<objects::DatabaseConfig> mConfig;

--- a/libcomp/src/DatabaseCassandra.h
+++ b/libcomp/src/DatabaseCassandra.h
@@ -123,9 +123,6 @@ private:
 
     /// Pointer to the Cassandra representation of the connection's session
     CassSession *mSession;
-
-    /// Pointer to the config file used to configure the database connection
-    std::shared_ptr<objects::DatabaseConfigCassandra> mConfig;
 };
 
 } // namespace libcomp

--- a/libcomp/src/DatabaseQuerySQLite3.cpp
+++ b/libcomp/src/DatabaseQuerySQLite3.cpp
@@ -87,7 +87,7 @@ bool DatabaseQuerySQLite3::Next()
     else
     {
         mDidJustExecute = false;
-        return true;
+        return SQLITE_DONE != mStatus;
     }
 
     return IsValid() && SQLITE_DONE != mStatus;

--- a/libcomp/src/DatabaseSQLite3.h
+++ b/libcomp/src/DatabaseSQLite3.h
@@ -123,9 +123,6 @@ private:
 
     /// Pointer to the SQLite3 representation of the database file connection
     sqlite3 *mDatabase;
-
-    /// Pointer to the config file used to configure the database connection
-    std::shared_ptr<objects::DatabaseConfigSQLite3> mConfig;
 };
 
 } // namespace libcomp

--- a/libcomp/src/Object.cpp
+++ b/libcomp/src/Object.cpp
@@ -41,20 +41,28 @@ Object::~Object()
 {
 }
 
-bool Object::LoadPacket(libcomp::ReadOnlyPacket& p)
+bool Object::LoadPacket(libcomp::ReadOnlyPacket& p, bool flat)
 {
     ReadOnlyPacketStream buffer(p);
     std::istream in(&buffer);
 
-    return Load(in, true);
+    auto startingPos = in.tellg();
+    bool success = Load(in, flat);
+    if(success)
+    {
+        //Fast forward the packet
+        auto newPos = in.tellg();
+        p.Skip(static_cast<uint32_t>(newPos - startingPos));
+    }
+    return success;
 }
 
-bool Object::SavePacket(libcomp::Packet& p) const
+bool Object::SavePacket(libcomp::Packet& p, bool flat) const
 {
     PacketStream buffer(p);
     std::ostream out(&buffer);
 
-    return Save(out, true);
+    return Save(out, flat);
 }
 
 const tinyxml2::XMLElement*

--- a/libcomp/src/Object.h
+++ b/libcomp/src/Object.h
@@ -170,16 +170,18 @@ public:
     /**
      * Load the object's data members from a data packet.
      * @param p Packet containing data member values
+     * @param flat Specifies if the call to Load should be flat
      * @return true if loading was successful, false if it was not
      */
-    virtual bool LoadPacket(libcomp::ReadOnlyPacket& p);
+    virtual bool LoadPacket(libcomp::ReadOnlyPacket& p, bool flat = true);
 
     /**
      * Save the object's data members to a data packet.
      * @param p Packet to save data member values to
+     * @param flat Specifies if the call to Save should be flat
      * @return true if saving was successful, false if it was not
      */
-    virtual bool SavePacket(libcomp::Packet& p) const;
+    virtual bool SavePacket(libcomp::Packet& p, bool flat = true) const;
 
     /**
      * Get the dynamic size count of the MetaObject definition.

--- a/libcomp/src/ObjectReference.h
+++ b/libcomp/src/ObjectReference.h
@@ -28,6 +28,7 @@
 #define LIBCOMP_SRC_OBJECTREFERENCE_H
 
 // libcomp Includes
+#include "Database.h"
 #include "PersistentObject.h"
 
 namespace libcomp
@@ -73,11 +74,12 @@ public:
      * Get the pointer to the referenced object.  This will
      * cause the reference to load from the database if only
      * the UUID is set.
+     * @param db Database to load from if persistent
      * @return Pointer to the referenced object
      */
-    const std::shared_ptr<T> Get()
+    const std::shared_ptr<T> Get(const std::shared_ptr<Database>& db = nullptr)
     {
-        LoadReference();
+        LoadReference(db);
 
         return mRef;
     }
@@ -97,13 +99,17 @@ public:
      * This will fail if the object is not persistent, the UUID
      * is not set or the load was attempted already and failed
      * without having the UUID modified.
+     * @param db Database to load from if persistent
      * @return true on success, false on failure
      */
-    bool LoadReference()
+    bool LoadReference(const std::shared_ptr<Database>& db = nullptr)
     {
-        if(IsPersistentReference() && !mUUID.IsNull() && !mLoadFailed)
+        // Do not count an attempt to load without a DB as a
+        // load failure
+        if(IsPersistentReference() && nullptr != db
+            && !mUUID.IsNull() && !mLoadFailed)
         {
-            mRef = PersistentObject::LoadObjectByUUID<T>(mUUID);
+            mRef = PersistentObject::LoadObjectByUUID<T>(db, mUUID);
             mLoadFailed = nullptr == mRef;
         }
         return mUUID.IsNull() || nullptr != mRef;

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -61,9 +61,9 @@ enum class LobbyClientPacketCode_t : uint16_t
  */
 enum class InternalPacketCode_t : uint16_t
 {
-    PACKET_DESCRIBE_WORLD = 0x1001, //!< Request to describe the world server.
-    PACKET_SET_WORLD_DESCRIPTION = 0x1002,  //!< Request to update a non-world server's world information.
-    PACKET_SET_CHANNEL_DESCRIPTION = 0x1003,    //!< Request to update a non-channel server's channel information.
+    PACKET_GET_WORLD_INFO = 0x1001, //!< Request to detail the world server.
+    PACKET_SET_WORLD_INFO = 0x1002,  //!< Request to update a non-world server's world information.
+    PACKET_SET_CHANNEL_INFO = 0x1003,    //!< Request to update a non-channel server's channel information.
 };
 
 /**

--- a/libcomp/src/PersistentObject.cpp
+++ b/libcomp/src/PersistentObject.cpp
@@ -140,7 +140,7 @@ std::shared_ptr<PersistentObject> PersistentObject::GetObjectByUUID(const libobj
 }
 
 std::shared_ptr<PersistentObject> PersistentObject::LoadObjectByUUID(std::type_index type,
-    const libobjgen::UUID& uuid)
+    const std::shared_ptr<Database>& db,  const libobjgen::UUID& uuid)
 {
     auto obj = GetObjectByUUID(uuid);
 
@@ -148,7 +148,7 @@ std::shared_ptr<PersistentObject> PersistentObject::LoadObjectByUUID(std::type_i
     {
         auto bind = new DatabaseBindUUID("uid", uuid);
 
-        obj = LoadObject(type, bind);
+        obj = LoadObject(type, db, bind);
 
         delete bind;
 
@@ -163,10 +163,9 @@ std::shared_ptr<PersistentObject> PersistentObject::LoadObjectByUUID(std::type_i
 }
 
 std::shared_ptr<PersistentObject> PersistentObject::LoadObject(
-    std::type_index type, DatabaseBind *pValue)
+    std::type_index type, const std::shared_ptr<Database>& db,
+    DatabaseBind *pValue)
 {
-    auto db = Database::GetMainDatabase();
-
     std::shared_ptr<PersistentObject> obj;
 
     if(nullptr != db)
@@ -222,61 +221,36 @@ std::shared_ptr<PersistentObject> PersistentObject::New(std::type_index type)
     return iter != sFactory.end() ? std::shared_ptr<PersistentObject>(iter->second()) : nullptr;
 }
 
-bool PersistentObject::Insert()
+bool PersistentObject::Insert(const std::shared_ptr<Database>& db)
 {
     if(mSelf.use_count() > 0)
     {
         auto self = mSelf.lock();
-        return Insert(self);
+        return nullptr != db ? db->InsertSingleObject(self) : false;
     }
 
     return false;
 }
 
-bool PersistentObject::Insert(std::shared_ptr<PersistentObject>& obj)
-{
-    auto db = Database::GetMainDatabase();
-    return nullptr != db ? db->InsertSingleObject(obj) : false;
-}
-
-bool PersistentObject::Update()
+bool PersistentObject::Update(const std::shared_ptr<Database>& db)
 {
     if(mSelf.use_count() > 0)
     {
         auto self = mSelf.lock();
-        return Update(self);
+        return nullptr != db ? db->UpdateSingleObject(self) : false;
     }
 
     return false;
 }
 
-bool PersistentObject::Update(std::shared_ptr<PersistentObject>& obj)
-{
-    auto db = Database::GetMainDatabase();
-    return nullptr != db ? db->UpdateSingleObject(obj) : false;
-}
-
-bool PersistentObject::Delete()
+bool PersistentObject::Delete(const std::shared_ptr<Database>& db)
 {
     if(mSelf.use_count() > 0)
     {
         auto self = mSelf.lock();
-        return Delete(self);
+        return nullptr == db || db->DeleteSingleObject(self);
     }
 
-    return false;
-}
-
-bool PersistentObject::Delete(std::shared_ptr<PersistentObject>& obj)
-{
-    auto db = Database::GetMainDatabase();
-    if(nullptr == db || db->DeleteSingleObject(obj))
-    {
-        // The database should have already handled this but call again
-        // just in case
-        obj->Unregister();
-        return true;
-    }
     return false;
 }
 

--- a/libcomp/src/PersistentObject.h
+++ b/libcomp/src/PersistentObject.h
@@ -41,6 +41,7 @@
 namespace libcomp
 {
 
+class Database;
 class DatabaseBind;
 class DatabaseQuery;
 
@@ -131,16 +132,17 @@ public:
     /*
      * Retrieve an object of the specified type by its UUID from the cache
      * or database.
+     * @param db Database to load from
      * @param uuid UUID of the object to load
      * @return Pointer to the object or nullptr if it doesn't exist
      */
     template<class T> static std::shared_ptr<T> LoadObjectByUUID(
-    const libobjgen::UUID& uuid)
+        const std::shared_ptr<Database>& db, const libobjgen::UUID& uuid)
     {
         if(std::is_base_of<PersistentObject, T>::value)
         {
             return std::dynamic_pointer_cast<T>(LoadObjectByUUID(
-                typeid(T), uuid));
+                typeid(T), db, uuid));
         }
 
         return nullptr;
@@ -150,11 +152,13 @@ public:
      * Retrieve an object of the specified type ID by its UUID from the cache
      * or database.
      * @param type C++ type representing the object type to load
+     * @param db Database to load from
      * @param uuid UUID of the object to load
      * @return Pointer to the object or nullptr if it doesn't exist
      */
     static std::shared_ptr<PersistentObject> LoadObjectByUUID(
-        std::type_index type, const libobjgen::UUID& uuid);
+        std::type_index type, const std::shared_ptr<Database>& db,
+        const libobjgen::UUID& uuid);
 
     /*
      * Get all PersistentObject derived class MetaObject definitions.
@@ -217,42 +221,24 @@ public:
 
     /*
      * Save a new record to the database.
+     * @param db Database to load from
      * @return true on success, false on failure
      */
-    bool Insert();
-
-    /*
-     * Save a new record to the database.
-     * @param obj Pointer to the object to save
-     * @return true on success, false on failure
-     */
-    static bool Insert(std::shared_ptr<PersistentObject>& obj);
+    bool Insert(const std::shared_ptr<Database>& db);
 
     /*
      * Update an existing record in the database.
+     * @param db Database to load from
      * @return true on success, false on failure
      */
-    bool Update();
-
-    /*
-     * Update an existing record in the database.
-     * @param obj Pointer to the object to update
-     * @return true on success, false on failure
-     */
-    static bool Update(std::shared_ptr<PersistentObject>& obj);
+    bool Update(const std::shared_ptr<Database>& db);
 
     /*
      * Deletes an existing record from the database.
+     * @param db Database to load from
      * @return true on success, false on failure
      */
-    bool Delete();
-
-    /*
-     * Deletes an existing record from the database.
-     * @param obj Pointer to the object to delete
-     * @return true on success, false on failure
-     */
-    static bool Delete(std::shared_ptr<PersistentObject>& obj);
+    bool Delete(const std::shared_ptr<Database>& db);
 
 protected:
     /*
@@ -269,11 +255,12 @@ protected:
     /*
      * Load an object from the database from a field database binding.
      * @param type C++ type representing the object type to load
+     * @param db Database to load from
      * @param pValue Pointer to a field bound to a database column
      * @return Pointer to the object or nullptr if it doesn't exist
      */
     static std::shared_ptr<PersistentObject> LoadObject(std::type_index type,
-        DatabaseBind *pValue);
+        const std::shared_ptr<Database>& db, DatabaseBind *pValue);
 
     /// Static value to be set to true if any PersistentObject type fails
     /// to register itself at runtime

--- a/libcomp/src/VectorStream.h
+++ b/libcomp/src/VectorStream.h
@@ -59,7 +59,8 @@ protected:
         return c;
     }
 
-    virtual pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+    virtual typename std::basic_streambuf<CharT, TraitsT>::pos_type
+        seekoff(off_type off, std::ios_base::seekdir dir,
         std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
     {
         (void)which;
@@ -73,35 +74,43 @@ protected:
         else if(std::ios_base::end == dir)
         {
             pos = static_cast<pos_type>(
-                (egptr() - eback()) + off);
+                (std::basic_streambuf<CharT, TraitsT>::egptr() -
+                    std::basic_streambuf<CharT, TraitsT>::eback()) + off);
         }
         else // std::ios_base::cur == dir
         {
             pos = static_cast<pos_type>(
-                (gptr() - eback()) + off);
+                (std::basic_streambuf<CharT, TraitsT>::gptr() -
+                    std::basic_streambuf<CharT, TraitsT>::eback()) + off);
         }
 
-        if(static_cast<pos_type>(egptr() - eback()) < pos)
+        if(static_cast<pos_type>(std::basic_streambuf<CharT, TraitsT>::egptr() -
+            std::basic_streambuf<CharT, TraitsT>::eback()) < pos)
         {
             return pos_type(off_type(-1));
         }
 
-        setg(eback(), eback() + pos, egptr());
+        setg(std::basic_streambuf<CharT, TraitsT>::eback(),
+            std::basic_streambuf<CharT, TraitsT>::eback() + pos,
+            std::basic_streambuf<CharT, TraitsT>::egptr());
 
         return pos;
     }
 
-    virtual pos_type seekpos(pos_type pos,
+    virtual typename std::basic_streambuf<CharT, TraitsT>::pos_type seekpos(pos_type pos,
         std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
     {
         (void)which;
 
-        if(static_cast<pos_type>(egptr() - eback()) < pos)
+        if(static_cast<pos_type>(std::basic_streambuf<CharT, TraitsT>::egptr() -
+            std::basic_streambuf<CharT, TraitsT>::eback()) < pos)
         {
             return pos_type(off_type(-1));
         }
 
-        setg(eback(), eback() + pos, egptr());
+        setg(std::basic_streambuf<CharT, TraitsT>::eback(),
+            std::basic_streambuf<CharT, TraitsT>::eback() + pos,
+            std::basic_streambuf<CharT, TraitsT>::egptr());
 
         return pos;
     }

--- a/libcomp/src/VectorStream.h
+++ b/libcomp/src/VectorStream.h
@@ -93,7 +93,7 @@ protected:
                 typename std::basic_streambuf<CharT, TraitsT>::off_type(-1));
         }
 
-        setg(std::basic_streambuf<CharT, TraitsT>::eback(),
+        this->setg(std::basic_streambuf<CharT, TraitsT>::eback(),
             std::basic_streambuf<CharT, TraitsT>::eback() + pos,
             std::basic_streambuf<CharT, TraitsT>::egptr());
 
@@ -114,7 +114,7 @@ protected:
                 typename std::basic_streambuf<CharT, TraitsT>::off_type(-1));
         }
 
-        setg(std::basic_streambuf<CharT, TraitsT>::eback(),
+        this->setg(std::basic_streambuf<CharT, TraitsT>::eback(),
             std::basic_streambuf<CharT, TraitsT>::eback() + pos,
             std::basic_streambuf<CharT, TraitsT>::egptr());
 

--- a/libcomp/src/VectorStream.h
+++ b/libcomp/src/VectorStream.h
@@ -60,34 +60,37 @@ protected:
     }
 
     virtual typename std::basic_streambuf<CharT, TraitsT>::pos_type
-        seekoff(off_type off, std::ios_base::seekdir dir,
-        std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
+        seekoff(typename std::basic_streambuf<CharT, TraitsT>::off_type off,
+            std::ios_base::seekdir dir,
+            std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
     {
         (void)which;
 
-        pos_type pos;
+        typename std::basic_streambuf<CharT, TraitsT>::pos_type pos;
 
         if(std::ios_base::beg == dir)
         {
-            pos = static_cast<pos_type>(off);
+            pos = static_cast<typename std::basic_streambuf<CharT, TraitsT>::pos_type>(off);
         }
         else if(std::ios_base::end == dir)
         {
-            pos = static_cast<pos_type>(
+            pos = static_cast<typename std::basic_streambuf<CharT, TraitsT>::pos_type>(
                 (std::basic_streambuf<CharT, TraitsT>::egptr() -
                     std::basic_streambuf<CharT, TraitsT>::eback()) + off);
         }
         else // std::ios_base::cur == dir
         {
-            pos = static_cast<pos_type>(
+            pos = static_cast<typename std::basic_streambuf<CharT, TraitsT>::pos_type>(
                 (std::basic_streambuf<CharT, TraitsT>::gptr() -
                     std::basic_streambuf<CharT, TraitsT>::eback()) + off);
         }
 
-        if(static_cast<pos_type>(std::basic_streambuf<CharT, TraitsT>::egptr() -
+        if(static_cast<typename std::basic_streambuf<CharT, TraitsT>::pos_type>(
+            std::basic_streambuf<CharT, TraitsT>::egptr() -
             std::basic_streambuf<CharT, TraitsT>::eback()) < pos)
         {
-            return pos_type(off_type(-1));
+            return typename std::basic_streambuf<CharT, TraitsT>::pos_type(
+                typename std::basic_streambuf<CharT, TraitsT>::off_type(-1));
         }
 
         setg(std::basic_streambuf<CharT, TraitsT>::eback(),
@@ -97,15 +100,18 @@ protected:
         return pos;
     }
 
-    virtual typename std::basic_streambuf<CharT, TraitsT>::pos_type seekpos(pos_type pos,
+    virtual typename std::basic_streambuf<CharT, TraitsT>::pos_type seekpos(
+        typename std::basic_streambuf<CharT, TraitsT>::pos_type pos,
         std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
     {
         (void)which;
 
-        if(static_cast<pos_type>(std::basic_streambuf<CharT, TraitsT>::egptr() -
+        if(static_cast<typename std::basic_streambuf<CharT, TraitsT>::pos_type>(
+            std::basic_streambuf<CharT, TraitsT>::egptr() -
             std::basic_streambuf<CharT, TraitsT>::eback()) < pos)
         {
-            return pos_type(off_type(-1));
+            return typename std::basic_streambuf<CharT, TraitsT>::pos_type(
+                typename std::basic_streambuf<CharT, TraitsT>::off_type(-1));
         }
 
         setg(std::basic_streambuf<CharT, TraitsT>::eback(),

--- a/libcomp/src/VectorStream.h
+++ b/libcomp/src/VectorStream.h
@@ -58,6 +58,53 @@ protected:
 
         return c;
     }
+
+    virtual pos_type seekoff(off_type off, std::ios_base::seekdir dir,
+        std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
+    {
+        (void)which;
+
+        pos_type pos;
+
+        if(std::ios_base::beg == dir)
+        {
+            pos = static_cast<pos_type>(off);
+        }
+        else if(std::ios_base::end == dir)
+        {
+            pos = static_cast<pos_type>(
+                (egptr() - eback()) + off);
+        }
+        else // std::ios_base::cur == dir
+        {
+            pos = static_cast<pos_type>(
+                (gptr() - eback()) + off);
+        }
+
+        if(static_cast<pos_type>(egptr() - eback()) < pos)
+        {
+            return pos_type(off_type(-1));
+        }
+
+        setg(eback(), eback() + pos, egptr());
+
+        return pos;
+    }
+
+    virtual pos_type seekpos(pos_type pos,
+        std::ios_base::openmode which = std::ios_base::in | std::ios_base::out)
+    {
+        (void)which;
+
+        if(static_cast<pos_type>(egptr() - eback()) < pos)
+        {
+            return pos_type(off_type(-1));
+        }
+
+        setg(eback(), eback() + pos, egptr());
+
+        return pos;
+    }
 };
 
 } // namespace libcomp

--- a/libobjgen/src/GeneratorSource.cpp
+++ b/libobjgen/src/GeneratorSource.cpp
@@ -47,15 +47,19 @@ std::string GeneratorSource::Generate(const MetaObject& obj)
     ss << std::endl;
 
     ss << "// libcomp Includes" << std::endl;
-    ss << "#include \"DatabaseBind.h\"" << std::endl;
-    ss << "#include \"DatabaseQuery.h\"" << std::endl;
-    ss << "#include \"Log.h\"" << std::endl;
-    ss << "#include \"VectorStream.h\"" << std::endl;
+    if(obj.IsPersistent())
+    {
+        ss << "#include <Database.h>" << std::endl;
+    }
+    ss << "#include <DatabaseBind.h>" << std::endl;
+    ss << "#include <DatabaseQuery.h>" << std::endl;
+    ss << "#include <Log.h>" << std::endl;
+    ss << "#include <VectorStream.h>" << std::endl;
 
     bool scriptEnabled = obj.IsScriptEnabled();
     if(scriptEnabled)
     {
-        ss << "#include \"ScriptEngine.h\"" << std::endl;
+        ss << "#include <ScriptEngine.h>" << std::endl;
     }
     ss << std::endl;
 

--- a/libobjgen/src/MetaVariable.cpp
+++ b/libobjgen/src/MetaVariable.cpp
@@ -511,7 +511,8 @@ std::string MetaVariable::GetAccessDeclarations(const Generator& generator,
     {
         ss << generator.Tab(tabLevel) << "static std::shared_ptr<" << object.GetName()
             << "> Load" << object.GetName() << "By"
-            << generator.GetCapitalName(*this) << "("
+            << generator.GetCapitalName(*this)
+            << "(const std::shared_ptr<libcomp::Database>& db, "
             << GetArgument("val") << ");" << std::endl;
     }
 
@@ -545,14 +546,15 @@ std::string MetaVariable::GetAccessFunctions(const Generator& generator,
         ss << "std::shared_ptr<" << objName << "> " << objName
             << "::Load" << objName << "By"
             << generator.GetCapitalName(*this)
-            << "(" << GetArgument("val") << ")" << std::endl;
+            << "(const std::shared_ptr<libcomp::Database>& db, "
+            << GetArgument("val") << ")" << std::endl;
         ss << "{" << std::endl;
         ss << generator.Tab() << "auto bind = (" << GetBindValueCode(
             generator, "val") << "());" << std::endl;
         ss << std::endl;
         ss << generator.Tab() << "auto obj = std::dynamic_pointer_cast<"
             << objName << ">(LoadObject(typeid(" << objName
-            << "), bind));" << std::endl;
+            << "), db, bind));" << std::endl;
         ss << std::endl;
         ss << generator.Tab() << "delete bind;" << std::endl;
         ss << std::endl;

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -64,7 +64,7 @@ SOURCE_GROUP("Source Files\\Packets\\Internal" src/packets/internal/*)
 
 SET(${PROJECT_NAME}_PACKETS
     #Internal packets
-    src/packets/internal/SetWorldDescription.cpp      # 0x1002
+    src/packets/internal/SetWorldInfo.cpp      # 0x1002
 )
 
 ADD_EXECUTABLE(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS}

--- a/server/channel/schema/channelconfig.xml
+++ b/server/channel/schema/channelconfig.xml
@@ -6,11 +6,5 @@
         <member type="u16" name="Port" inherited="true" default="14666"/>
         <member type="string" name="WorldIP" default="127.0.0.1"/>
         <member type="u16" name="WorldPort" default="18666"/>
-        <member type="DatabaseConfigCassandra*" name="CassandraConfig" inherited="true">
-            <member type="string" name="Keyspace" default="world"/>
-        </member>
-        <member type="DatabaseConfigSQLite3*" name="SQLite3Config" inherited="true">
-            <member type="string" name="DatabaseName" default="world"/>
-        </member>
     </object>
 </objgen>

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -84,8 +84,8 @@ bool ChannelServer::Initialize(std::weak_ptr<BaseServer>& self)
 
     auto internalPacketManager = std::shared_ptr<libcomp::ManagerPacket>(
         new libcomp::ManagerPacket(self));
-    internalPacketManager->AddParser<Parsers::SetWorldDescription>(
-        to_underlying(InternalPacketCode_t::PACKET_SET_WORLD_DESCRIPTION));
+    internalPacketManager->AddParser<Parsers::SetWorldInfo>(
+        to_underlying(InternalPacketCode_t::PACKET_SET_WORLD_INFO));
 
     //Add the managers to the main worker.
     mMainWorker.AddManager(internalPacketManager);

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -118,6 +118,26 @@ std::shared_ptr<objects::WorldDescription> ChannelServer::GetWorldDescription()
     return mWorldDescription;
 }
 
+std::shared_ptr<libcomp::Database> ChannelServer::GetWorldDatabase() const
+{
+    return mWorldDatabase;
+}
+
+void ChannelServer::SetWorldDatabase(const std::shared_ptr<libcomp::Database>& database)
+{
+    mWorldDatabase = database;
+}
+   
+std::shared_ptr<libcomp::Database> ChannelServer::GetLobbyDatabase() const
+{
+    return mLobbyDatabase;
+}
+
+void ChannelServer::SetLobbyDatabase(const std::shared_ptr<libcomp::Database>& database)
+{
+    mLobbyDatabase = database;
+}
+
 std::shared_ptr<libcomp::TcpConnection> ChannelServer::CreateConnection(
     asio::ip::tcp::socket& socket)
 {

--- a/server/channel/src/ChannelServer.h
+++ b/server/channel/src/ChannelServer.h
@@ -77,6 +77,30 @@ public:
      * @return Pointer to the WorldDescription
      */
     std::shared_ptr<objects::WorldDescription> GetWorldDescription();
+    
+    /**
+     * Get the world database.
+     * @return Pointer to the world's database
+     */
+    std::shared_ptr<libcomp::Database> GetWorldDatabase() const;
+
+    /**
+     * Set the world database.
+     * @param database Pointer to the world's database
+     */
+    void SetWorldDatabase(const std::shared_ptr<libcomp::Database>& database);
+    
+    /**
+     * Get the lobby database.
+     * @return Pointer to the lobby's database
+     */
+    std::shared_ptr<libcomp::Database> GetLobbyDatabase() const;
+
+    /**
+     * Set the lobby database.
+     * @param database Pointer to the lobby's database
+     */
+    void SetLobbyDatabase(const std::shared_ptr<libcomp::Database>& database);
 
 protected:
     /**
@@ -92,6 +116,12 @@ protected:
 
     /// Pointer to the description of the world.
     std::shared_ptr<objects::WorldDescription> mWorldDescription;
+
+    /// A shared pointer to the world database used by the server.
+    std::shared_ptr<libcomp::Database> mWorldDatabase;
+
+    /// A shared pointer to the main database used by the server.
+    std::shared_ptr<libcomp::Database> mLobbyDatabase;
 
     /// Pointer to the description of the channel.
     std::shared_ptr<objects::ChannelDescription> mDescription;

--- a/server/channel/src/ManagerConnection.cpp
+++ b/server/channel/src/ManagerConnection.cpp
@@ -109,7 +109,7 @@ void ManagerConnection::RequestWorldDescription()
     {
         //Request world information
         libcomp::Packet packet;
-        packet.WritePacketCode(InternalPacketCode_t::PACKET_DESCRIBE_WORLD);
+        packet.WritePacketCode(InternalPacketCode_t::PACKET_GET_WORLD_INFO);
 
         mWorldConnection->SendPacket(packet);
     }

--- a/server/channel/src/Packets.h
+++ b/server/channel/src/Packets.h
@@ -36,7 +36,7 @@ namespace channel
 namespace Parsers
 {
 
-PACKET_PARSER_DECL(SetWorldDescription);               // 0x1002
+PACKET_PARSER_DECL(SetWorldInfo);               // 0x1002
 
 } // namespace Parsers
 

--- a/server/lobby/CMakeLists.txt
+++ b/server/lobby/CMakeLists.txt
@@ -89,8 +89,8 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/game/PurchaseTicket.cpp      # 0x0013
     
     #Internal packets
-    src/packets/internal/SetWorldDescription.cpp      # 0x1002
-    src/packets/internal/SetChannelDescription.cpp    # 0x1003
+    src/packets/internal/SetWorldInfo.cpp      # 0x1002
+    src/packets/internal/SetChannelInfo.cpp    # 0x1003
 )
 
 ADD_CUSTOM_COMMAND(

--- a/server/lobby/schema/lobbyconfig.xml
+++ b/server/lobby/schema/lobbyconfig.xml
@@ -4,5 +4,7 @@
         <member type="u16" name="Port" inherited="true" default="10666"/>
         <member type="u16" name="WebListeningPort" default="10999"/>
         <member type="float" name="ClientVersion" default="1.666"/>
+        <member type="DatabaseConfigSQLite3*" name="SQLite3Config"/>
+        <member type="DatabaseConfigCassandra*" name="CassandraConfig"/>
     </object>
 </objgen>

--- a/server/lobby/src/LobbyServer.cpp
+++ b/server/lobby/src/LobbyServer.cpp
@@ -78,8 +78,6 @@ bool LobbyServer::Initialize(std::weak_ptr<BaseServer>& self)
         return false;
     }
 
-    libcomp::Database::SetMainDatabase(mDatabase);
-
     if(mUnitTestMode)
     {
         if(!InitializeTestMode())
@@ -222,7 +220,7 @@ bool LobbyServer::InitializeTestMode()
     account->Register(std::dynamic_pointer_cast<
         libcomp::PersistentObject>(account));
 
-    if(!account->Insert())
+    if(!account->Insert(mDatabase))
     {
         LOG_ERROR("Failed to create test account.\n");
     }
@@ -451,7 +449,7 @@ void LobbyServer::PromptCreateAccount()
     account->Register(std::dynamic_pointer_cast<
         libcomp::PersistentObject>(account));
 
-    if(!account->Insert())
+    if(!account->Insert(mDatabase))
     {
         LOG_ERROR("Failed to create account!\n");
     }

--- a/server/lobby/src/LobbyServer.cpp
+++ b/server/lobby/src/LobbyServer.cpp
@@ -100,10 +100,10 @@ bool LobbyServer::Initialize(std::weak_ptr<BaseServer>& self)
 
     auto internalPacketManager = std::shared_ptr<libcomp::ManagerPacket>(
         new libcomp::ManagerPacket(self));
-    internalPacketManager->AddParser<Parsers::SetWorldDescription>(
-        to_underlying(InternalPacketCode_t::PACKET_SET_WORLD_DESCRIPTION));
-    internalPacketManager->AddParser<Parsers::SetChannelDescription>(
-        to_underlying(InternalPacketCode_t::PACKET_SET_CHANNEL_DESCRIPTION));
+    internalPacketManager->AddParser<Parsers::SetWorldInfo>(
+        to_underlying(InternalPacketCode_t::PACKET_SET_WORLD_INFO));
+    internalPacketManager->AddParser<Parsers::SetChannelInfo>(
+        to_underlying(InternalPacketCode_t::PACKET_SET_CHANNEL_INFO));
 
     //Add the managers to the main worker.
     mMainWorker.AddManager(internalPacketManager);

--- a/server/lobby/src/LobbyServer.h
+++ b/server/lobby/src/LobbyServer.h
@@ -79,6 +79,12 @@ public:
      * @return Pointer to the connected world.
      */
     std::shared_ptr<lobby::World> GetWorldByConnection(std::shared_ptr<libcomp::InternalConnection> connection);
+    
+    /**
+     * Get the main database.
+     * @return Pointer to the main database
+     */
+    std::shared_ptr<libcomp::Database> GetMainDatabase() const;
 
 protected:
     /**
@@ -109,6 +115,9 @@ protected:
      */
     virtual std::shared_ptr<libcomp::TcpConnection> CreateConnection(
         asio::ip::tcp::socket& socket);
+
+    /// A shared pointer to the main database used by the server.
+    std::shared_ptr<libcomp::Database> mDatabase;
 
     /// Pointer to the manager in charge of connection messages.
     std::shared_ptr<ManagerConnection> mManagerConnection;

--- a/server/lobby/src/LoginWebHandler.cpp
+++ b/server/lobby/src/LoginWebHandler.cpp
@@ -38,7 +38,8 @@
 
 using namespace lobby;
 
-LoginHandler::LoginHandler()
+LoginHandler::LoginHandler(const std::shared_ptr<libcomp::Database>& database)
+    : mDatabase(database)
 {
     mVfs.AddArchiveLoader(new ttvfs::VFSZipArchiveLoader);
 
@@ -147,7 +148,7 @@ void LoginHandler::ParsePost(CivetServer *pServer,
     /// @todo Do proper authentication.
     if(pServer->getParam(szPostData, "login", postValue))
     {
-        auto account = objects::Account::LoadAccountByUserName(postVars.id);
+        auto account = objects::Account::LoadAccountByUserName(mDatabase, postVars.id);
 
         if(nullptr != account && account->GetPassword() ==
             libcomp::Decrypt::HashPassword(postVars.pass, account->GetSalt()))

--- a/server/lobby/src/LoginWebHandler.h
+++ b/server/lobby/src/LoginWebHandler.h
@@ -32,6 +32,7 @@
 
 // libcomp Includes
 #include <CString.h>
+#include <Database.h>
 
 // Standard C++11 Includes
 #include <vector>
@@ -48,7 +49,7 @@ namespace lobby
 class LoginHandler : public CivetHandler
 {
 public:
-    LoginHandler();
+    LoginHandler(const std::shared_ptr<libcomp::Database>& database);
     virtual ~LoginHandler();
 
     virtual bool handleGet(CivetServer *pServer,
@@ -89,6 +90,8 @@ private:
     std::vector<char> LoadVfsFile(const libcomp::String& path);
 
     ttvfs::Root mVfs;
+
+    std::shared_ptr<libcomp::Database> mDatabase;
 };
 
 } // namespace lobby

--- a/server/lobby/src/ManagerConnection.cpp
+++ b/server/lobby/src/ManagerConnection.cpp
@@ -26,11 +26,19 @@
 
 #include "ManagerConnection.h"
 
+// lobby Includes
+#include "LobbyConfig.h"
+#include "LobbyServer.h"
+
 // libcomp Includes
+#include <DatabaseConfigCassandra.h>
+#include <DatabaseConfigSQLite3.h>
 #include <Log.h>
 #include <MessageConnectionClosed.h>
 #include <MessageEncrypted.h>
 #include <MessageWorldNotification.h>
+#include <Packet.h>
+#include <PacketCodes.h>
 
 // Standard C++ 11 Includes
 #include <thread>
@@ -103,7 +111,7 @@ bool ManagerConnection::ProcessMessage(const libcomp::Message::Message *pMessage
                 auto world = GetWorldByConnection(std::dynamic_pointer_cast<libcomp::InternalConnection>(connection));
                 if (nullptr != world)
                 {
-                    return world->Initialize();
+                    return InitializeWorld(world);
                 }
                 else
                 {
@@ -131,6 +139,29 @@ bool ManagerConnection::ProcessMessage(const libcomp::Message::Message *pMessage
     }
     
     return false;
+}
+
+bool ManagerConnection::InitializeWorld(const std::shared_ptr<lobby::World>& world)
+{
+    libcomp::Packet packet;
+    packet.WritePacketCode(InternalPacketCode_t::PACKET_DESCRIBE_WORLD);
+
+    auto server = mServer.lock();
+    auto config = std::dynamic_pointer_cast<objects::LobbyConfig>(server->GetConfig());
+    
+    switch(config->GetDatabaseType())
+    {
+        case objects::ServerConfig::DatabaseType_t::CASSANDRA:
+            config->GetCassandraConfig().Get()->SavePacket(packet, false);
+            break;
+        case objects::ServerConfig::DatabaseType_t::SQLITE3:
+            config->GetSQLite3Config().Get()->SavePacket(packet, false);
+            break;
+    }
+
+    world->GetConnection()->SendPacket(packet);
+
+    return true;
 }
 
 std::list<std::shared_ptr<lobby::World>> ManagerConnection::GetWorlds() const
@@ -161,8 +192,15 @@ void ManagerConnection::RemoveWorld(std::shared_ptr<lobby::World>& world)
         if(iter != mWorlds.end())
         {
             mWorlds.erase(iter);
-            LOG_INFO(libcomp::String("World connection removed: (%1) %2\n")
-                .Arg(desc->GetID()).Arg(desc->GetName()));
+            if(nullptr != desc)
+            {
+                LOG_INFO(libcomp::String("World connection removed: (%1) %2\n")
+                    .Arg(desc->GetID()).Arg(desc->GetName()));
+            }
+            else
+            {
+                LOG_WARNING("Uninitialized world connection closed.\n");
+            }
         }
     }
 }

--- a/server/lobby/src/ManagerConnection.cpp
+++ b/server/lobby/src/ManagerConnection.cpp
@@ -144,19 +144,12 @@ bool ManagerConnection::ProcessMessage(const libcomp::Message::Message *pMessage
 bool ManagerConnection::InitializeWorld(const std::shared_ptr<lobby::World>& world)
 {
     libcomp::Packet packet;
-    packet.WritePacketCode(InternalPacketCode_t::PACKET_DESCRIBE_WORLD);
+    packet.WritePacketCode(InternalPacketCode_t::PACKET_GET_WORLD_INFO);
 
-    auto server = mServer.lock();
-    auto config = std::dynamic_pointer_cast<objects::LobbyConfig>(server->GetConfig());
-    
-    switch(config->GetDatabaseType())
+    auto server = std::dynamic_pointer_cast<LobbyServer>(mServer.lock());
+    if(!server->GetMainDatabase()->GetConfig()->SavePacket(packet, false))
     {
-        case objects::ServerConfig::DatabaseType_t::CASSANDRA:
-            config->GetCassandraConfig().Get()->SavePacket(packet, false);
-            break;
-        case objects::ServerConfig::DatabaseType_t::SQLITE3:
-            config->GetSQLite3Config().Get()->SavePacket(packet, false);
-            break;
+        return false;
     }
 
     world->GetConnection()->SendPacket(packet);

--- a/server/lobby/src/ManagerConnection.h
+++ b/server/lobby/src/ManagerConnection.h
@@ -76,6 +76,14 @@ public:
     virtual bool ProcessMessage(const libcomp::Message::Message *pMessage);
 
     /**
+     * Request information about the world and send database
+     * connection information to the main DB.
+     * @param world World to intialize
+     * @return true on success, false on failure
+     */
+    bool InitializeWorld(const std::shared_ptr<lobby::World>& world);
+
+    /**
      * Get a list of connected worlds.
      * @return List of pointers to connected worlds
      */

--- a/server/lobby/src/Packets.h
+++ b/server/lobby/src/Packets.h
@@ -47,8 +47,8 @@ PACKET_PARSER_DECL(QueryPurchaseTicket); // 0x0011
 PACKET_PARSER_DECL(PurchaseTicket);      // 0x0013
 
 //Internal Packets
-PACKET_PARSER_DECL(SetWorldDescription);      // 0x1002
-PACKET_PARSER_DECL(SetChannelDescription);    // 0x1003
+PACKET_PARSER_DECL(SetWorldInfo);      // 0x1002
+PACKET_PARSER_DECL(SetChannelInfo);    // 0x1003
 
 } // namespace Parsers
 

--- a/server/lobby/src/World.cpp
+++ b/server/lobby/src/World.cpp
@@ -41,17 +41,6 @@ World::~World()
 {
 }
 
-bool World::Initialize()
-{
-    //Request world information
-    libcomp::Packet packet;
-    packet.WritePacketCode(InternalPacketCode_t::PACKET_DESCRIBE_WORLD);
-
-    mConnection->SendPacket(packet);
-
-    return true;
-}
-
 std::shared_ptr<libcomp::InternalConnection> World::GetConnection() const
 {
     return mConnection;
@@ -92,6 +81,16 @@ bool World::RemoveChannelDescriptionByID(uint8_t id)
     }
 
     return false;
+}
+
+std::shared_ptr<libcomp::Database> World::GetWorldDatabase() const
+{
+    return mDatabase;
+}
+
+void World::SetWorldDatabase(const std::shared_ptr<libcomp::Database>& database)
+{
+    mDatabase = database;
 }
 
 void World::SetWorldDescription(const std::shared_ptr<objects::WorldDescription>& worldDescription)

--- a/server/lobby/src/World.h
+++ b/server/lobby/src/World.h
@@ -29,6 +29,7 @@
 
 // libcomp Includes
 #include <ChannelDescription.h>
+#include <Database.h>
 #include <InternalConnection.h>
 
 // object Includes
@@ -54,13 +55,6 @@ public:
      * Clean up the world.
      */
     virtual ~World();
-
-    /**
-     * Gather necessary information for the world by sending a
-     * request for the world description.
-     * @return true on success, false on failure
-     */
-    bool Initialize();
 
     /**
      * Get a pointer to the world's connection.
@@ -93,6 +87,18 @@ public:
      * @return true if the description existed, false if it did not exist
      */
     bool RemoveChannelDescriptionByID(uint8_t id);
+    
+    /**
+     * Get the world database.
+     * @return Pointer to the world's database
+     */
+    std::shared_ptr<libcomp::Database> GetWorldDatabase() const;
+
+    /**
+     * Set the world database.
+     * @param database Pointer to the world's database
+     */
+    void SetWorldDatabase(const std::shared_ptr<libcomp::Database>& database);
 
     /**
      * Set the world description.
@@ -112,6 +118,9 @@ private:
 
     /// Pointer to the world's description
     std::shared_ptr<objects::WorldDescription> mWorldDescription;
+
+    /// A shared pointer to the world database used by the server.
+    std::shared_ptr<libcomp::Database> mDatabase;
 
     /// List of pointers to the channel descriptions
     std::list<std::shared_ptr<objects::ChannelDescription>> mChannelDescriptions;

--- a/server/lobby/src/main.cpp
+++ b/server/lobby/src/main.cpp
@@ -86,6 +86,8 @@ int main(int argc, const char *argv[])
         return EXIT_FAILURE;
     }
 
+    auto mainDB = server->GetMainDatabase();
+
     /// @todo Consider moving the web server.
     std::vector<std::string> options;
     options.push_back("listening_ports");
@@ -93,7 +95,7 @@ int main(int argc, const char *argv[])
         objects::LobbyConfig>(config)->GetWebListeningPort()));
 
     CivetServer webServer(options);
-    webServer.addHandler("/", new lobby::LoginHandler);
+    webServer.addHandler("/", new lobby::LoginHandler(mainDB));
 
     // Set this for the signal handler.
     libcomp::Shutdown::Configure(server.get());

--- a/server/lobby/src/packets/game/Login.cpp
+++ b/server/lobby/src/packets/game/Login.cpp
@@ -28,6 +28,7 @@
 
 // lobby Includes
 #include "LobbyClientConnection.h"
+#include "LobbyServer.h"
 
 // libcomp Includes
 #include <ErrorCodes.h>
@@ -62,8 +63,11 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
     reply.SetCommandCode(to_underlying(
         LobbyClientPacketCode_t::PACKET_LOGIN_RESPONSE));
 
+    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
+    auto mainDB = server->GetMainDatabase();
+
     /// @todo Ask the world server is the user is already logged in.
-    auto account = objects::Account::LoadAccountByUserName(obj.GetUsername());
+    auto account = objects::Account::LoadAccountByUserName(mainDB, obj.GetUsername());
 
     uint32_t clientVersion = static_cast<uint32_t>(
         conf->GetClientVersion() * 1000.0f);

--- a/server/world/CMakeLists.txt
+++ b/server/world/CMakeLists.txt
@@ -62,8 +62,8 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
 SOURCE_GROUP("Source Files\\Packets" src/packets/*)
 
 SET(${PROJECT_NAME}_PACKETS
-    src/packets/DescribeWorld.cpp               # 0x1001
-    src/packets/SetChannelDescription.cpp               # 0x1003
+    src/packets/GetWorldInfo.cpp               # 0x1001
+    src/packets/SetChannelInfo.cpp               # 0x1003
 )
 
 ADD_EXECUTABLE(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS}

--- a/server/world/schema/worldconfig.xml
+++ b/server/world/schema/worldconfig.xml
@@ -6,10 +6,10 @@
         <member type="u16" name="Port" inherited="true" default="18666"/>
         <member type="string" name="LobbyIP" default="127.0.0.1"/>
         <member type="u16" name="LobbyPort" default="10666"/>
-        <member type="DatabaseConfigCassandra*" name="CassandraConfig" inherited="true">
+        <member type="DatabaseConfigCassandra*" name="CassandraConfig">
             <member type="string" name="Keyspace" default="world"/>
         </member>
-        <member type="DatabaseConfigSQLite3*" name="SQLite3Config" inherited="true">
+        <member type="DatabaseConfigSQLite3*" name="SQLite3Config">
             <member type="string" name="DatabaseName" default="world"/>
         </member>
     </object>

--- a/server/world/src/ManagerConnection.cpp
+++ b/server/world/src/ManagerConnection.cpp
@@ -136,7 +136,7 @@ void ManagerConnection::RemoveConnection(std::shared_ptr<libcomp::InternalConnec
         //Channel disconnected
         libcomp::Packet packet;
         packet.WritePacketCode(
-            InternalPacketCode_t::PACKET_SET_CHANNEL_DESCRIPTION);
+            InternalPacketCode_t::PACKET_SET_CHANNEL_INFO);
         packet.WriteU8(to_underlying(
             InternalPacketAction_t::PACKET_ACTION_REMOVE));
         channelDesc->SavePacket(packet);

--- a/server/world/src/Packets.h
+++ b/server/world/src/Packets.h
@@ -36,8 +36,8 @@ namespace world
 namespace Parsers
 {
 
-PACKET_PARSER_DECL(DescribeWorld);               // 0x1001
-PACKET_PARSER_DECL(SetChannelDescription);               // 0x1003
+PACKET_PARSER_DECL(GetWorldInfo);               // 0x1001
+PACKET_PARSER_DECL(SetChannelInfo);               // 0x1003
 
 } // namespace Parsers
 

--- a/server/world/src/WorldServer.cpp
+++ b/server/world/src/WorldServer.cpp
@@ -126,10 +126,10 @@ bool WorldServer::Initialize(std::weak_ptr<BaseServer>& self)
     auto connectionManager = std::dynamic_pointer_cast<libcomp::Manager>(mManagerConnection);
 
     auto packetManager = std::shared_ptr<libcomp::ManagerPacket>(new libcomp::ManagerPacket(self));
-    packetManager->AddParser<Parsers::DescribeWorld>(to_underlying(
-        InternalPacketCode_t::PACKET_DESCRIBE_WORLD));
-    packetManager->AddParser<Parsers::SetChannelDescription>(to_underlying(
-        InternalPacketCode_t::PACKET_SET_CHANNEL_DESCRIPTION));
+    packetManager->AddParser<Parsers::GetWorldInfo>(to_underlying(
+        InternalPacketCode_t::PACKET_GET_WORLD_INFO));
+    packetManager->AddParser<Parsers::SetChannelInfo>(to_underlying(
+        InternalPacketCode_t::PACKET_SET_CHANNEL_INFO));
 
     //Add the managers to the main worker.
     mMainWorker.AddManager(packetManager);

--- a/server/world/src/WorldServer.cpp
+++ b/server/world/src/WorldServer.cpp
@@ -74,8 +74,6 @@ bool WorldServer::Initialize(std::weak_ptr<BaseServer>& self)
         return false;
     }
 
-    libcomp::Database::SetMainDatabase(mDatabase);
-
     asio::io_service service;
 
     // Connect to the world server.

--- a/server/world/src/WorldServer.cpp
+++ b/server/world/src/WorldServer.cpp
@@ -27,6 +27,8 @@
 #include "WorldServer.h"
 
 // libcomp Includes
+#include <DatabaseConfigCassandra.h>
+#include <DatabaseConfigSQLite3.h>
 #include <InternalConnection.h>
 #include <LobbyConnection.h>
 #include <Log.h>
@@ -52,6 +54,28 @@ bool WorldServer::Initialize(std::weak_ptr<BaseServer>& self)
         return false;
     }
 
+    auto conf = std::dynamic_pointer_cast<objects::WorldConfig>(mConfig);
+    mDescription->SetID(conf->GetID());
+    mDescription->SetName(conf->GetName());
+    
+    libcomp::EnumMap<objects::ServerConfig::DatabaseType_t,
+        std::shared_ptr<objects::DatabaseConfig>> configMap;
+
+    configMap[objects::ServerConfig::DatabaseType_t::SQLITE3]
+        = conf->GetSQLite3Config().Get();
+
+    configMap[objects::ServerConfig::DatabaseType_t::CASSANDRA]
+        = conf->GetCassandraConfig().Get();
+
+    mDatabase = GetDatabase(configMap, true);
+
+    if(nullptr == mDatabase)
+    {
+        return false;
+    }
+
+    libcomp::Database::SetMainDatabase(mDatabase);
+
     asio::io_service service;
 
     // Connect to the world server.
@@ -64,10 +88,6 @@ bool WorldServer::Initialize(std::weak_ptr<BaseServer>& self)
 
     lobbyConnection->SetSelf(lobbyConnection);
     lobbyConnection->SetMessageQueue(messageQueue);
-
-    auto conf = std::dynamic_pointer_cast<objects::WorldConfig>(mConfig);
-    mDescription->SetID(conf->GetID());
-    mDescription->SetName(conf->GetName());
 
     lobbyConnection->Connect(conf->GetLobbyIP(), conf->GetLobbyPort(), false);
 
@@ -167,6 +187,21 @@ bool WorldServer::RemoveChannelDescription(const std::shared_ptr<libcomp::Intern
     }
 
     return false;
+}
+
+std::shared_ptr<libcomp::Database> WorldServer::GetWorldDatabase() const
+{
+    return mDatabase;
+}
+   
+std::shared_ptr<libcomp::Database> WorldServer::GetLobbyDatabase() const
+{
+    return mLobbyDatabase;
+}
+
+void WorldServer::SetLobbyDatabase(const std::shared_ptr<libcomp::Database>& database)
+{
+    mLobbyDatabase = database;
 }
 
 std::shared_ptr<libcomp::TcpConnection> WorldServer::CreateConnection(

--- a/server/world/src/WorldServer.h
+++ b/server/world/src/WorldServer.h
@@ -106,6 +106,24 @@ public:
      * @return true if the description existed, false if it did not
      */
     bool RemoveChannelDescription(const std::shared_ptr<libcomp::InternalConnection>& connection);
+    
+    /**
+     * Get the world database.
+     * @return Pointer to the world's database
+     */
+    std::shared_ptr<libcomp::Database> GetWorldDatabase() const;
+    
+    /**
+     * Get the lobby database.
+     * @return Pointer to the lobby's database
+     */
+    std::shared_ptr<libcomp::Database> GetLobbyDatabase() const;
+
+    /**
+     * Set the lobby database.
+     * @param database Pointer to the lobby's database
+     */
+    void SetLobbyDatabase(const std::shared_ptr<libcomp::Database>& database);
 
 protected:
     /**
@@ -115,6 +133,12 @@ protected:
      */
     virtual std::shared_ptr<libcomp::TcpConnection> CreateConnection(
         asio::ip::tcp::socket& socket);
+
+    /// A shared pointer to the world database used by the server.
+    std::shared_ptr<libcomp::Database> mDatabase;
+
+    /// A shared pointer to the world database used by the server.
+    std::shared_ptr<libcomp::Database> mLobbyDatabase;
 
     /// Pointer to the description of the world.
     std::shared_ptr<objects::WorldDescription> mDescription;

--- a/server/world/src/packets/GetWorldInfo.cpp
+++ b/server/world/src/packets/GetWorldInfo.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/world/src/packets/DescribeWorld.cpp
+ * @file server/world/src/packets/GetWorldInfo.cpp
  * @ingroup world
  *
  * @author HACKfrost
  *
- * @brief Parser to handle describing the world for the lobby.
+ * @brief Parser to handle detailing the world for the lobby.
  *
  * This file is part of the World Server (world).
  *
@@ -43,7 +43,7 @@
 
 using namespace world;
 
-bool Parsers::DescribeWorld::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::GetWorldInfo::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
@@ -94,7 +94,7 @@ bool Parsers::DescribeWorld::Parse(libcomp::ManagerPacket *pPacketManager,
     // information as well.
     libcomp::Packet reply;
 
-    reply.WritePacketCode(InternalPacketCode_t::PACKET_SET_WORLD_DESCRIPTION);
+    reply.WritePacketCode(InternalPacketCode_t::PACKET_SET_WORLD_INFO);
     server->GetDescription()->SavePacket(reply);
     
     switch(databaseType)

--- a/server/world/src/packets/SetChannelInfo.cpp
+++ b/server/world/src/packets/SetChannelInfo.cpp
@@ -1,12 +1,12 @@
 /**
- * @file server/lobby/src/packets/SetChannelDescription.cpp
- * @ingroup lobby
+ * @file server/world/src/packets/SetChannelInfo.cpp
+ * @ingroup world
  *
  * @author HACKfrost
  *
- * @brief Parser to handle describing a channel for the lobby.
+ * @brief Parser to handle detailing the world for the lobby.
  *
- * This file is part of the Lobby Server (lobby).
+ * This file is part of the World Server (world).
  *
  * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
  *
@@ -36,24 +36,15 @@
 #include <PacketCodes.h>
 #include <ReadOnlyPacket.h>
 
-// lobby Includes
-#include "LobbyServer.h"
+// world Includes
+#include "WorldServer.h"
 
-using namespace lobby;
+using namespace world;
 
-bool Parsers::SetChannelDescription::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::SetChannelInfo::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() == 0)
-    {
-        return false;
-    }
-
-    auto action = static_cast<InternalPacketAction_t>(p.ReadU8());
-
-    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
-
     auto desc = std::shared_ptr<objects::ChannelDescription>(new objects::ChannelDescription);
 
     if(!desc->LoadPacket(p))
@@ -63,18 +54,28 @@ bool Parsers::SetChannelDescription::Parse(libcomp::ManagerPacket *pPacketManage
 
     auto conn = std::dynamic_pointer_cast<libcomp::InternalConnection>(connection);
 
-    auto world = server->GetWorldByConnection(conn);
+    if(nullptr == conn)
+    {
+        return false;
+    }
 
-    if(InternalPacketAction_t::PACKET_ACTION_REMOVE == action)
-    {
-        world->RemoveChannelDescriptionByID(desc->GetID());
-    }
-    else
-    {
-        LOG_DEBUG(libcomp::String("Updating Channel Server description: (%1) %2\n")
-            .Arg(desc->GetID()).Arg(desc->GetName()));
-        world->SetChannelDescription(desc);
-    }
+    LOG_DEBUG(libcomp::String("Updating Channel Server description: (%1) %2\n").Arg(desc->GetID())
+        .Arg(desc->GetName()));
+
+    auto server = std::dynamic_pointer_cast<WorldServer>(pPacketManager->GetServer());
+
+    server->SetChannelDescription(desc, conn);
+
+    //Forward the information to the lobby
+    auto lobbyConnection = server->GetLobbyConnection();
+
+    libcomp::Packet packet;
+    packet.WritePacketCode(
+        InternalPacketCode_t::PACKET_SET_CHANNEL_INFO);
+    packet.WriteU8(to_underlying(
+        InternalPacketAction_t::PACKET_ACTION_UPDATE));
+    desc->SavePacket(packet);
+    lobbyConnection->SendPacket(packet);
 
     return true;
 }


### PR DESCRIPTION
The lobby sends connection info to the main DB to a connecting world.
The world responds with connection info to it's instance DB.
The channel no longer has any DB connection information in its settings and the world is responsible for sending both its database and the lobby's for the channel to use.