### PR TITLE
Character stats and Persistent Reference fixes

### DIFF
--- a/libcomp/schema/account.xml
+++ b/libcomp/schema/account.xml
@@ -11,5 +11,9 @@
         <member type="s32" name="UserLevel"/>
         <member type="bool" name="Enabled"/>
         <member type="u32" name="LastLogin"/>
+        <member type="map" name="CharactersByCID">
+            <key type="u8"/>
+            <value type="Character*"/>
+        </member>
     </object>
 </objgen>

--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objgen>
     <object name="Character" location="world">
+        <!-- Basic Information -->
         <member type="string" name="Name" size="32"/>
         <member type="Account*" name="Account" key="true" unique="false"/>
         <member type="u8" name="CID" caps="true"/>
         <member type="u8" name="WorldID"/>
         <member type="u32" name="KillTime"/>
-        <member type="u8" name="Level" default="1"/>
         <member type="enum" name="Gender" size="8" default="MALE">
             <value>MALE</value>
             <value>FEMALE</value>
@@ -18,5 +18,29 @@
         <member type="u8" name="HairColor"/>
         <member type="u8" name="LeftEyeColor"/>
         <member type="u8" name="RightEyeColor"/>
+        
+        <!-- Leveling/Alignment -->
+        <member type="u8" name="Level" default="1"/>
+        <member type="u64" name="XP" caps="true"/>
+        <member type="s16" name="LNC" caps="true"/>
+        <member type="u32" name="Points"/>
+        
+        <!-- Stats -->
+        <member type="u16" name="HP" caps="true" default="73"/>
+        <member type="u16" name="MP" caps="true" default="11"/>
+        <member type="u16" name="MaxHP" default="73"/>
+        <member type="u16" name="MaxMP" default="11"/>
+        <member type="u16" name="STR" caps="true" default="1"/>
+        <member type="u16" name="MAGIC" caps="true" default="1"/>
+        <member type="u16" name="VIT" caps="true" default="1"/>
+        <member type="u16" name="INTEL" caps="true" default="1"/>
+        <member type="u16" name="SPEED" caps="true" default="1"/>
+        <member type="u16" name="LUCK" caps="true" default="1"/>
+        <member type="u16" name="CLSR" caps="true"/>
+        <member type="u16" name="LNGR" caps="true"/>
+        <member type="u16" name="SPELL" caps="true"/>
+        <member type="u16" name="SUPPORT" caps="true"/>
+        <member type="u16" name="PDEF" caps="true"/>
+        <member type="u16" name="MDEF" caps="true"/>
     </object>
 </objgen>

--- a/libcomp/src/DatabaseCassandra.cpp
+++ b/libcomp/src/DatabaseCassandra.cpp
@@ -796,6 +796,7 @@ String DatabaseCassandra::GetVariableType(const std::shared_ptr
             return "int";
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_S64:
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_U32:
+        case libobjgen::MetaVariable::MetaVariableType_t::TYPE_U64:
             return "bigint";
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_FLOAT:
             return "float";
@@ -803,7 +804,6 @@ String DatabaseCassandra::GetVariableType(const std::shared_ptr
             return "double";
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_REF:
             return "uuid";
-        case libobjgen::MetaVariable::MetaVariableType_t::TYPE_U64:
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_ARRAY:
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_LIST:
         case libobjgen::MetaVariable::MetaVariableType_t::TYPE_MAP:

--- a/libcomp/src/DatabaseQueryCassandra.cpp
+++ b/libcomp/src/DatabaseQueryCassandra.cpp
@@ -584,7 +584,7 @@ bool DatabaseQueryCassandra::GetTextValue(const CassValue *pValue,
         size_t valueSize = 0;
 
         if(CASS_OK == cass_value_get_string(pValue, &szValueData,
-            &valueSize) && nullptr != szValueData && 0 != valueSize)
+            &valueSize) && nullptr != szValueData)
         {
             value = String(szValueData, valueSize);
 

--- a/libcomp/src/DatabaseQuerySQLite3.cpp
+++ b/libcomp/src/DatabaseQuerySQLite3.cpp
@@ -98,7 +98,7 @@ bool DatabaseQuerySQLite3::Bind(size_t index, const String& value)
     int idx = (int)index;
     int len = (int)value.Size();
     mStatus = sqlite3_bind_text(mStatement, idx,
-        value.C(), len, 0);
+        value.C(), len, SQLITE_TRANSIENT);
     return IsValid();
 }
 
