### PR TITLE
Character deletion and object reference caching

### DIFF
--- a/contrib/testing/lobby.xml
+++ b/contrib/testing/lobby.xml
@@ -21,6 +21,7 @@
         <member name="MultithreadMode">true</member>
         
         <!-- From LobbyConfig -->
+        <member name="CharacterDeletionDelay">1440</member>	<!-- In minutes, 24 hours by default -->
         <member name="WebListeningPort">10999</member>
         <member name="ClientVersion">1.666</member>
     </object>

--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -22,7 +22,7 @@
         
         <!-- Character specific attributes -->
         <member type="s16" name="LNC" caps="true"/>
-        <member type="u32" name="Points"/>
+        <member type="s32" name="Points"/>
 
         <!-- Collections -->
         <member type="array" name="EquippedItems" size="15">
@@ -40,24 +40,24 @@
         <member type="CharacterProgress*" name="Progress"/>
     </object>
     <object name="EntityStats" location="world">
-        <member type="u8" name="Level" default="1"/>
-        <member type="u64" name="XP" caps="true"/>
-        <member type="u16" name="HP" caps="true" default="73"/>
-        <member type="u16" name="MP" caps="true" default="11"/>
-        <member type="u16" name="MaxHP" default="73"/>
-        <member type="u16" name="MaxMP" default="11"/>
-        <member type="u16" name="STR" caps="true" default="1"/>
-        <member type="u16" name="MAGIC" caps="true" default="1"/>
-        <member type="u16" name="VIT" caps="true" default="1"/>
-        <member type="u16" name="INTEL" caps="true" default="1"/>
-        <member type="u16" name="SPEED" caps="true" default="1"/>
-        <member type="u16" name="LUCK" caps="true" default="1"/>
-        <member type="u16" name="CLSR" caps="true"/>
-        <member type="u16" name="LNGR" caps="true"/>
-        <member type="u16" name="SPELL" caps="true"/>
-        <member type="u16" name="SUPPORT" caps="true"/>
-        <member type="u16" name="PDEF" caps="true"/>
-        <member type="u16" name="MDEF" caps="true"/>
+        <member type="s8" name="Level" default="1"/>
+        <member type="s64" name="XP" caps="true"/>
+        <member type="s16" name="HP" caps="true" default="73"/>
+        <member type="s16" name="MP" caps="true" default="11"/>
+        <member type="s16" name="MaxHP" default="73"/>
+        <member type="s16" name="MaxMP" default="11"/>
+        <member type="s16" name="STR" caps="true" default="1"/>
+        <member type="s16" name="MAGIC" caps="true" default="1"/>
+        <member type="s16" name="VIT" caps="true" default="1"/>
+        <member type="s16" name="INTEL" caps="true" default="1"/>
+        <member type="s16" name="SPEED" caps="true" default="1"/>
+        <member type="s16" name="LUCK" caps="true" default="1"/>
+        <member type="s16" name="CLSR" caps="true"/>
+        <member type="s16" name="LNGR" caps="true"/>
+        <member type="s16" name="SPELL" caps="true"/>
+        <member type="s16" name="SUPPORT" caps="true"/>
+        <member type="s16" name="PDEF" caps="true"/>
+        <member type="s16" name="MDEF" caps="true"/>
     </object>
     <object name="CharacterProgress" location="world">
         <member type="array" name="Maps" size="32">

