### PR TITLE
Character/demon properties, enum enhancements and misc fixes

### DIFF
--- a/libcomp/CMakeLists.txt
+++ b/libcomp/CMakeLists.txt
@@ -213,12 +213,18 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     AccountLogin.cpp
     Character.h
     Character.cpp
+    CharacterProgress.h
+    CharacterProgress.cpp
     DatabaseConfig.h
     DatabaseConfig.cpp
     DatabaseConfigCassandra.h
     DatabaseConfigCassandra.cpp
     DatabaseConfigSQLite3.h
     DatabaseConfigSQLite3.cpp
+    Demon.h
+    Demon.cpp
+    EntityStats.h
+    EntityStats.cpp
     PacketLogin.h
     PacketLogin.cpp
     PacketResponseCode.h

--- a/libcomp/schema/account.xml
+++ b/libcomp/schema/account.xml
@@ -10,11 +10,10 @@
         <member type="u8" name="TicketCount"/>
         <member type="s32" name="UserLevel"/>
         <member type="bool" name="Enabled"/>
-        <member type="bool" name="IsGM" key="false"/>
+        <member type="bool" name="IsGM" default="false"/>
         <member type="u32" name="LastLogin"/>
-        <member type="map" name="CharactersByCID">
-            <key type="u8"/>
-            <value type="Character*"/>
+        <member type="array" name="Characters" size="20">
+            <element type="Character*"/>
         </member>
     </object>
 </objgen>

--- a/libcomp/schema/accountlogin.xml
+++ b/libcomp/schema/accountlogin.xml
@@ -2,7 +2,7 @@
 <objgen>
     <object name="AccountLogin" persistent="false">
         <member type="Account*" name="Account"/>
-        <member type="u8" name="CID"/>
+        <member type="u8" name="CID" max="19"/>
         <member type="s8" name="WorldID" default="-1"/>
         <member type="s8" name="ChannelID" default="-1"/>
         <member type="string" name="SessionID" size="300"/>

--- a/libcomp/schema/binarydata/itemdata.xml
+++ b/libcomp/schema/binarydata/itemdata.xml
@@ -10,7 +10,24 @@
         <member type="s32" name="unk1"/>
         <member type="s16" name="unk2"/>
         <member type="u8" name="unk3"/>
-        <member type="s8" name="equipType"/>
+        <member type="enum" name="equipType" underlying="int8_t">
+            <value num="-1">EQUIP_TYPE_NONE</value>
+            <value>EQUIP_TYPE_HEAD</value>
+            <value>EQUIP_TYPE_FACE</value>
+            <value>EQUIP_TYPE_NECK</value>
+            <value>EQUIP_TYPE_TOP</value>
+            <value>EQUIP_TYPE_ARMS</value>
+            <value>EQUIP_TYPE_BOTTOM</value>
+            <value>EQUIP_TYPE_FEET</value>
+            <value>EQUIP_TYPE_COMP</value>
+            <value>EQUIP_TYPE_RING</value>
+            <value>EQUIP_TYPE_EARRING</value>
+            <value>EQUIP_TYPE_EXTRA</value>
+            <value>EQUIP_TYPE_BACK</value>
+            <value>EQUIP_TYPE_TALISMAN</value>
+            <value>EQUIP_TYPE_WEAPON</value>
+            <value>EQUIP_TYPE_BULLETS</value>
+        </member>
         <member type="u32" name="unk4"/>
     </object>
     <object name="MiPossessionData" persistent="false" scriptenabled="true">

--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objgen>
     <object name="Character" location="world">
-        <!-- Basic Information -->
         <member type="string" name="Name" size="32"/>
         <member type="Account*" name="Account" key="true" unique="false"/>
-        <member type="u8" name="CID" caps="true"/>
+        <member type="u8" name="CID" caps="true" max="19"/>
         <member type="u8" name="WorldID"/>
         <member type="u32" name="KillTime"/>