@@ -120,7 +120,7 @@ bool DatabaseQuerySQLite3::Bind(size_t index, const std::vector<char>& value)
     {
         int idx = (int)index;
         int size = (int)value.size();
-        mStatus = sqlite3_bind_blob(mStatement, idx, &value[0], size, 0);
+        mStatus = sqlite3_bind_blob(mStatement, idx, &value[0], size, SQLITE_TRANSIENT);
     }
     else
     {

--- a/libcomp/src/DatabaseSQLite3.cpp
+++ b/libcomp/src/DatabaseSQLite3.cpp
@@ -261,7 +261,7 @@ bool DatabaseSQLite3::InsertSingleObject(std::shared_ptr<PersistentObject>& obj)
     columnNames.push_back("UID");
 
     std::list<String> columnBinds;
-    columnBinds.push_back(String("'%1'").Arg(obj->GetUUID().ToString()));
+    columnBinds.push_back(":UID");
 
     auto values = obj->GetMemberBindValues();
 
@@ -282,6 +282,14 @@ bool DatabaseSQLite3::InsertSingleObject(std::shared_ptr<PersistentObject>& obj)
     if(!query.IsValid())
     {
         LOG_ERROR(String("Failed to prepare SQL query: %1\n").Arg(sql));
+        LOG_ERROR(String("Database said: %1\n").Arg(GetLastError()));
+
+        return false;
+    }
+
+    if(!query.Bind("UID", obj->GetUUID()))
+    {
+        LOG_ERROR("Failed to bind value: UID\n");
         LOG_ERROR(String("Database said: %1\n").Arg(GetLastError()));
 
         return false;
@@ -336,16 +344,23 @@ bool DatabaseSQLite3::UpdateSingleObject(std::shared_ptr<PersistentObject>& obj)
         columnNames.push_back(String("%1 = :%1").Arg(value->GetColumn()));
     }
 
-    String sql = String("UPDATE %1 SET %2 WHERE UID = '%3';").Arg(
+    String sql = String("UPDATE %1 SET %2 WHERE UID = :UID;").Arg(
         metaObject->GetName()).Arg(
-        String::Join(columnNames, ", ")).Arg(
-        obj->GetUUID().ToString());
+        String::Join(columnNames, ", "));
 
     DatabaseQuery query = Prepare(sql);
 
     if(!query.IsValid())
     {
         LOG_ERROR(String("Failed to prepare SQL query: %1\n").Arg(sql));
+        LOG_ERROR(String("Database said: %1\n").Arg(GetLastError()));
+
+        return false;
+    }
+
+    if(!query.Bind("UID", obj->GetUUID()))
+    {
+        LOG_ERROR("Failed to bind value: UID\n");
         LOG_ERROR(String("Database said: %1\n").Arg(GetLastError()));
 
         return false;

--- a/libcomp/src/PersistentObject.cpp
+++ b/libcomp/src/PersistentObject.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<PersistentObject> PersistentObject::LoadObjectByUUID(std::type_i
 
         if(nullptr == obj)
         {
-            LOG_ERROR(String("Unknown UUID '%1' for '%2' failed to load")
+            LOG_ERROR(String("Unknown UUID '%1' for '%2' failed to load\n")
                 .Arg(uuid.ToString()).Arg(sTypeMap[type]->GetName()));
         }
     }

--- a/libobjgen/res/VariablePersistentReferenceLoad.cpp
+++ b/libobjgen/res/VariablePersistentReferenceLoad.cpp
@@ -1,16 +1,21 @@
 ([&]() -> bool
 {
-    std::vector<char> data;
-    data.reserve(sizeof(uint64_t) * 2);
+    auto uidSize = sizeof(uint64_t) * 2;
+    char* buffer = new char[uidSize];
 
-    bool good = @STREAM@.stream.read(&data[0], static_cast<std::streamsize>(
-        data.size())).good();
+    bool good = @STREAM@.stream.read(buffer, static_cast<std::streamsize>(
+        uidSize)).good();
+
+    std::vector<char> data;
+    data.insert(data.begin(), buffer, buffer + uidSize);
 
     if(good)
     {
         auto uuid = libobjgen::UUID(data);
         good = @VAR_NAME@.SetUUID(uuid);
     }
+
+    delete[] buffer;
 
     return good;
 })()

--- a/libobjgen/res/VariablePersistentReferenceLoadRaw.cpp
+++ b/libobjgen/res/VariablePersistentReferenceLoadRaw.cpp
@@ -1,21 +1,21 @@
 ([&]() -> bool
 {
-    if(flat)
+    auto uidSize = sizeof(uint64_t) * 2;
+    char* buffer = new char[uidSize];
+
+    bool good = @STREAM@.read(buffer, static_cast<std::streamsize>(
+        uidSize)).good();
+
+    std::vector<char> data;
+    data.insert(data.begin(), buffer, buffer + uidSize);
+
+    if(good)
     {
-        std::vector<char> data;
-        data.reserve(sizeof(uint64_t) * 2);
-
-        bool good = @STREAM@.read(&data[0], static_cast<std::streamsize>(
-            data.size())).good();
-
-        if(good)
-        {
-            auto uuid = libobjgen::UUID(data);
-            good = @VAR_NAME@.SetUUID(uuid);
-        }
-
-        return good;
+        auto uuid = libobjgen::UUID(data);
+        good = @VAR_NAME@.SetUUID(uuid);
     }
-    
-    return true;
+
+    delete[] buffer;
+
+    return good;
 })()

--- a/libobjgen/res/VariablePersistentReferenceSave.cpp
+++ b/libobjgen/res/VariablePersistentReferenceSave.cpp
@@ -4,7 +4,7 @@
 
     if(!@VAR_NAME@.IsNull())
     {
-        uuid = @VAR_NAME@.GetCurrentReference()->GetUUID();
+        uuid = @VAR_NAME@.GetUUID();
     }
 
     std::vector<char> data = uuid.ToData();

--- a/libobjgen/res/VariablePersistentReferenceSaveRaw.cpp
+++ b/libobjgen/res/VariablePersistentReferenceSaveRaw.cpp
@@ -1,21 +1,14 @@
 ([&]() -> bool
 {
-    if(flat)
+    libobjgen::UUID uuid;
+
+    if(!@VAR_NAME@.IsNull())
     {
-        libobjgen::UUID uuid;
-
-        if(!@VAR_NAME@.IsNull())
-        {
-            uuid = @VAR_NAME@.GetCurrentReference()->GetUUID();
-        }
-
-        std::vector<char> data = uuid.ToData();
-
-        return @STREAM@.write(&data[0], static_cast<std::streamsize>(
-            data.size())).good();
+        uuid = @VAR_NAME@.GetUUID();
     }
-    else
-    {
-        return true;
-    }
+
+    std::vector<char> data = uuid.ToData();
+
+    return @STREAM@.write(&data[0], static_cast<std::streamsize>(
+        data.size())).good();
 })()

--- a/libobjgen/res/VariablePersistentReferenceXmlLoad.cpp
+++ b/libobjgen/res/VariablePersistentReferenceXmlLoad.cpp
@@ -1,10 +1,8 @@
 ([&]() -> @VAR_CODE_TYPE@
 {
-    if(!@VAR_NAME@.IsNull())
-    {
-        auto uuid = GetXmlText(*@NODE@);
-        @VAR_NAME@.SetUUID(uuid);
-    }
+    @VAR_CODE_TYPE@ ref;
+    auto uuid = GetXmlText(*@NODE@);
+    ref.SetUUID(uuid);
 
-    return @VAR_NAME@;
+    return ref;
 })()

--- a/libobjgen/src/GeneratorSource.cpp
+++ b/libobjgen/src/GeneratorSource.cpp
@@ -160,12 +160,8 @@ std::string GeneratorSource::Generate(const MetaObject& obj)
     ss << "bool " << obj.GetName() << "::IsValid(bool recursive) const"
         << std::endl;
     ss << "{" << std::endl;
-
-    if(references.empty())
-    {
-        ss << Tab() << "(void)recursive;" << std::endl;
-        ss << std::endl;
-    }
+    ss << Tab() << "(void)recursive;" << std::endl;
+    ss << std::endl;
 
     ss << Tab() << "bool status = " + GetBaseBooleanReturnValue(obj, "IsValid(recursive)") + ";" << std::endl;
 

--- a/libobjgen/src/MetaObject.cpp
+++ b/libobjgen/src/MetaObject.cpp
@@ -256,13 +256,15 @@ bool MetaObject::IsValid() const
 
 bool MetaObject::Load(std::istream& stream)
 {
-    Generator::LoadString(stream, mName);
-    Generator::LoadString(stream, mBaseObject);
+    bool result = true;
+
+    result &= Generator::LoadString(stream, mName);
+    result &= Generator::LoadString(stream, mBaseObject);
     stream.read(reinterpret_cast<char*>(&mScriptEnabled),
         sizeof(mScriptEnabled));
     stream.read(reinterpret_cast<char*>(&mPersistent),
         sizeof(mPersistent));
-    Generator::LoadString(stream, mSourceLocation);
+    result &= Generator::LoadString(stream, mSourceLocation);
 
     VariableList vars;
     if(MetaVariable::LoadVariableList(stream, vars))
@@ -271,11 +273,15 @@ bool MetaObject::Load(std::istream& stream)
         mVariableMapping.clear();
         for(auto var : vars)
         {
-            AddVariable(var);
+            result &= AddVariable(var);
         }
     }
+    else
+    {
+        result = false;
+    }
 
-    return stream.good();
+    return result && stream.good();
 }
 
 bool MetaObject::Save(std::ostream& stream) const
@@ -285,15 +291,17 @@ bool MetaObject::Save(std::ostream& stream) const
         return false;
     }
 
-    Generator::SaveString(stream, mName);
-    Generator::SaveString(stream, mBaseObject);
+    bool result = true;
+
+    result &= Generator::SaveString(stream, mName);
+    result &= Generator::SaveString(stream, mBaseObject);
     stream.write(reinterpret_cast<const char*>(&mScriptEnabled),
         sizeof(mScriptEnabled));
     stream.write(reinterpret_cast<const char*>(&mPersistent),
         sizeof(mPersistent));
-    Generator::SaveString(stream, mSourceLocation);
+    result &= Generator::SaveString(stream, mSourceLocation);
 
-    return stream.good() &&
+    return result && stream.good() &&
         MetaVariable::SaveVariableList(stream, mVariables);
 }
 

