### PR TITLE
[FIX] Race condition where the lobby connects to the world too fast.

### DIFF
--- a/libcomp/CMakeLists.txt
+++ b/libcomp/CMakeLists.txt
@@ -66,6 +66,7 @@ SET(${PROJECT_NAME}_SRCS
     #src/MemoryFile.cpp
     src/MessageConnectionClosed.cpp
     src/MessageEncrypted.cpp
+    src/MessageInit.cpp
     src/MessagePacket.cpp
     src/MessagePong.cpp
     src/MessageShutdown.cpp
@@ -131,6 +132,7 @@ SET(${PROJECT_NAME}_HDRS
     src/Message.h
     src/MessageConnectionClosed.h
     src/MessageEncrypted.h
+    src/MessageInit.h
     src/MessagePacket.h
     src/MessagePong.h
     src/MessageQueue.h

--- a/libcomp/src/BaseServer.h
+++ b/libcomp/src/BaseServer.h
@@ -45,7 +45,7 @@ namespace libcomp
  * are responsible for choosing which of the workers it
  * manages will be assigned to each incoming connection.
  */
-class BaseServer : public TcpServer
+class BaseServer : public TcpServer, public Manager
 {
 public:
     /**
@@ -69,7 +69,26 @@ public:
      * @return true on success, false on failure
      */
     virtual bool Initialize(std::weak_ptr<BaseServer>& self);
+
+    /**
+     * Do any initialize that should happen after the server is listening and
+     * fully started.
+     */
+    virtual void FinishInitialize();
     
+    /**
+     * Get the different types of messages handled by this manager.
+     * @return List of supported message types
+     */
+    virtual std::list<libcomp::Message::MessageType> GetSupportedTypes() const;
+
+    /**
+     * Process a message from the queue.
+     * @param pMessage Message to be processed
+     * @return true on success, false on failure
+     */
+    virtual bool ProcessMessage(const libcomp::Message::Message *pMessage);
+
     /**
      * Get an open database connection of the database type associated to the
      * server.

--- a/libcomp/src/MessageInit.cpp
+++ b/libcomp/src/MessageInit.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file libcomp/src/MessageInit.cpp
+ * @ingroup libcomp
+ *
+ * @author COMP Omega <compomega@tutanota.com>
+ *
+ * @brief Indicates that the server should finish initialization.
+ *
+ * This file is part of the COMP_hack Library (libcomp).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MessageInit.h"
+
+using namespace libcomp;
+
+Message::Init::Init()
+{
+}
+
+Message::Init::~Init()
+{
+}
+
+Message::MessageType Message::Init::GetType() const
+{
+    return MessageType::MESSAGE_TYPE_SYSTEM;
+}

--- a/libcomp/src/MessageInit.h
+++ b/libcomp/src/MessageInit.h
@@ -1,0 +1,66 @@
+/**
+ * @file libcomp/src/MessageInit.h
+ * @ingroup libcomp
+ *
+ * @author COMP Omega <compomega@tutanota.com>
+ *
+ * @brief Indicates that the server should finish initialization.
+ *
+ * This file is part of the COMP_hack Library (libcomp).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LIBCOMP_SRC_MESSAGEINIT_H
+#define LIBCOMP_SRC_MESSAGEINIT_H
+
+// libcomp Includes
+#include "CString.h"
+#include "Message.h"
+
+// Standard C++11 Includes
+#include <memory>
+
+namespace libcomp
+{
+
+namespace Message
+{
+
+/**
+ * Message that signifies that a @ref BaseServer is shutting down.
+ */
+class Init : public Message
+{
+public:
+    /**
+     * Create the message.
+     */
+    Init();
+
+    /**
+     * Cleanup the message.
+     */
+    virtual ~Init();
+
+    virtual MessageType GetType() const;
+};
+
+} // namespace Message
+
+} // namespace libcomp
+
+#endif // LIBCOMP_SRC_MESSAGEINIT_H

--- a/server/world/src/ManagerConnection.cpp
+++ b/server/world/src/ManagerConnection.cpp
@@ -72,6 +72,8 @@ bool ManagerConnection::ProcessMessage(const libcomp::Message::Message *pMessage
                     auto connection = encrypted->GetConnection();
 
                     /// @todo: verify this is in fact the lobby
+                    /// @todo: if it's not this reacts horribly
+                    /// @todo: if the lobby pointer is not set before a channel it will crash the world
 
                     mLobbyConnection = std::dynamic_pointer_cast<libcomp::InternalConnection>(connection);
                 }

--- a/server/world/src/WorldServer.h
+++ b/server/world/src/WorldServer.h
@@ -70,6 +70,12 @@ public:
     virtual bool Initialize(std::weak_ptr<BaseServer>& self);
 
     /**
+     * Do any initialize that should happen after the server is listening and
+     * fully started.
+     */
+    virtual void FinishInitialize();
+
+    /**
      * Get the description of the world read from the config.
      * @return Pointer to the WorldDescription
      */


### PR DESCRIPTION
[FIX] Race condition where the lobby can attempt to connect back before the world is listening on the socket. This race existed in travis builds too but the other servers were not starting so we did not notice. See: https://travis-ci.org/comphack/comp_hack/jobs/188126878