-        <member type="enum" name="Gender" underlying="int8_t" default="MALE">
+
+        <!-- Character Customization -->
+        <member type="enum" name="Gender" underlying="int8_t">
             <value>MALE</value>
             <value>FEMALE</value>
         </member>
@@ -19,13 +20,28 @@
         <member type="u8" name="LeftEyeColor"/>
         <member type="u8" name="RightEyeColor"/>
         
-        <!-- Leveling/Alignment -->
-        <member type="u8" name="Level" default="1"/>
-        <member type="u64" name="XP" caps="true"/>
+        <!-- Character specific attributes -->
         <member type="s16" name="LNC" caps="true"/>
         <member type="u32" name="Points"/>
-        
-        <!-- Stats -->
+
+        <!-- Collections -->
+        <member type="array" name="EquippedItems" size="15">
+            <element type="u32"/>
+        </member>
+        <member type="array" name="Materials" size="52">
+            <element type="u32"/>
+        </member>
+        <member type="array" name="COMP" caps="true" size="10">
+            <element type="Demon*"/>
+        </member>
+
+        <!-- Sub-sections -->
+        <member type="EntityStats*" name="CoreStats"/>
+        <member type="CharacterProgress*" name="Progress"/>
+    </object>
+    <object name="EntityStats" location="world">
+        <member type="u8" name="Level" default="1"/>
+        <member type="u64" name="XP" caps="true"/>
         <member type="u16" name="HP" caps="true" default="73"/>
         <member type="u16" name="MP" caps="true" default="11"/>
         <member type="u16" name="MaxHP" default="73"/>
@@ -42,5 +58,22 @@
         <member type="u16" name="SUPPORT" caps="true"/>
         <member type="u16" name="PDEF" caps="true"/>
         <member type="u16" name="MDEF" caps="true"/>
+    </object>
+    <object name="CharacterProgress" location="world">
+        <member type="array" name="Maps" size="32">
+            <element type="u8"/>
+        </member>
+        <member type="array" name="Plugins" size="32">
+            <element type="u8"/>
+        </member>
+        <member type="array" name="Valuables" size="64">
+            <element type="u8"/>
+        </member>
+        <member type="array" name="DevilBook" size="512">
+            <element type="u8"/>
+        </member>
+        <member type="array" name="CompletedQuests" size="512">
+            <element type="u8"/>
+        </member>
     </object>
 </objgen>

--- a/libcomp/schema/demon.xml
+++ b/libcomp/schema/demon.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <object name="Demon" location="world">
+        <!-- Sub-sections -->
+        <member type="EntityStats*" name="CoreStats"/>
+    </object>
+</objgen>

--- a/libcomp/schema/master.xml
+++ b/libcomp/schema/master.xml
@@ -13,6 +13,7 @@
     <include path="account.xml"/>
     <include path="accountlogin.xml"/>
     <include path="character.xml"/>
+    <include path="demon.xml"/>
     <include path="registeredchannel.xml"/>
     <include path="registeredworld.xml"/>
 

--- a/libcomp/src/ObjectReference.h
+++ b/libcomp/src/ObjectReference.h
@@ -77,7 +77,7 @@ public:
      * @param db Database to load from if persistent
      * @return Pointer to the referenced object
      */