--- a/libobjgen/src/MetaVariableArray.cpp
+++ b/libobjgen/src/MetaVariableArray.cpp
@@ -110,7 +110,7 @@ bool MetaVariableArray::Load(std::istream& stream)
     stream.read(reinterpret_cast<char*>(&mElementCount),
         sizeof(mElementCount));
 
-    return stream.good() && IsValid() && mElementType->Load(stream);
+    return stream.good() && mElementType->Load(stream) && IsValid();
 }
 
 bool MetaVariableArray::Save(std::ostream& stream) const
@@ -493,7 +493,7 @@ std::string MetaVariableArray::GetUtilityFunctions(const Generator& generator,
         replacements["@VAR_CAMELCASE_NAME@"] = generator.GetCapitalName(*this);
         replacements["@ELEMENT_COUNT@"] = std::to_string(mElementCount);
 
-        auto entryValidation = mElementType->GetValidCondition(generator, "val", true);
+        auto entryValidation = mElementType->GetValidCondition(generator, "val", false);
 
         replacements["@ELEMENT_VALIDATION_CODE@"] = entryValidation.length() > 0
             ? entryValidation : "([&]() { (void)val; return true; })()";

--- a/libobjgen/src/MetaVariableInt.h
+++ b/libobjgen/src/MetaVariableInt.h
@@ -670,7 +670,8 @@ public:
             {
                 bindType = "BigInt";
                 castType = "int64_t";
-                cast = sizeof(T) != sizeof(int64_t);
+                cast = sizeof(T) != sizeof(int64_t) ||
+                    !std::numeric_limits<T>::is_signed;
             }
         }
         else if(typeid(float) == typeid(T))