--- a/libcomp/src/ObjectReference.h
+++ b/libcomp/src/ObjectReference.h
@@ -35,9 +35,53 @@ namespace libcomp
 {
 
 /**
- * Templated class that serves the dual purpose of containing an
- * @ref Object reference as well as UUID for for a @ref PersistentObject
- * that can be lazy loaded from the database when needed.
+ * Represents a UUID and its associated PersistentObject that can either
+ * be loaded from the DB or pending loading from the DB.  These are
+ * cached in @ref ObjectReferenceData when the UUID is not null so each
+ * reference to that UUID will have the loaded the PersistentObject
+ * accessible the moment it gets cached.
+ */
+class ObjectReferenceData
+{
+public:
+    /**
+     * Create a null reference with no unsaved object.
+     */
+    ObjectReferenceData()
+    {
+        mLoadFailed = false;
+    }
+
+    /**
+     * Create a reference to a persistent object.  This object does
+     * not need to be saved in the DB yet.
+     * @param ref Pointer to the object this references
+     * @param uuid Optional param to set the UUID only for when the
+     * PersistentObject is not loaded yet
+     */
+    ObjectReferenceData(const std::shared_ptr<PersistentObject>& ref,
+        const libobjgen::UUID& uuid = libobjgen::UUID())
+        : mRef(ref),
+        mUUID(ref != nullptr ? ref->GetUUID() : uuid)
+    {
+        mLoadFailed = false;
+    }
+
+    /// Referenced object pointer
+    std::shared_ptr<PersistentObject> mRef;
+
+    /// UUID of the persistent object reference
+    const libobjgen::UUID mUUID;
+
+    /// Indicator that the object with the matching UUID failed to load
+    bool mLoadFailed;
+};
+
+/**
+ * Templated class that handles references to a @ref PersistentObject
+ * derived class that can be lazy loaded from the database when needed.
+ * References to a UUID are cached between all instances of this object
+ * allowing one database load to populate all references simultaneously.
  */
 template <class T>
 class ObjectReference
@@ -48,7 +92,7 @@ public:
      */
     ObjectReference()
     {
-        mLoadFailed = false;
+        mData = sNull;
     }
 
     /**
@@ -57,159 +101,256 @@ public:
      */
     ObjectReference(std::shared_ptr<T> ref)
     {
-        mLoadFailed = false;
+        mData = sNull;
         SetReference(ref);
     }
 
     /**
-     * Check if there is no UUID and no reference pointer.
+     * Clean up the reference.
+     */
+    ~ObjectReference()
+    {
+        ClearReference();
+    }
+
+    /**
+     * Check if there is no UUID and no reference set.
      * @return true if both are null, false if one is not
      */
     bool IsNull() const
     {
-        return mUUID.IsNull() && nullptr == mRef;
+        return mData == sNull;
     }
 
     /**
      * Get the pointer to the referenced object.  This will
-     * cause the reference to load from the database if only
-     * the UUID is set.
-     * @param db Database to load from if persistent
+     * cause the reference to load from the database if the
+     * database is specified and only the UUID is set.
+     * @param db Database to load from
      * @return Pointer to the referenced object
      */
-    const std::shared_ptr<T>& Get(const std::shared_ptr<Database>& db = nullptr)
+    const std::shared_ptr<T> Get(const std::shared_ptr<Database>& db = nullptr)
     {
         LoadReference(db);
 
-        return mRef;
+        return GetReference();
     }
 
     /**
      * Get the pointer to the referenced object but do
-     * not load from the databaseif it is not loaded already.
+     * not load from the database if it is not loaded already.
      * @return Pointer to the referenced object
      */
     const std::shared_ptr<T> GetCurrentReference() const
     {
-        return mRef;
+        return GetReference();
     }
 
     /**
      * Get the pointer to the referenced object but do
-     * not load from the databaseif it is not loaded already.
+     * not load from the database if it is not loaded already.
      * @return Pointer to the referenced object
      */
-    T* operator->() const
+    std::shared_ptr<T> operator->()
     {
-        return mRef.get();
+        return Get();
+    }
+
+    /**
+    * Update the data associated to this reference.
+    * @param ref Pointer to the referenced object
+    */
+    void SetReference(const std::shared_ptr<T>& ref)
+    {
+        libobjgen::UUID uuid;
+        auto pRef = std::dynamic_pointer_cast<PersistentObject>(ref);
+        if (nullptr != pRef)
+        {
+            uuid = pRef->GetUUID();
+        }
+
+        SetReference(uuid, pRef);
     }
 
     /**
      * Checks if the pointer is valid or a nullptr.
+     * @return true if the reference is set, false if it is not
      */
     operator bool() const
     {
-        return nullptr != mRef.get();
+        return nullptr != mData->mRef;
+    }
+
+    /**
+     * Get the UUID of the reference.
+     * @return UUID of the reference
+     */
+    const libobjgen::UUID& GetUUID() const
+    {
+        return mData->mUUID;
+    }
+
+    /**
+     * Set the UUID of the reference.  If the reference associated
+     * to that UUID is already cached, it will not need to be loaded.
+     * If it is not, it will need to be lazy loaded later.
+     * @param uuid UUID of the persistent object
+     * @return true on success, false on failure
+     */
+    bool SetUUID(const libobjgen::UUID& uuid)
+    {
+        SetReference(uuid);
+        return true;
+    }
+
+protected:
+    /**
+     * Get the PersistentObject reference casted to the templated
+     * type.
+     * @return Casted pointer to the reference
+     */
+    const std::shared_ptr<T> GetReference() const
+    {
+        std::lock_guard<std::mutex> lock(mReferenceLock);
+        return std::dynamic_pointer_cast<T>(mData->mRef);
     }
 
     /**
      * Load the referenced object from the database by its UUID.
-     * This will fail if the object is not persistent, the UUID
-     * is not set or the load was attempted already and failed
-     * without having the UUID modified.
-     * @param db Database to load from if persistent
+     * This will fail if the UUID is not set or the load fails.
+     * Calling this function without a DB set will pull from the
+     * PersistentObject cache instead.
+     * @param db Database to load from
      * @return true on success, false on failure
      */
     bool LoadReference(const std::shared_ptr<Database>& db = nullptr)
     {
         // Do not count an attempt to load without a DB as a
         // load failure
-        if(IsPersistentReference() && nullptr == mRef &&
-            !mUUID.IsNull() && !mLoadFailed)
+        if(!mData->mLoadFailed && nullptr == mData->mRef &&
+            !mData->mUUID.IsNull())
         {
-            if(nullptr != db)
+            auto uuid = mData->mUUID;
+
+            bool dbLoad = nullptr != db;
+            std::shared_ptr<PersistentObject> pRef;
+            if(dbLoad)
             {
-                mRef = PersistentObject::LoadObjectByUUID<T>(db, mUUID);
-                mLoadFailed = nullptr == mRef;
+                pRef = std::dynamic_pointer_cast<PersistentObject>(
+                    PersistentObject::LoadObjectByUUID<T>(db, uuid));
             }
             else
             {
-                mRef = std::dynamic_pointer_cast<T>(
-                    PersistentObject::GetObjectByUUID(mUUID));
+                pRef = PersistentObject::GetObjectByUUID(uuid);
             }
-        }
-        return mUUID.IsNull() || nullptr != mRef;
-    }
 
+            SetReference(uuid, pRef, dbLoad);
+        }
+
+        return IsNull() || nullptr != GetReference();
+    }
+    
     /**
-     * Set the referenced object pointer and also the UUID if
-     * the object is persistent.
+     * Update the data associated to this reference.  The values
+     * set can be just a UUID, just the reference or both.
+     * @param uuid UUID of the referenced object
      * @param ref Pointer to the referenced object
+     * @param setLoadFailure Marks the reference to not attempt
+     *  a second load if specified and the pointer passed in is null
      */