-    const std::shared_ptr<T> Get(const std::shared_ptr<Database>& db = nullptr)
+    const std::shared_ptr<T>& Get(const std::shared_ptr<Database>& db = nullptr)
     {
         LoadReference(db);
 
@@ -124,11 +124,19 @@ public:
     {
         // Do not count an attempt to load without a DB as a
         // load failure
-        if(IsPersistentReference() && nullptr != db
-            && !mUUID.IsNull() && !mLoadFailed)
+        if(IsPersistentReference() && nullptr == mRef &&
+            !mUUID.IsNull() && !mLoadFailed)
         {
-            mRef = PersistentObject::LoadObjectByUUID<T>(db, mUUID);
-            mLoadFailed = nullptr == mRef;
+            if(nullptr != db)
+            {
+                mRef = PersistentObject::LoadObjectByUUID<T>(db, mUUID);
+                mLoadFailed = nullptr == mRef;
+            }
+            else
+            {
+                mRef = std::dynamic_pointer_cast<T>(
+                    PersistentObject::GetObjectByUUID(mUUID));
+            }
         }
         return mUUID.IsNull() || nullptr != mRef;
     }

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -68,7 +68,8 @@ enum class ChannelClientPacketCode_t : uint16_t
     PACKET_SEND_DATA = 0x0004,  //!< The client is requesting data from the server.
     PACKET_LOGOUT = 0x0005,  //!< Logout request from the client.
     PACKET_LOGOUT_RESPONSE = 0x0009,  //!< Logout response to the client.
-    PACKET_CHARACTER_DATA_RESPONSE = 0x000F,  //!< Response to the client containing all sorts of character data.
+    PACKET_CHARACTER_DATA = 0x000F,  //!< Message to the client containing all sorts of character data.
+    PACKET_SHOW_CHARACTER = 0x001A,  //!< Message to the client to display a character.
     PACKET_ZONE_CHANGE = 0x0023,  //!< Information about a character's zone for the client.
     PACKET_CHAT = 0x0026, //!< Client request to add a message to the chat or process a GM command.
     PACKET_CHAT_RESPONSE = 0x0028, //!< Client response from chat request.
@@ -77,7 +78,7 @@ enum class ChannelClientPacketCode_t : uint16_t
     PACKET_STATE = 0x005A,  //!< Client request for their character state.
     PACKET_SYNC = 0x00F3,  //!< Client request to retrieve the server time.
     PACKET_SYNC_RESPONSE = 0x00F4,  //!< Response to client containing the server time.
-    PACKET_STATUS_ICON_RESPONSE = 0x0195,  //!< Response to client containing the icon to show for the character.
+    PACKET_STATUS_ICON = 0x0195,  //!< Message to the client containing the icon to show for the character.
 
     PACKET_CONFIRMATION = 0x1FFF,  //!< Generic confirmation response to the client.
 };

--- a/libcomp/src/PersistentObject.h
+++ b/libcomp/src/PersistentObject.h
@@ -36,6 +36,7 @@
 #include <UUID.h>
 
 // Standard C++ 11 Includes
+#include <mutex>
 #include <typeindex>
 
 namespace libcomp
@@ -327,6 +328,9 @@ private:
     /// Map of intantiated objects listed by their UUID
     static std::unordered_map<std::string,
         std::weak_ptr<PersistentObject>> sCached;
+
+    /// Mutex to lock accessing the cache
+    static std::mutex mCacheLock;
 
     /// Static map of MetaObject definitions by the source object's C++ type
     static TypeMap sTypeMap;