--- a/libobjgen/src/MetaVariableList.cpp
+++ b/libobjgen/src/MetaVariableList.cpp
@@ -84,7 +84,7 @@ bool MetaVariableList::Load(std::istream& stream)
 {
     MetaVariable::Load(stream);
 
-    return IsValid() && mElementType->Load(stream);
+    return stream.good() && mElementType->Load(stream) && IsValid();
 }
 
 bool MetaVariableList::Save(std::ostream& stream) const
@@ -407,7 +407,7 @@ std::string MetaVariableList::GetUtilityFunctions(const Generator& generator,
         replacements["@OBJECT_NAME@"] = object.GetName();
         replacements["@VAR_CAMELCASE_NAME@"] = generator.GetCapitalName(*this);
 
-        auto entryValidation = mElementType->GetValidCondition(generator, "val", true);
+        auto entryValidation = mElementType->GetValidCondition(generator, "val", false);
 
         replacements["@ELEMENT_VALIDATION_CODE@"] = entryValidation.length() > 0
             ? entryValidation : "([&]() { (void)val; return true; })()";

--- a/libobjgen/src/MetaVariableMap.cpp
+++ b/libobjgen/src/MetaVariableMap.cpp
@@ -92,7 +92,7 @@ bool MetaVariableMap::Load(std::istream& stream)
 {
     MetaVariable::Load(stream);
 
-    return IsValid() && mKeyElementType->Load(stream) && mValueElementType->Load(stream);
+    return mKeyElementType->Load(stream) && mValueElementType->Load(stream) && IsValid();
 }
 
 bool MetaVariableMap::Save(std::ostream& stream) const
@@ -444,8 +444,8 @@ std::string MetaVariableMap::GetUtilityFunctions(const Generator& generator,
         replacements["@OBJECT_NAME@"] = object.GetName();
         replacements["@VAR_CAMELCASE_NAME@"] = generator.GetCapitalName(*this);
 
-        auto keyValidation = mKeyElementType->GetValidCondition(generator, "key", true);
-        auto valueValidation = mValueElementType->GetValidCondition(generator, "val", true);
+        auto keyValidation = mKeyElementType->GetValidCondition(generator, "key", false);
+        auto valueValidation = mValueElementType->GetValidCondition(generator, "val", false);
 
         replacements["@KEY_VALIDATION_CODE@"] = keyValidation.length() > 0
             ? keyValidation : "([&]() { (void)key; return true; })()";

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -71,14 +71,14 @@ SOURCE_GROUP("Source Files\\Packets\\Internal" src/packets/internal/*)
 
 SET(${PROJECT_NAME}_PACKETS
     src/packets/game/Login.cpp               # 0x0000
-    src/packets/game/Auth.cpp               # 0x0002
-    src/packets/game/SendData.cpp               # 0x0004
-    src/packets/game/KeepAlive.cpp               # 0x0056
+    src/packets/game/Auth.cpp                # 0x0002
+    src/packets/game/SendData.cpp            # 0x0004
+    src/packets/game/KeepAlive.cpp           # 0x0056
     src/packets/game/State.cpp               # 0x005A
-    src/packets/game/Sync.cpp               # 0x00F3
+    src/packets/game/Sync.cpp                # 0x00F3
 
     #Internal packets
-    src/packets/internal/SetWorldInfo.cpp      # 0x1002
+    src/packets/internal/SetWorldInfo.cpp    # 0x1002
 )
 
 ADD_EXECUTABLE(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS}

--- a/server/channel/src/Packets.h
+++ b/server/channel/src/Packets.h
@@ -36,16 +36,14 @@ namespace channel
 namespace Parsers
 {
 
-PACKET_PARSER_DECL(Login);               // 0x0000
+PACKET_PARSER_DECL(Login);              // 0x0000
 PACKET_PARSER_DECL(Auth);               // 0x0002
-PACKET_PARSER_DECL(SendData);               // 0x0004
-PACKET_PARSER_DECL(Move);               // 0x001C
-PACKET_PARSER_DECL(KeepAlive);               // 0x0056
-PACKET_PARSER_DECL(State);               // 0x005A
-PACKET_PARSER_DECL(WorldTime);               // 0x0072
+PACKET_PARSER_DECL(SendData);           // 0x0004
+PACKET_PARSER_DECL(KeepAlive);          // 0x0056
+PACKET_PARSER_DECL(State);              // 0x005A
 PACKET_PARSER_DECL(Sync);               // 0x00F3
 
-PACKET_PARSER_DECL(SetWorldInfo);               // 0x1002
+PACKET_PARSER_DECL(SetWorldInfo);       // 0x1002
 
 } // namespace Parsers
 

--- a/server/channel/src/packets/game/Login.cpp
+++ b/server/channel/src/packets/game/Login.cpp
@@ -49,49 +49,9 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-	// Where to store the username and session key
-	libcomp::String username;
-	uint32_t sessionKey;
-
-	// If the size of the login packet isn't right, this might be the new
-	// Atlus login method.
-	if(p.Size() < 6 || p.Size() != (uint32_t)(6 + p.PeekU16Little()))
-	{
-		// Check if the authentication string is there
-        if(p.Size() < (uint16_t)(2 + p.PeekU16Little()))
-        {
-            return false;
-        }
-
-		// Read the authentication string
-		/// @todo validate this key instead of ignoring it
-		libcomp::String authKey = p.ReadString16Little(
-            libcomp::Convert::ENCODING_UTF8);
-
-		// Check if the session key is there
-		if(p.Left() < 4)
-        {
-            return false;
-        }
-
-		// Read the session key
-		sessionKey = p.ReadU32Little();
-
-		// Check if the username is there
-		if(p.Left() != (uint32_t)(2 + p.PeekU16Little()))
-        {
-            return false;
-        }
-
-		// Read the username
-		username = p.ReadString16(libcomp::Convert::ENCODING_UTF8);
-	}
-	else
-	{
-		// Classic authentication method: username followed by the session key
-		username = p.ReadString16(libcomp::Convert::ENCODING_UTF8);
-		sessionKey = p.ReadU32Little();
-	}
+    // Classic authentication method: username followed by the session key
+    libcomp::String username = p.ReadString16(libcomp::Convert::ENCODING_UTF8);
+    uint32_t sessionKey = p.ReadU32Little();
 
     // Remove null terminator
     username = username.C();
@@ -111,25 +71,16 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         /// @todo: load the information the lobby retrieved
         auto cid = sessionKey;
+        auto charactersByCID = account->GetCharactersByCID();
 
-        std::shared_ptr<objects::Character> character;
-        /// @todo: load character by uid via account map keyed on cid
-        for(auto accountCharacter : objects::Character::LoadCharacterListByAccount(
-            worldDB, account))
-        {
-            if(accountCharacter->GetCID() == cid)
-            {
-                character = accountCharacter;
-                break;
-            }
-        }
+        auto character = charactersByCID.find(cid);
 
-        if(nullptr != character)
+        if(character != charactersByCID.end() && character->second.Get(worldDB))
         {
             auto state = std::shared_ptr<ClientState>(new ClientState);
             state->SetAccount(account);
             state->SetSessionKey(sessionKey);
-            state->SetCharacter(character);
+            state->SetCharacter(character->second.GetCurrentReference());
 
             client->SetClientState(state);
 

--- a/server/channel/src/packets/game/Login.cpp
+++ b/server/channel/src/packets/game/Login.cpp
@@ -70,7 +70,7 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
     if(nullptr != account)
     {
         /// @todo: load the information the lobby retrieved
-        auto cid = sessionKey;
+        auto cid = (uint8_t)sessionKey;
         auto charactersByCID = account->GetCharactersByCID();
 
         auto character = charactersByCID.find(cid);

--- a/server/channel/src/packets/game/State.cpp
+++ b/server/channel/src/packets/game/State.cpp
@@ -50,136 +50,135 @@ void SendCharacterData(const std::shared_ptr<channel::ChannelClientConnection>& 
     libcomp::Packet reply;
     reply.WritePacketCode(ChannelClientPacketCode_t::PACKET_CHARACTER_DATA_RESPONSE);
     
-	reply.WriteU32Little((uint32_t)c->GetCID());    /// @todo: replace with unique entity ID
+    reply.WriteU32Little((uint32_t)c->GetCID());    /// @todo: replace with unique entity ID
     reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
         c->GetName(), true);
-	reply.WriteU32Little(0); // Special Title
-	reply.WriteU8((uint8_t)c->GetGender());
-	reply.WriteU8(c->GetSkinType());
-	reply.WriteU8(c->GetHairType());
-	reply.WriteU8(c->GetHairColor());
-	reply.WriteU8(c->GetGender() == objects::Character::Gender_t::MALE
+    reply.WriteU32Little(0); // Special Title
+    reply.WriteU8((uint8_t)c->GetGender());
+    reply.WriteU8(c->GetSkinType());
+    reply.WriteU8(c->GetHairType());
+    reply.WriteU8(c->GetHairColor());
+    reply.WriteU8(c->GetGender() == objects::Character::Gender_t::MALE
         ? 0x03 : 0x65); // One of these is wrong
-	reply.WriteU8(c->GetRightEyeColor());
-	reply.WriteU8(c->GetFaceType());
-	reply.WriteU8(c->GetLeftEyeColor());
-	reply.WriteU8(0x00); // Unknown
-	reply.WriteU8(0x01); // Unknown
+    reply.WriteU8(c->GetRightEyeColor());
+    reply.WriteU8(c->GetFaceType());
+    reply.WriteU8(c->GetLeftEyeColor());
+    reply.WriteU8(0x00); // Unknown
+    reply.WriteU8(0x01); // Unknown
 
     /// @todo: equipment
-	for(int z = 0; z < 15; z++)
-	{
-		/*uint32_t equip = c->equip(z);
+    for(int z = 0; z < 15; z++)
+    {
+        /*uint32_t equip = c->equip(z);
 
-		if(equip != 0)
-			reply.WriteU32Little(equip);
-		else*/
-			reply.WriteU32Little(0xFFFFFFFF);
-	}
+        if(equip != 0)
+            reply.WriteU32Little(equip);
+        else*/
+            reply.WriteU32Little(0xFFFFFFFF);
+    }
 
-    /// @todo: status
     //Character status
-	reply.WriteU16Little(50);   //Max HP
-	reply.WriteU16Little(50);   //Max MP
-	reply.WriteU16Little(50);   //HP
-	reply.WriteU16Little(50);   //MP
-	reply.WriteU64Little(0);    //XP
-	reply.WriteU32Little(0);    //Points
-	reply.WriteU8(c->GetLevel());
-	reply.WriteS16Little(1);    //lnc?
-	reply.WriteU16Little(1);    //str
-	reply.WriteU16Little(1);    //str2
-	reply.WriteU16Little(1);    //magic
-	reply.WriteU16Little(1);    //magic2
-	reply.WriteU16Little(1);    //vit
-	reply.WriteU16Little(1);    //vit2
-	reply.WriteU16Little(1);    //intel
-	reply.WriteU16Little(1);    //intel2
-	reply.WriteU16Little(1);    //speed
-	reply.WriteU16Little(1);    //speed2
-	reply.WriteU16Little(1);    //luck
-	reply.WriteU16Little(1);    //luck2
-	reply.WriteU16Little(1);    //cls?
-	reply.WriteU16Little(1);    //cls2?
-	reply.WriteU16Little(1);    //lng?
-	reply.WriteU16Little(1);    //lng2?
-	reply.WriteU16Little(1);    //spell
-	reply.WriteU16Little(1);    //spell2
-	reply.WriteU16Little(1);    //supp?
-	reply.WriteU16Little(1);    //supp2?
-	reply.WriteU16Little(1);    //pdef
-	reply.WriteU16Little(1);    //pdef2
-	reply.WriteU16Little(1);    //mdef
-	reply.WriteU16Little(1);    //mdef2
+    reply.WriteU16Little(c->GetMaxHP());
+    reply.WriteU16Little(c->GetMaxMP());
+    reply.WriteU16Little(c->GetHP());
+    reply.WriteU16Little(c->GetMP());
+    reply.WriteU64Little(c->GetXP());
+    reply.WriteU32Little(c->GetPoints());
+    reply.WriteU8(c->GetLevel());
+    reply.WriteS16Little(c->GetLNC());
+    reply.WriteU16Little(c->GetSTR());
+    reply.WriteU16Little(0);     /// @todo: calculated STR boost
+    reply.WriteU16Little(c->GetMAGIC());
+    reply.WriteU16Little(0);     /// @todo: calculated MAGIC boost
+    reply.WriteU16Little(c->GetVIT());
+    reply.WriteU16Little(0);     /// @todo: calculated VIT boost
+    reply.WriteU16Little(c->GetINTEL());
+    reply.WriteU16Little(0);     /// @todo: calculated INTEL boost
+    reply.WriteU16Little(c->GetSPEED());
+    reply.WriteU16Little(0);     /// @todo: calcualted SPEED boost
+    reply.WriteU16Little(c->GetLUCK());
+    reply.WriteU16Little(0);     /// @todo: calculated LUCK boost
+    reply.WriteU16Little(c->GetCLSR());
+    reply.WriteU16Little(0);     /// @todo: calculated CLSR boost
+    reply.WriteU16Little(c->GetLNGR());
+    reply.WriteU16Little(0);     /// @todo: calcualted LNGR boost
+    reply.WriteU16Little(c->GetSPELL());
+    reply.WriteU16Little(0);     /// @todo: calculated SPELL boost
+    reply.WriteU16Little(c->GetSUPPORT());
+    reply.WriteU16Little(0);     /// @todo: calcualted SUPPORT boost
+    reply.WriteU16Little(c->GetPDEF());
+    reply.WriteU16Little(0);     /// @todo: calculated PDEF boost
+    reply.WriteU16Little(c->GetMDEF());
+    reply.WriteU16Little(0);     /// @todo: calculated MDEF boost
 
-	reply.WriteU32Little(367061536); // Unknown
+    reply.WriteU32Little(367061536); // Unknown
 
     /// @todo: status effects
-	uint32_t statusEffectCount = 0;
+    uint32_t statusEffectCount = 0;
 
-	reply.WriteU32Little(statusEffectCount + 1);
+    reply.WriteU32Little(statusEffectCount + 1);
 
-	for(uint32_t i = 0; i < statusEffectCount; i++)
-	{
-		/*BfStatusEffectDataPtr sfx = cs->statusEffect(i);
+    for(uint32_t i = 0; i < statusEffectCount; i++)
+    {
+        /*BfStatusEffectDataPtr sfx = cs->statusEffect(i);
 
-		reply.WriteU32Little(sfx->effect());
-		reply.WriteFloat(state->clientTime(state->serverTicks() +
-			sfx->duration()));
-		reply.WriteU8(sfx->stack());*/
-	}
+        reply.WriteU32Little(sfx->effect());
+        reply.WriteFloat(state->clientTime(state->serverTicks() +
+            sfx->duration()));
+        reply.WriteU8(sfx->stack());*/
+    }
 