-    void SetReference(const std::shared_ptr<T>& ref)
+    void SetReference(const libobjgen::UUID& uuid,
+        const std::shared_ptr<PersistentObject>& ref = nullptr,
+        bool setLoadFailure = false)
     {
-        if(IsPersistentReference())
+        ClearReference();
+
+        if(!uuid.IsNull())
         {
-            libobjgen::UUID uuid;
+            std::string uuidStr = uuid.ToString();
+
+            std::lock_guard<std::mutex> lock(mReferenceLock);
+            auto iter = sData.find(uuidStr);
+            if(iter == sData.end())
+            {
+                sData[uuidStr] = std::shared_ptr<ObjectReferenceData>(
+                    new ObjectReferenceData(ref, uuid));
+            }
+            else if(sData[uuidStr]->mRef == nullptr)
+            {
+                sData[uuidStr]->mRef = ref;
+            }
+
+            if(ref == nullptr && setLoadFailure)
+            {
+                sData[uuidStr]->mLoadFailed = true;
+            }
+
+            mData = sData[uuidStr];
+        }
+        else
+        {
             if(ref != nullptr)
             {
-                uuid = std::dynamic_pointer_cast<PersistentObject>(
-                    ref)->GetUUID();
+                mData = std::shared_ptr<ObjectReferenceData>(
+                    new ObjectReferenceData(ref));
             }
-            SetUUID(uuid);
+            else
+            {
+                mData = sNull;
+            }
         }
-
-        mRef = ref;
     }
 
     /**
-     * Get the UUID of the persistent object reference.
-     * @return UUID of the persistent object reference
+     * Clear the data associated to this reference, setting it
+     * back to null.  If the old data associated is no longer
+     * being used by another reference, clear it from the cache.
      */
-    const libobjgen::UUID& GetUUID() const
+    void ClearReference()
     {
-        return mUUID;
-    }
-
-    /**
-     * Set the UUID of the persistent object reference and clear
-     * the referenced object pointer to load later.  This will
-     * fail if the object is not persistent.
-     * @param uuid UUID of the persistent object
-     * @return true on success, false on failure
-     */
-    bool SetUUID(const libobjgen::UUID& uuid)
-    {
-        if(IsPersistentReference())
+        if(mData != nullptr && !mData->mUUID.IsNull())
         {
-            mUUID = uuid;
-            mRef = nullptr;
-            mLoadFailed = false;
-            return true;
+            std::string uuidStr = mData->mUUID.ToString();
+
+            std::lock_guard<std::mutex> lock(mReferenceLock);
+            mData = sNull;
+
+            if(sData[uuidStr].use_count() == 1)
+            {
+                sData.erase(uuidStr);
+            }
         }
-
-        return false;
+        else
+        {
+            mData = sNull;
+        }
     }
 
-    /**
-     * Check if the object referenced is of type @ref PersistentObject.
-     * @return true if it is persistent, false if it is not
-     */
-    bool IsPersistentReference()
-    {
-        return std::is_base_of<PersistentObject, T>::value;
-    }
+    /// Local copy of the data cached in sData
+    std::shared_ptr<ObjectReferenceData> mData;
 
-protected:
-    /// Referenced object pointer
-    std::shared_ptr<T> mRef;
+    /// Static cache of non-null UUIDs to persistent objects
+    static std::unordered_map<std::string,
+        std::shared_ptr<ObjectReferenceData>> sData;
 
-    /// UUID of the persistent object reference
-    libobjgen::UUID mUUID;
+    /// Default value of mData instantiated once to avoid newing up
+    /// excess shared_ptrs
+    static std::shared_ptr<ObjectReferenceData> sNull;
 
-    /// Indicator that the object with the matching UUID failed to load
-    bool mLoadFailed;
+    /// Mutex to lock accessing the cache
+    static std::mutex mReferenceLock;
 };
+
+template<class T>
+std::unordered_map<std::string, std::shared_ptr<ObjectReferenceData>>
+    ObjectReference<T>::sData;
+
+template<class T>
+std::shared_ptr<ObjectReferenceData> ObjectReference<T>::sNull = 
+    std::shared_ptr<ObjectReferenceData>(new ObjectReferenceData);
+
+template<class T>
+std::mutex ObjectReference<T>::mReferenceLock;
 
 } // namespace libcomp
 

--- a/libcomp/src/ObjectReference.h
+++ b/libcomp/src/ObjectReference.h
@@ -150,7 +150,13 @@ public:
     {
         if(IsPersistentReference())
         {
-            SetUUID(std::dynamic_pointer_cast<PersistentObject>(ref)->GetUUID());
+            libobjgen::UUID uuid;
+            if(ref != nullptr)
+            {
+                uuid = std::dynamic_pointer_cast<PersistentObject>(
+                    ref)->GetUUID();
+            }
+            SetUUID(uuid);
         }
 
         mRef = ref;

--- a/libobjgen/res/VariableReferenceLoad.cpp
+++ b/libobjgen/res/VariableReferenceLoad.cpp
@@ -1,1 +1,1 @@
-!(@VAR_NAME@ = @CONSTRUCT_VALUE@).IsNull() && @VAR_NAME@.Get()->Load(@STREAM@)
+nullptr != (@VAR_NAME@ = @CONSTRUCT_VALUE@) && @VAR_NAME@->Load(@STREAM@)

--- a/libobjgen/res/VariableReferenceLoadRaw.cpp
+++ b/libobjgen/res/VariableReferenceLoadRaw.cpp
@@ -1,1 +1,1 @@
-flat || (!(@VAR_NAME@ = @CONSTRUCT_VALUE@).IsNull() && @VAR_NAME@.Get()->Load(@STREAM@))
+flat || (nullptr != (@VAR_NAME@ = @CONSTRUCT_VALUE@) && @VAR_NAME@->Load(@STREAM@))

--- a/libobjgen/res/VariableReferenceSave.cpp
+++ b/libobjgen/res/VariableReferenceSave.cpp
@@ -1,1 +1,1 @@
-!@VAR_NAME@.IsNull() && @VAR_NAME@.GetCurrentReference()->Save(@STREAM@)
+nullptr != @VAR_NAME@ && @VAR_NAME@->Save(@STREAM@)

--- a/libobjgen/res/VariableReferenceSaveRaw.cpp
+++ b/libobjgen/res/VariableReferenceSaveRaw.cpp
@@ -1,1 +1,1 @@
-flat || (!@VAR_NAME@.IsNull() && @VAR_NAME@.GetCurrentReference()->Save(@STREAM@))
+flat || (nullptr != @VAR_NAME@ && @VAR_NAME@->Save(@STREAM@))

--- a/libobjgen/res/VariableReferenceXmlLoad.cpp
+++ b/libobjgen/res/VariableReferenceXmlLoad.cpp
@@ -1,7 +1,7 @@
 ([&]() -> @VAR_CODE_TYPE@
 {
     @VAR_CODE_TYPE@ ref = @CONSTRUCT_VALUE@;
-    ref.Get()->Load(@DOC@, *@NODE@);
+    ref->Load(@DOC@, *@NODE@);
 
     return ref;
 })()

--- a/libobjgen/res/VariableReferenceXmlSave.cpp
+++ b/libobjgen/res/VariableReferenceXmlSave.cpp
@@ -1,4 +1,4 @@
-if(!@VAR_NAME@.IsNull())
+if(nullptr != @VAR_NAME@)
 {
     tinyxml2::XMLElement *temp = @PARENT@;
     {
@@ -10,7 +10,7 @@ if(!@VAR_NAME@.IsNull())
         @PARENT@ = pMember;
     }
 
-    @VAR_NAME@.GetCurrentReference()->Save(@DOC@, *@PARENT@);
+    @VAR_NAME@->Save(@DOC@, *@PARENT@);
 
     @PARENT@ = temp;
 }

--- a/libobjgen/src/MetaObjectXmlParser.cpp
+++ b/libobjgen/src/MetaObjectXmlParser.cpp
@@ -226,7 +226,7 @@ bool MetaObjectXmlParser::LoadMembers(const std::string& object,
         mObject->mVariables.clear();
     }
 
-    error |= mError.length() > 0;
+    error |= mError.length() > 0 || !mObject->IsValid();
     if(!result || error)
     {
         return false;

--- a/libobjgen/src/MetaVariableInt.h
+++ b/libobjgen/src/MetaVariableInt.h
@@ -341,6 +341,11 @@ public:
             }
 
             SetMinimumValue(value);
+
+            if(nullptr == szDefault && mDefaultValue < mMinimumValue)
+            {
+                mDefaultValue = mMinimumValue;
+            }
         }
 
         const char *szMaximum = root.Attribute("max");