--- a/libobjgen/res/VariableArrayLoad.cpp
+++ b/libobjgen/res/VariableArrayLoad.cpp
@@ -1,6 +1,6 @@
 ([&]() -> bool
 {
-    for(auto& value : @VAR_NAME@)
+    for(auto& element : @VAR_NAME@)
     {
         if(!(@VAR_LOAD_CODE@))
         {

--- a/libobjgen/res/VariableArraySave.cpp
+++ b/libobjgen/res/VariableArraySave.cpp
@@ -1,6 +1,6 @@
 ([&]() -> bool
 {
-    for(auto& value : @VAR_NAME@)
+    for(auto& element : @VAR_NAME@)
     {
         if(!(@VAR_SAVE_CODE@))
         {

--- a/libobjgen/res/VariableEnumXmlLoad.cpp
+++ b/libobjgen/res/VariableEnumXmlLoad.cpp
@@ -4,7 +4,7 @@
     {
         auto text = GetXmlText(*@NODE@);
         
-        auto result = Get@VAR_NAME@Value(text, status);
+        auto result = Get@VAR_CAMELCASE_NAME@Value(text, status);
         return status ? result : @VAR_CODE_TYPE@::@DEFAULT@;
     }
     catch (...)

--- a/libobjgen/res/VariableEnumXmlSave.cpp
+++ b/libobjgen/res/VariableEnumXmlSave.cpp
@@ -2,7 +2,7 @@
     tinyxml2::XMLElement *pMember = doc.NewElement(@ELEMENT_NAME@);
     pMember->SetAttribute("name", @VAR_XML_NAME@);
 
-    tinyxml2::XMLText *pText = doc.NewText(Get@VAR_NAME@String(@GETTER@).c_str());
+    tinyxml2::XMLText *pText = doc.NewText(Get@VAR_CAMELCASE_NAME@String(@GETTER@).c_str());
     pMember->InsertEndChild(pText);
 
     @PARENT@->InsertEndChild(pMember);

--- a/libobjgen/src/GeneratorHeader.cpp
+++ b/libobjgen/src/GeneratorHeader.cpp
@@ -68,14 +68,15 @@ std::string GeneratorHeader::GenerateClass(const MetaObject& obj)
 
         if(var->GetMetaType() == MetaVariable::MetaVariableType_t::TYPE_ENUM)
         {
-            ss << Tab() << "enum class " << var->GetName() << "_t : "
+            ss << Tab() << "enum class " << Generator::GetCapitalName(var) << "_t : "
                 << std::dynamic_pointer_cast<MetaVariableEnum>(var)->GetUnderlyingType()
                 << std::endl;
             ss << Tab() << "{" << std::endl;
             auto values = std::dynamic_pointer_cast<MetaVariableEnum>(var)->GetValues();
             for(auto value : values)
             {
-                ss << Tab(2) << value << "," << std::endl;
+                ss << Tab(2) << value.first <<
+                    (!value.second.empty() ? " = " + value.second : "") << "," << std::endl;
             }
             ss << Tab() << "};" << std::endl << std::endl;
         }

--- a/libobjgen/src/MetaVariableArray.cpp
+++ b/libobjgen/src/MetaVariableArray.cpp
@@ -265,7 +265,7 @@ std::string MetaVariableArray::GetLoadCode(const Generator& generator,
     if(mElementType && MetaObject::IsValidIdentifier(name) &&
         MetaObject::IsValidIdentifier(stream))
     {
-        code = mElementType->GetLoadCode(generator, "value", stream);
+        code = mElementType->GetLoadCode(generator, "element", stream);
 
         if(!code.empty())
         {
@@ -292,7 +292,7 @@ std::string MetaVariableArray::GetSaveCode(const Generator& generator,
     if(mElementType && MetaObject::IsValidIdentifier(name) &&
         MetaObject::IsValidIdentifier(stream))
     {
-        code = mElementType->GetSaveCode(generator, "value", stream);
+        code = mElementType->GetSaveCode(generator, "element", stream);
 
         if(!code.empty())
         {
@@ -319,7 +319,7 @@ std::string MetaVariableArray::GetLoadRawCode(const Generator& generator,
     if(mElementType && MetaObject::IsValidIdentifier(name) &&
         MetaObject::IsValidIdentifier(stream))
     {
-        code = mElementType->GetLoadRawCode(generator, "value", stream);
+        code = mElementType->GetLoadRawCode(generator, "element", stream);
 
         if(!code.empty())
         {
@@ -346,7 +346,7 @@ std::string MetaVariableArray::GetSaveRawCode(const Generator& generator,
     if(mElementType && MetaObject::IsValidIdentifier(name) &&
         MetaObject::IsValidIdentifier(stream))
     {
-        code = mElementType->GetSaveRawCode(generator, "value", stream);
+        code = mElementType->GetSaveRawCode(generator, "element", stream);
 
         if(!code.empty())
         {

--- a/libobjgen/src/MetaVariableEnum.h
+++ b/libobjgen/src/MetaVariableEnum.h
@@ -48,8 +48,10 @@ public:
     std::string GetUnderlyingType() const;
     void SetUnderlyingType(const std::string& underlyingType);
 
-    const std::vector<std::string> GetValues() const;
-    bool SetValues(const std::vector<std::string>& values);
+    const std::vector<std::pair<std::string, std::string>>
+        GetValues() const;
+    bool SetValues(const std::vector<std::pair<std::string,
+        std::string>>& values);
 
     virtual size_t GetSize() const;
 
@@ -100,12 +102,13 @@ public:
     virtual std::string GetUtilityFunctions(const Generator& generator,
         const MetaObject& object, const std::string& name) const;
 
-    bool ValueExists(const std::string& val) const;
-
 private:
-    bool ContainsDupilicateValues(const std::vector<std::string>& values) const;
+    bool NumericValueIsValid(const std::string& num) const;
+    bool ValueExists(const std::string& val, bool first) const;
+    bool ContainsDuplicateValues(const std::vector<std::pair<std::string,
+        std::string>>& values) const;
 
-    std::vector<std::string> mValues;
+    std::vector<std::pair<std::string, std::string>> mValues;
     std::string mTypePrefix;
     std::string mDefaultValue;
     std::string mUnderlyingType;

--- a/libobjgen/src/MetaVariableReference.h
+++ b/libobjgen/src/MetaVariableReference.h
@@ -100,6 +100,11 @@ public:
         const std::string elemName = "member") const;
     virtual std::string GetBindValueCode(const Generator& generator,
         const std::string& name, size_t tabLevel = 1) const;
+    virtual std::string GetAccessDeclarations(const Generator& generator,
+        const MetaObject& object, const std::string& name,
+        size_t tabLevel = 1) const;
+    virtual std::string GetAccessFunctions(const Generator& generator,
+        const MetaObject& object, const std::string& name) const;
 
 private:
     std::string mReferenceType;

--- a/libobjgen/tests/MetaVariable.cpp
+++ b/libobjgen/tests/MetaVariable.cpp
@@ -151,13 +151,29 @@ TEST(MetaVariableType, Enum)
     ASSERT_FALSE(var.IsValid())
         << "Checking validity with missing requirements.";
 
-    std::vector<std::string> values = { "VALUE_1", "VALUE_2", "VALUE_1" };
+    std::vector<std::pair<std::string, std::string>> values =
+        { { "VALUE_1", "0" }, { "VALUE_2", "1" }, { "VALUE_1", "2" } };
     ASSERT_FALSE(var.SetValues(values))
-        << "Setting invalid values containing an duplicate.";
+        << "Setting invalid values containing an duplicate enum value.";
+    
+    values =
+        { { "VALUE_1", "" },{ "VALUE_2", "1" },{ "VALUE_3", "1" } };
+    ASSERT_FALSE(var.SetValues(values))
+        << "Setting invalid values containing an duplicate numeric value.";
 
-    values = { "VALUE_1", "VALUE_2", "VALUE_3" };
+    values =
+        { { "VALUE_1", "" },{ "VALUE_2", "2" },{ "VALUE_3", "3" } };
     ASSERT_TRUE(var.SetValues(values))
         << "Setting valid values.";
+
+    values = var.GetValues();
+    ASSERT_EQ(values.size(), 3);
+    ASSERT_EQ(values[0].first, "VALUE_1");
+    ASSERT_EQ(values[0].second, "0");
+    ASSERT_EQ(values[1].first, "VALUE_2");
+    ASSERT_EQ(values[1].second, "2");
+    ASSERT_EQ(values[2].first, "VALUE_3");
+    ASSERT_EQ(values[2].second, "3");
 
     var.SetDefaultValue("VALUE_3");
     var.SetTypePrefix("Testing");

--- a/server/channel/src/CharacterManager.h
+++ b/server/channel/src/CharacterManager.h
@@ -59,6 +59,13 @@ public:
         channel::ChannelClientConnection>& client);
 
     /**
+     * Tell the game client to show a character.
+     * @param client Pointer to the client connection
+     */
+    void ShowCharacter(const std::shared_ptr<
+        channel::ChannelClientConnection>& client);
+
+    /**
      * Send a character's status icon to the game clients.
      * @param client Pointer to the client connection containing
      *  the character

--- a/server/channel/src/CharacterState.cpp
+++ b/server/channel/src/CharacterState.cpp
@@ -28,6 +28,7 @@
 
 // objects Includes
 #include <Character.h>
+#include <EntityStats.h>
 
 using namespace channel;
 
@@ -42,24 +43,25 @@ CharacterState::~CharacterState()
 bool CharacterState::RecalculateStats()
 {
     auto c = GetCharacter().Get();
+    auto cs = c->GetCoreStats();
 
     if(nullptr == c)
     {
         return false;
     }
 
-    SetSTR(c->GetSTR());
-    SetMAGIC(c->GetMAGIC());
-    SetVIT(c->GetVIT());
-    SetINTEL(c->GetINTEL());
-    SetSPEED(c->GetSPEED());
-    SetLUCK(c->GetLUCK());
-    SetCLSR(c->GetCLSR());
-    SetLNGR(c->GetLNGR());
-    SetSPELL(c->GetSPELL());
-    SetSUPPORT(c->GetSUPPORT());
-    SetPDEF(c->GetPDEF());
-    SetMDEF(c->GetMDEF());
+    SetSTR(cs->GetSTR());
+    SetMAGIC(cs->GetMAGIC());
+    SetVIT(cs->GetVIT());
+    SetINTEL(cs->GetINTEL());
+    SetSPEED(cs->GetSPEED());
+    SetLUCK(cs->GetLUCK());
+    SetCLSR(cs->GetCLSR());
+    SetLNGR(cs->GetLNGR());
+    SetSPELL(cs->GetSPELL());
+    SetSUPPORT(cs->GetSUPPORT());
+    SetPDEF(cs->GetPDEF());
+    SetMDEF(cs->GetMDEF());
 
     /// @todo: transform stats
 

--- a/server/lobby/src/packets/game/WorldList.cpp
+++ b/server/lobby/src/packets/game/WorldList.cpp
@@ -55,6 +55,11 @@ bool Parsers::WorldList::Parse(libcomp::ManagerPacket *pPacketManager,
     auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
 
     auto worlds = server->GetWorlds();
+    worlds.remove_if([](const std::shared_ptr<lobby::World>& world)
+        {
+            return world->GetRegisteredWorld()->GetStatus()
+                == objects::RegisteredWorld::Status_t::INACTIVE;
+        });
 
     // World count.
     reply.WriteU8((uint8_t)worlds.size());

--- a/server/world/src/packets/AccountLogin.cpp
+++ b/server/world/src/packets/AccountLogin.cpp
@@ -66,9 +66,9 @@ void LobbyLogin(std::shared_ptr<WorldServer> server,
     else
     {
         auto cid = login->GetCID();
-        auto charactersByCID = account->GetCharactersByCID();
-        if(charactersByCID.find(cid) == charactersByCID.end() ||
-            nullptr == charactersByCID[cid].Get(worldDB))
+        auto characters = account->GetCharacters();
+        if(characters[cid].IsNull() ||
+            nullptr == characters[cid].Get(worldDB))
         {
             LOG_ERROR(libcomp::String("Character ID '%1' is not valid"
                 " for this world.\n").Arg(cid));


### PR DESCRIPTION
-Enums now default to the first value and can have a "num" attribute specified for specific values
-Persistent references now generate a LoadMemberName(Database) function so they can be loaded without retrieving them, loading them and setting them back on the parent object
-Added shared object type EntityStats containing Character and Devil shared stats, level and XP
-Added more Character fields for equipment (just type ID for now), progress indicators (maps, quests etc) and COMP
-Converted CharactersByCID on Account to a Characters array
-Not returning World servers (and their characters) not currently connected to the lobby that were causing crashes through create character and start game