-	reply.WriteU32Little(1055); //Unknown
-	reply.WriteU32Little(1325025608);   //Unknown
-	reply.WriteU8(1);   //Unknown
+    reply.WriteU32Little(1055); //Unknown
+    reply.WriteU32Little(1325025608);   //Unknown
+    reply.WriteU8(1);   //Unknown
 
     /// @todo: skills
-	reply.WriteU32Little(0);
+    reply.WriteU32Little(0);
 
-	/*for(uint32_t skill : state->tempSkillCopy())
-		reply.WriteU32Little(skill);
-	for(uint32_t skill : c->learnedSkillCopy())
-		reply.WriteU32Little(skill);
+    /*for(uint32_t skill : state->tempSkillCopy())
+        reply.WriteU32Little(skill);
+    for(uint32_t skill : c->learnedSkillCopy())
+        reply.WriteU32Little(skill);
 
-	reply.WriteArray(defSkills, 4 * defaultCount);*/
+    reply.WriteArray(defSkills, 4 * defaultCount);*/
 
-	for(int i = 0; i < 38; i++)
-	{
-		//const BfExpertise& exp = c->expertise(i);
+    for(int i = 0; i < 38; i++)
+    {
+        //const BfExpertise& exp = c->expertise(i);
 
-		reply.WriteU32Little(0);
-		reply.WriteU8(0);
-		reply.WriteU8(0); // 0 - Raise | 1 - Capped
-	}
+        reply.WriteU32Little(0);
+        reply.WriteU8(0);
+        reply.WriteU8(0); // 0 - Raise | 1 - Capped
+    }
 