--- a/libobjgen/src/MetaVariableReference.cpp
+++ b/libobjgen/src/MetaVariableReference.cpp
@@ -218,16 +218,14 @@ bool MetaVariableReference::SetDynamicSizeCount(uint16_t dynamicSizeCount)
 
 std::string MetaVariableReference::GetCodeType() const
 {
-    std::string code;
-
-    if(!mReferenceType.empty())
+    if(mPersistentReference)
     {
-        std::stringstream ss;
-        ss << "libcomp::ObjectReference<" << GetReferenceType(true) << ">";
-        code = ss.str();
+        return "libcomp::ObjectReference<" + GetReferenceType(true) + ">";
     }
-
-    return code;
+    else
+    {
+        return "std::shared_ptr<" + GetReferenceType(true) + ">";
+    }
 }
 
 std::string MetaVariableReference::GetConstructValue() const
@@ -239,9 +237,7 @@ std::string MetaVariableReference::GetConstructValue() const
     }
     else
     {
-        std::string fullName = GetReferenceType(true);
-        defaultVal << GetCodeType()
-            << "(std::shared_ptr<" << fullName << ">(new " << fullName << "))";
+        defaultVal << GetCodeType() << "(new " << GetReferenceType(true) << ")";
     }
 
     std::stringstream ss;
@@ -322,10 +318,20 @@ std::string MetaVariableReference::GetValidCondition(const Generator& generator,
 
     if(recursive)
     {
-        std::stringstream ss;
-        ss << "nullptr != " << name  << ".GetCurrentReference() && (!recursive || "
-            << name << ".GetCurrentReference()->IsValid(recursive))";
-        return ss.str();
+        if(mPersistentReference)
+        {
+            std::stringstream ss;
+            ss << "nullptr != " << name << ".GetCurrentReference() && (!recursive || "
+                << name << ".GetCurrentReference()->IsValid(recursive))";
+            return ss.str();
+        }
+        else
+        {
+            std::stringstream ss;
+            ss << "nullptr != " << name << " && (!recursive || "
+                << name << "->IsValid(recursive))";
+            return ss.str();
+        }
     }
     else
     {
@@ -486,7 +492,7 @@ std::string MetaVariableReference::GetAccessDeclarations(const Generator& genera
     if(mPersistentReference)
     {
         ss << generator.Tab(tabLevel) << "const std::shared_ptr<"
-            << GetReferenceType(true) << ">& Load" << generator.GetCapitalName(*this)
+            << GetReferenceType(true) << "> Load" << generator.GetCapitalName(*this)
             << "(const std::shared_ptr<libcomp::Database>& db = nullptr);" << std::endl;
     }
 
@@ -501,7 +507,7 @@ std::string MetaVariableReference::GetAccessFunctions(const Generator& generator
 
     if(mPersistentReference)
     {
-        ss << "const std::shared_ptr<" << GetReferenceType(true) << ">& "
+        ss << "const std::shared_ptr<" << GetReferenceType(true) << "> "
             << object.GetName() << "::Load" << generator.GetCapitalName(*this)
             << "(const std::shared_ptr<libcomp::Database>& db)" << std::endl;
         ss << "{" << std::endl;

--- a/server/channel/schema/channelconfig.xml
+++ b/server/channel/schema/channelconfig.xml
@@ -2,6 +2,7 @@
 <objgen>
     <object name="ChannelConfig" baseobject="ServerConfig">
         <member type="string" name="Name"/>
+        <member type="string" name="ExternalIP"/>
         <member type="u16" name="Port" inherited="true" default="14666"/>
         <member type="string" name="WorldIP" default="127.0.0.1"/>
         <member type="u16" name="WorldPort" default="18666"/>

--- a/server/channel/schema/characterstate.xml
+++ b/server/channel/schema/characterstate.xml
@@ -4,17 +4,17 @@
         <member type="Character*" name="Character"/>
         
         <!-- Calculated Stats -->
-        <member type="u16" name="STR"/>
-        <member type="u16" name="MAGIC"/>
-        <member type="u16" name="VIT"/>
-        <member type="u16" name="INTEL"/>
-        <member type="u16" name="SPEED"/>
-        <member type="u16" name="LUCK"/>
-        <member type="u16" name="CLSR"/>
-        <member type="u16" name="LNGR"/>
-        <member type="u16" name="SPELL"/>
-        <member type="u16" name="SUPPORT"/>
-        <member type="u16" name="PDEF"/>
-        <member type="u16" name="MDEF"/>
+        <member type="s16" name="STR"/>
+        <member type="s16" name="MAGIC"/>
+        <member type="s16" name="VIT"/>
+        <member type="s16" name="INTEL"/>
+        <member type="s16" name="SPEED"/>
+        <member type="s16" name="LUCK"/>
+        <member type="s16" name="CLSR"/>
+        <member type="s16" name="LNGR"/>
+        <member type="s16" name="SPELL"/>
+        <member type="s16" name="SUPPORT"/>
+        <member type="s16" name="PDEF"/>
+        <member type="s16" name="MDEF"/>
     </object>
 </objgen>

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -181,8 +181,18 @@ bool ChannelServer::RegisterServer(uint8_t channelID)
         registeredChannel = std::shared_ptr<objects::RegisteredChannel>(new objects::RegisteredChannel);
         registeredChannel->SetID(channelID);
         registeredChannel->SetName(name);
-        registeredChannel->SetIP(""); //Let the world set the externally visible IP
         registeredChannel->SetPort(conf->GetPort());
+
+        if(!conf->GetExternalIP().IsEmpty())
+        {
+            registeredChannel->SetIP(conf->GetExternalIP());
+        }
+        else
+        {
+            //Let the world set the IP it gets connected to from
+            registeredChannel->SetIP("");
+        }
+
         if(!registeredChannel->Register(registeredChannel) || !registeredChannel->Insert(mWorldDatabase))
         {
             return false;

--- a/server/channel/src/CharacterManager.cpp
+++ b/server/channel/src/CharacterManager.cpp
@@ -54,7 +54,7 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
     libcomp::Packet reply;
     reply.WritePacketCode(ChannelClientPacketCode_t::PACKET_CHARACTER_DATA);
 
-    reply.WriteU32Little((uint32_t)c->GetCID());    /// @todo: replace with unique entity ID
+    reply.WriteS32Little((int32_t)c->GetCID());    /// @todo: replace with unique object ID
     reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
         c->GetName(), true);
     reply.WriteU32Little(0); // Special Title
@@ -68,7 +68,7 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
     reply.WriteU8(c->GetFaceType());
     reply.WriteU8(c->GetLeftEyeColor());
     reply.WriteU8(0x00); // Unknown
-    reply.WriteU8(0x01); // Unknown
+    reply.WriteU8(0x01); // Unknown bool
 
     for(size_t i = 0; i < 15; i++)
     {
@@ -85,52 +85,53 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
     }
 
     //Character status
-    reply.WriteU16Little(cs->GetMaxHP());
-    reply.WriteU16Little(cs->GetMaxMP());
-    reply.WriteU16Little(cs->GetHP());
-    reply.WriteU16Little(cs->GetMP());
-    reply.WriteU64Little(cs->GetXP());
-    reply.WriteU32Little(c->GetPoints());
-    reply.WriteU8(cs->GetLevel());
+    reply.WriteS16Little(cs->GetMaxHP());
+    reply.WriteS16Little(cs->GetMaxMP());
+    reply.WriteS16Little(cs->GetHP());
+    reply.WriteS16Little(cs->GetMP());
+    reply.WriteS64Little(cs->GetXP());
+    reply.WriteS32Little(c->GetPoints());
+    reply.WriteS8(cs->GetLevel());
     reply.WriteS16Little(c->GetLNC());
-    reply.WriteU16Little(cs->GetSTR());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetSTR());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetSTR() - cs->GetSTR()));
-    reply.WriteU16Little(cs->GetMAGIC());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetMAGIC());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetMAGIC() - cs->GetMAGIC()));
-    reply.WriteU16Little(cs->GetVIT());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetVIT());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetVIT() - cs->GetVIT()));
-    reply.WriteU16Little(cs->GetINTEL());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetINTEL());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetINTEL() - cs->GetINTEL()));
-    reply.WriteU16Little(cs->GetSPEED());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetSPEED());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetSPEED() - cs->GetSPEED()));
-    reply.WriteU16Little(cs->GetLUCK());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetLUCK());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetLUCK() - cs->GetLUCK()));
-    reply.WriteU16Little(cs->GetCLSR());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetCLSR());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetCLSR() - cs->GetCLSR()));
-    reply.WriteU16Little(cs->GetLNGR());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetLNGR());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetLNGR() - cs->GetLNGR()));
-    reply.WriteU16Little(cs->GetSPELL());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetSPELL());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetSPELL() - cs->GetSPELL()));
-    reply.WriteU16Little(cs->GetSUPPORT());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetSUPPORT());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetSUPPORT() - cs->GetSUPPORT()));
-    reply.WriteU16Little(cs->GetPDEF());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetPDEF());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetPDEF() - cs->GetPDEF()));
-    reply.WriteU16Little(cs->GetMDEF());
-    reply.WriteU16Little(static_cast<uint16_t>(
+    reply.WriteS16Little(cs->GetMDEF());
+    reply.WriteS16Little(static_cast<int16_t>(
         cState->GetMDEF() - cs->GetMDEF()));
 
-    reply.WriteU32Little(367061536); // Unknown
+    reply.WriteS16(5600); // Unknown
+    reply.WriteS16(-5600); // Unknown
 
     /// @todo: status effects
     uint32_t statusEffectCount = 0;
@@ -143,13 +144,15 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
 
         reply.WriteU32Little(sfx->effect());
         reply.WriteFloat(state->clientTime(state->serverTicks() +
-            sfx->duration()));
+            sfx->duration())); // thinks this is an int32 but i don't believe it
         reply.WriteU8(sfx->stack());*/
     }
 