-	reply.WriteU32Little(0);
+    reply.WriteU32Little(0);
 
     /// @todo: demons
-	/*if(nullptr != state->demon() && c->activeDemon() > 0)
-		reply.WriteU64Little(c->activeDemon());
-	else*/
-		reply.WriteS64Little(-1);
+    /*if(nullptr != state->demon() && c->activeDemon() > 0)
+        reply.WriteU64Little(c->activeDemon());
+    else*/
+        reply.WriteS64Little(-1);
 
-	reply.WriteU32Little(0xFFFFFFFF);
-	reply.WriteU32Little(0xFFFFFFFF);
-	reply.WriteU32Little(0xFFFFFFFF);
-	reply.WriteU32Little(0xFFFFFFFF);
+    reply.WriteU32Little(0xFFFFFFFF);
+    reply.WriteU32Little(0xFFFFFFFF);
+    reply.WriteU32Little(0xFFFFFFFF);
+    reply.WriteU32Little(0xFFFFFFFF);
 
-	//BfZonePtr zone = state->zoneInst()->zone();
+    //BfZonePtr zone = state->zoneInst()->zone();
     
     /// @todo: zone position
-	reply.WriteU32Little(1);    //set
-	reply.WriteU32Little(0x00004E85); // Zone ID
-	reply.WriteFloat(0);    //x
-	reply.WriteFloat(0);    //y
-	reply.WriteFloat(0);    //rotation
+    reply.WriteU32Little(1);    //set
+    reply.WriteU32Little(0x00004E85); // Zone ID
+    reply.WriteFloat(0);    //x
+    reply.WriteFloat(0);    //y
+    reply.WriteFloat(0);    //rotation
 
-	reply.WriteU8(0);
-	reply.WriteU32Little(0); // Homepoint zone
-	reply.WriteU32Little(0x43FA8000); // Homepoint X
-	reply.WriteU32Little(0x3F800000); // Homepoint Y
-	reply.WriteU16Little(0);
-	reply.WriteU8(1);
+    reply.WriteU8(0);
+    reply.WriteU32Little(0); // Homepoint zone
+    reply.WriteU32Little(0x43FA8000); // Homepoint X
+    reply.WriteU32Little(0x3F800000); // Homepoint Y
+    reply.WriteU16Little(0);
+    reply.WriteU8(1);
 
     client->SendPacket(reply);
 }


### PR DESCRIPTION
I fixed the formatting issues from last commit.  The naming convention I went with for the Account Characters map mimics ValueByKey (in this case CharactersByCID) so the usage is more easily understood than a map just called Characters.  I also had to fix some binding issues in both DB implementations that became more apparent when building out Character more.