-    reply.WriteU32Little(1055); //Unknown
-    reply.WriteU32Little(1325025608);   //Unknown
-    reply.WriteU8(1);   //Unknown
+    // This is the COMP experience alpha status effect (hence +1)...
+    reply.WriteU32Little(1055);
+    // Some skills have game time ticks and other have a fixed real time (this is the latter)
+    reply.WriteU32Little(1325025608);
+    reply.WriteU8(1);
 
     /// @todo: skills
     reply.WriteU32Little(0);
@@ -165,12 +168,15 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
     {
         //const BfExpertise& exp = c->expertise(i);
 
-        reply.WriteU32Little(0);
-        reply.WriteU8(0);
-        reply.WriteU8(0); // 0 - Raise | 1 - Capped
+        reply.WriteS32Little(0);    // Points
+        reply.WriteS8(0);   // Unknown
+        reply.WriteU8(0); // bool: 0 - Raise | 1 - Capped
     }
 
-    reply.WriteU32Little(0);
+    reply.WriteU8(0);   // Unknown bool
+    reply.WriteU8(0);   // Unknown bool
+    reply.WriteU8(0);   // Unknown bool
+    reply.WriteU8(0);   // Unknown bool
 
     /// @todo: demons
     /*if(nullptr != state->demon() && c->activeDemon() > 0)
@@ -178,26 +184,33 @@ void CharacterManager::SendCharacterData(const std::shared_ptr<
     else*/
         reply.WriteS64Little(-1);
 
-    reply.WriteU32Little(0xFFFFFFFF);
-    reply.WriteU32Little(0xFFFFFFFF);
-    reply.WriteU32Little(0xFFFFFFFF);
-    reply.WriteU32Little(0xFFFFFFFF);
+    reply.WriteS64Little(-1);
+    reply.WriteS64Little(-1);
 
     //BfZonePtr zone = state->zoneInst()->zone();
 
     /// @todo: zone position
-    reply.WriteU32Little(1);    //set
-    reply.WriteU32Little(0x00004E85); // Zone ID
+    reply.WriteS32Little(1);    //set
+    reply.WriteS32Little(0x00004E85); // Zone ID
     reply.WriteFloat(0);    //x
     reply.WriteFloat(0);    //y
     reply.WriteFloat(0);    //rotation
 
-    reply.WriteU8(0);
-    reply.WriteU32Little(0); // Homepoint zone
+    reply.WriteU8(0);   //Unknown bool
+    reply.WriteS32Little(0); // Homepoint zone
     reply.WriteU32Little(0x43FA8000); // Homepoint X
     reply.WriteU32Little(0x3F800000); // Homepoint Y
-    reply.WriteU16Little(0);
-    reply.WriteU8(1);
+    reply.WriteS8(0);
+    reply.WriteS8(0);
+    reply.WriteS8(1);
+    
+    reply.WriteS32(0); // some count
+
+    /*
+    // count number of these elements
+    reply.WriteS8(0);
+    reply.WriteU32Little(0);
+    */
 
     client->SendPacket(reply);
 
@@ -212,7 +225,7 @@ void CharacterManager::ShowCharacter(const std::shared_ptr<channel::ChannelClien
 
     libcomp::Packet reply;
     reply.WritePacketCode(ChannelClientPacketCode_t::PACKET_SHOW_CHARACTER);
-    reply.WriteU32Little((uint32_t)c->GetCID());
+    reply.WriteS32Little((uint32_t)c->GetCID());
 
     client->SendPacket(reply);
 }

--- a/server/lobby/schema/lobbyconfig.xml
+++ b/server/lobby/schema/lobbyconfig.xml
@@ -6,5 +6,6 @@
         <member type="float" name="ClientVersion" default="1.666"/>
         <member type="DatabaseConfigSQLite3*" name="SQLite3Config"/>
         <member type="DatabaseConfigCassandra*" name="CassandraConfig"/>
+        <member type="u16" name="CharacterDeletionDelay" default="1440"/>
     </object>
 </objgen>

--- a/server/lobby/src/AccountManager.cpp
+++ b/server/lobby/src/AccountManager.cpp
@@ -197,7 +197,7 @@ bool AccountManager::UpdateKillTime(const libcomp::String& username,
     auto login = GetUserLogin(username);
     auto account = login->GetAccount();
     auto character = account->GetCharacters(cid);
-    if(character.GetCurrentReference())
+    if(character.Get())
     {
         auto world = server->GetWorldByID(character->GetWorldID());
         auto worldDB = world->GetWorldDatabase();
@@ -246,7 +246,7 @@ std::list<uint8_t> AccountManager::GetCharactersForDeletion(const libcomp::Strin
     time_t now = time(0);
     for(auto character : characters)
     {
-        if(character.GetCurrentReference() && character->GetKillTime() != 0 &&
+        if(character.Get() && character->GetKillTime() != 0 &&
             character->GetKillTime() <= (uint32_t)now)
         {
             cids.push_back(character->GetCID());
@@ -263,7 +263,7 @@ bool AccountManager::DeleteCharacter(const libcomp::String& username, uint8_t ci
     auto account = login->GetAccount();
     auto characters = account->GetCharacters();
     auto deleteCharacter = characters[cid];
-    if(deleteCharacter.GetCurrentReference())
+    if(deleteCharacter.Get())
     {
         auto world = server->GetWorldByID(deleteCharacter->GetWorldID());
         auto worldDB = world->GetWorldDatabase();

--- a/server/lobby/src/AccountManager.cpp
+++ b/server/lobby/src/AccountManager.cpp
@@ -26,6 +26,19 @@
 
 #include "AccountManager.h"
 
+// libcomp Includes
+#include <Log.h>
+
+// Standard C++11 Includes
+#include <ctime>
+
+// objects Includes
+#include <Account.h>
+#include <Character.h>
+
+// lobby Includes
+#include "LobbyServer.h"
+
 using namespace lobby;
 
 bool AccountManager::IsLoggedIn(const libcomp::String& username)
@@ -173,4 +186,107 @@ std::list<libcomp::String> AccountManager::LogoutUsersInWorld(int8_t world,
     }
 
     return usernames;
+}
+
+bool AccountManager::UpdateKillTime(const libcomp::String& username,
+    uint8_t cid, std::shared_ptr<LobbyServer>& server)
+{
+    auto config = std::dynamic_pointer_cast<objects::LobbyConfig>(
+        server->GetConfig());
+
+    auto login = GetUserLogin(username);
+    auto account = login->GetAccount();
+    auto character = account->GetCharacters(cid);
+    if(character.GetCurrentReference())
+    {
+        auto world = server->GetWorldByID(character->GetWorldID());
+        auto worldDB = world->GetWorldDatabase();
+
+        if(character->GetKillTime() > 0)
+        {
+            // Clear the kill time
+            character->SetKillTime(0);
+        }
+        else
+        {
+            auto deleteMinutes = config->GetCharacterDeletionDelay();
+            if(deleteMinutes > 0)
+            {
+                // Set the kill time
+                time_t now = time(0);
+                character->SetKillTime(static_cast<uint32_t>(now + (deleteMinutes * 60)));
+            }
+            else
+            {
+                // Delete the character now
+                return DeleteCharacter(username, cid, server);
+            }
+        }
+
+        if(!character->Update(worldDB))
+        {
+            LOG_DEBUG("Character kill time failed to save.\n");
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+std::list<uint8_t> AccountManager::GetCharactersForDeletion(const libcomp::String& username)
+{
+    std::list<uint8_t> cids;
+
+    auto login = GetUserLogin(username);
+    auto account = login->GetAccount();
+    auto characters = account->GetCharacters();
+
+    time_t now = time(0);
+    for(auto character : characters)
+    {
+        if(character.GetCurrentReference() && character->GetKillTime() != 0 &&
+            character->GetKillTime() <= (uint32_t)now)
+        {
+            cids.push_back(character->GetCID());
+        }
+    }
+
+    return cids;
+}
+
+bool AccountManager::DeleteCharacter(const libcomp::String& username, uint8_t cid,
+    std::shared_ptr<LobbyServer>& server)
+{
+    auto login = GetUserLogin(username);
+    auto account = login->GetAccount();
+    auto characters = account->GetCharacters();
+    auto deleteCharacter = characters[cid];
+    if(deleteCharacter.GetCurrentReference())
+    {
+        auto world = server->GetWorldByID(deleteCharacter->GetWorldID());
+        auto worldDB = world->GetWorldDatabase();
+
+        if(!deleteCharacter->Delete(worldDB))
+        {
+            LOG_ERROR(libcomp::String("Character failed to delete: %1\n").Arg(
+                deleteCharacter->GetUUID().ToString()));
+            return false;
+        }
+
+        characters[cid].SetReference(nullptr);
+        account->SetCharacters(characters);
+
+        if(!account->Update(server->GetMainDatabase()))
+        {
+            LOG_ERROR(libcomp::String("Account failed to update after character"
+                " deletion: %1\n").Arg(deleteCharacter->GetUUID().ToString()));
+            return false;
+        }
+
+        return true;
+    }
+
+    return false;
 }

--- a/server/lobby/src/AccountManager.h
+++ b/server/lobby/src/AccountManager.h
@@ -40,6 +40,8 @@
 namespace lobby
 {
 
+class LobbyServer;
+
 /**
  * Manages logged in user accounts.
  */
@@ -110,6 +112,40 @@ public:
      */
     std::list<libcomp::String> LogoutUsersInWorld(int8_t world,
         int8_t channel = -1);
+    
+    /**
+     * Mark or clear a character by CID for deletion.  This assumes the character
+     * has already been loaded and will not load them if they are not.
+     * @param username Username of the account that the character belongs to.
+     * @param cid CID of the character to update.
+     * @param server Pointer to the lobby server.
+     * @return true if the character was updated, false otherwise.
+     */
+    bool UpdateKillTime(const libcomp::String& username,
+        uint8_t cid, std::shared_ptr<LobbyServer>& server);
+
+    /**
+     * Get characters on an account with a KillTime that has passed.
+     * This assumes characters have already been loaded and will not
+     * load them if they are not.
+     * @param username Username of the account that the characters belong to.
+     * @return List of CIDs for characters to delete.
+     */
+    std::list<uint8_t> GetCharactersForDeletion(
+        const libcomp::String& username);
+
+    /**
+     * Delete a character by CID and update the Characters array on
+     * the account.  This assumes the character has already been loaded and
+     * will not load them if they are not.
+     * @param username Username of the account that the character belongs to.
+     * @param cid CID of the character to delete.
+     * @param server Pointer to the lobby server.
+     * @return true if the character was deleted and the account was updated,
+     *  false otherwise.
+     */
+    bool DeleteCharacter(const libcomp::String& username,
+        uint8_t cid, std::shared_ptr<LobbyServer>& server);
 
 private:
     /// Mutex to lock access to the account map.

--- a/server/lobby/src/LobbyServer.cpp
+++ b/server/lobby/src/LobbyServer.cpp
@@ -69,10 +69,10 @@ bool LobbyServer::Initialize()
         std::shared_ptr<objects::DatabaseConfig>> configMap;
 
     configMap[objects::ServerConfig::DatabaseType_t::SQLITE3]
-        = conf->GetSQLite3Config().Get();
+        = conf->GetSQLite3Config();
 
     configMap[objects::ServerConfig::DatabaseType_t::CASSANDRA]
-        = conf->GetCassandraConfig().Get();
+        = conf->GetCassandraConfig();
 
     mDatabase = GetDatabase(configMap, true);
 

--- a/server/lobby/src/packets/game/CharacterList.cpp
+++ b/server/lobby/src/packets/game/CharacterList.cpp
@@ -172,7 +172,7 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
         reply.WriteS8(-1);
 
         // Level.
-        reply.WriteU8(stats->GetLevel());
+        reply.WriteS8(stats->GetLevel());
 
         // Skin type.
         reply.WriteU8(character->GetSkinType());

--- a/server/lobby/src/packets/game/CharacterList.cpp
+++ b/server/lobby/src/packets/game/CharacterList.cpp
@@ -114,11 +114,6 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
                         .Arg(account->GetUUID().ToString()));
                     return false;
                 }
-                else
-                {
-                    //Write back the loaded character
-                    account->SetCharacters(cid, existing);
-                }
             }
             else
             {

--- a/server/lobby/src/packets/game/DeleteCharacter.cpp
+++ b/server/lobby/src/packets/game/DeleteCharacter.cpp
@@ -65,7 +65,7 @@ bool Parsers::DeleteCharacter::Parse(libcomp::ManagerPacket *pPacketManager,
 
     //Every character should have already been loaded by the CharacterList
     auto deleteCharacter = account->GetCharacters(cid);
-    if(deleteCharacter.GetCurrentReference())
+    if(deleteCharacter.Get())
     {
         auto world = server->GetWorldByID(deleteCharacter->GetWorldID());
         auto worldDB = world->GetWorldDatabase();

--- a/server/lobby/src/packets/game/DeleteCharacter.cpp
+++ b/server/lobby/src/packets/game/DeleteCharacter.cpp
@@ -34,14 +34,21 @@
 #include <ReadOnlyPacket.h>
 #include <TcpConnection.h>
 
+// object Includes
+#include <Account.h>
+#include <Character.h>
+
+// lobby Includes
+#include "LobbyClientConnection.h"
+#include "LobbyServer.h"
+#include "ManagerPacket.h"
+
 using namespace lobby;
 
 bool Parsers::DeleteCharacter::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    (void)pPacketManager;
-
     if(p.Size() != 1)
     {
         return false;
@@ -51,12 +58,39 @@ bool Parsers::DeleteCharacter::Parse(libcomp::ManagerPacket *pPacketManager,
 
     LOG_DEBUG(libcomp::String("Character ID: %1\n").Arg(cid));
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(
-        LobbyClientPacketCode_t::PACKET_DELETE_CHARACTER_RESPONSE);
-    reply.WriteU8(cid);
+    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
+    auto config = std::dynamic_pointer_cast<objects::LobbyConfig>(server->GetConfig());
+    auto lobbyConnection = std::dynamic_pointer_cast<LobbyClientConnection>(connection);
+    auto account = lobbyConnection->GetClientState()->GetAccount();
 
-    connection->SendPacket(reply);
+    //Every character should have already been loaded by the CharacterList
+    auto deleteCharacter = account->GetCharacters(cid);
+    if(deleteCharacter.GetCurrentReference())
+    {
+        auto world = server->GetWorldByID(deleteCharacter->GetWorldID());
+        auto worldDB = world->GetWorldDatabase();
+
+        server->QueueWork([](const std::shared_ptr<LobbyClientConnection> client,
+            uint8_t c, std::shared_ptr<LobbyServer> s)
+        {
+            libcomp::Packet reply;
+            reply.WritePacketCode(
+                LobbyClientPacketCode_t::PACKET_DELETE_CHARACTER_RESPONSE);
+
+            if(s->GetAccountManager()->UpdateKillTime(
+                client->GetClientState()->GetAccount()->GetUsername(), c, s))
+            {
+                reply.WriteS8((int8_t)c);
+            }
+            else
+            {
+                //Send failure
+                reply.WriteS8(-1);
+            }
+
+            client->SendPacket(reply);
+        }, lobbyConnection, cid, server);
+    }
 
     return true;
 }

--- a/server/world/src/WorldServer.cpp
+++ b/server/world/src/WorldServer.cpp
@@ -62,10 +62,10 @@ bool WorldServer::Initialize()
         std::shared_ptr<objects::DatabaseConfig>> configMap;
 
     configMap[objects::ServerConfig::DatabaseType_t::SQLITE3]
-        = conf->GetSQLite3Config().Get();
+        = conf->GetSQLite3Config();
 
     configMap[objects::ServerConfig::DatabaseType_t::CASSANDRA]
-        = conf->GetCassandraConfig().Get();
+        = conf->GetCassandraConfig();
 
     mDatabase = GetDatabase(configMap, true);
 

--- a/server/world/src/packets/GetWorldInfo.cpp
+++ b/server/world/src/packets/GetWorldInfo.cpp
@@ -118,10 +118,10 @@ bool Parsers::GetWorldInfo::Parse(libcomp::ManagerPacket *pPacketManager,
         switch(databaseType)
         {
             case objects::ServerConfig::DatabaseType_t::CASSANDRA:
-                config->GetCassandraConfig().Get()->SavePacket(reply, false);
+                config->GetCassandraConfig()->SavePacket(reply, false);
                 break;
             case objects::ServerConfig::DatabaseType_t::SQLITE3:
-                config->GetSQLite3Config().Get()->SavePacket(reply, false);
+                config->GetSQLite3Config()->SavePacket(reply, false);
                 break;
         }
 

--- a/server/world/src/packets/SetChannelInfo.cpp
+++ b/server/world/src/packets/SetChannelInfo.cpp
@@ -77,11 +77,16 @@ bool Parsers::SetChannelInfo::Parse(libcomp::ManagerPacket *pPacketManager,
         .Arg(svr->GetID())
         .Arg(svr->GetName()));
 
-    svr->SetIP(connection->GetRemoteAddress());
-    if(!svr->Update(worldDB))
+    // If the channel has already set the IP, it should be the externally facing IP
+    // so we'll leave it alone
+    if(svr->GetIP().IsEmpty())
     {
-        LOG_DEBUG("Channel Server could not be updated with its address.\n");
-        return false;
+        svr->SetIP(connection->GetRemoteAddress());
+        if(!svr->Update(worldDB))
+        {
+            LOG_DEBUG("Channel Server could not be updated with its address.\n");
+            return false;
+        }
     }
 
     server->RegisterChannel(svr, conn);


### PR DESCRIPTION
-Implemented character deletion with a configurable time delay
-Non-persistent object reference fields are just shared_ptrs again
-Persistent object references are now cached by UUID so they only need to be loaded once for all reference instances
-Added external IP config value to the channel config for world and channel servers running on the same machine
-Using signed integers for various character values