### PR TITLE
Game time and character tickets

### DIFF
--- a/contrib/testing/lobby.xml
+++ b/contrib/testing/lobby.xml
@@ -22,6 +22,7 @@
         
         <!-- From LobbyConfig -->
         <member name="CharacterDeletionDelay">1440</member>	<!-- In minutes, 24 hours by default -->
+        <member name="CharacterTicketCost">0</member>
         <member name="WebListeningPort">10999</member>
         <member name="ClientVersion">1.666</member>
     </object>

--- a/libcomp/src/ReadOnlyPacket.cpp
+++ b/libcomp/src/ReadOnlyPacket.cpp
@@ -230,73 +230,103 @@ String ReadOnlyPacket::ReadString(Convert::Encoding_t encoding)
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString16(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString16(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint16_t sz = ReadU16();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString16Big(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString16Big(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint16_t sz = ReadU16Big();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString16Little(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString16Little(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint16_t sz = ReadU16Little();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString32(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString32(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint32_t sz = ReadU32();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString32Big(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString32Big(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint32_t sz = ReadU32Big();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);
 }
 
-String ReadOnlyPacket::ReadString32Little(Convert::Encoding_t encoding)
+String ReadOnlyPacket::ReadString32Little(Convert::Encoding_t encoding,
+    bool trimNull)
 {
     // Read the size of the string.
     uint32_t sz = ReadU32Little();
 
     // Read the string into the buffer.
     std::vector<char> buffer = ReadArray(sz);
+    if(trimNull && buffer.size() > 0 && buffer.back() == 0)
+    {
+        buffer.pop_back();
+    }
 
     // Convert the string to the requested encoding.
     return Convert::FromEncoding(encoding, buffer);

--- a/libcomp/src/ReadOnlyPacket.h
+++ b/libcomp/src/ReadOnlyPacket.h
@@ -166,12 +166,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString16
      * @sa ReadString16Big
      * @sa ReadString16Little
      */
-    String ReadString16(Convert::Encoding_t encoding);
+    String ReadString16(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read the string @em str encoded with @em encoding from the packet. The
@@ -182,12 +183,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString16
      * @sa ReadString16
      * @sa ReadString16Little
      */
-    String ReadString16Big(Convert::Encoding_t encoding);
+    String ReadString16Big(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read the string @em str encoded with @em encoding from the packet. The
@@ -198,12 +200,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString16
      * @sa ReadString16
      * @sa ReadString16Big
      */
-    String ReadString16Little(Convert::Encoding_t encoding);
+    String ReadString16Little(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read the string @em str encoded with @em encoding from the packet. The
@@ -213,12 +216,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString32
      * @sa ReadString32Big
      * @sa ReadString32Little
      */
-    String ReadString32(Convert::Encoding_t encoding);
+    String ReadString32(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read the string @em str encoded with @em encoding from the packet. The
@@ -229,12 +233,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString32
      * @sa ReadString32
      * @sa ReadString32Little
      */
-    String ReadString32Big(Convert::Encoding_t encoding);
+    String ReadString32Big(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read the string @em str encoded with @em encoding from the packet. The
@@ -245,12 +250,13 @@ public:
      * - ENCODING_UTF8 (Unicode)
      * - ENCODING_CP932 (Japanese)
      * - ENCODING_CP1252 (US English)
+     * @param trimNull When true the null terminator will be removed
      * @returns The string that was read.
      * @sa WriteString32
      * @sa ReadString32
      * @sa ReadString32Big
      */
-    String ReadString32Little(Convert::Encoding_t encoding);
+    String ReadString32Little(Convert::Encoding_t encoding, bool trimNull = false);
 
     /**
      * Read a 8-bit unsigned integer from the packet but do not advance the

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -126,6 +126,11 @@ ChannelServer::~ChannelServer()
     delete[] mChatManager;
 }
 
+ServerTime ChannelServer::GetServerTime()
+{
+    return sGetServerTime();
+}
+
 const std::shared_ptr<objects::RegisteredChannel> ChannelServer::GetRegisteredChannel()
 {
     return mRegisteredChannel;
@@ -248,4 +253,23 @@ std::shared_ptr<libcomp::TcpConnection> ChannelServer::CreateConnection(
 
 
     return connection;
+}
+
+GET_SERVER_TIME ChannelServer::sGetServerTime =
+    std::chrono::high_resolution_clock::is_steady
+        ? &ChannelServer::GetServerTimeHighResolution
+        : &ChannelServer::GetServerTimeSteady;
+
+ServerTime ChannelServer::GetServerTimeSteady()
+{
+    auto now = std::chrono::steady_clock::now();
+    return (ServerTime)std::chrono::time_point_cast<std::chrono::microseconds>(now)
+        .time_since_epoch().count();
+}
+
+ServerTime ChannelServer::GetServerTimeHighResolution()
+{
+    auto now = std::chrono::high_resolution_clock::now();
+    return (ServerTime)std::chrono::time_point_cast<std::chrono::microseconds>(now)
+        .time_since_epoch().count();
 }

--- a/server/channel/src/ChannelServer.h
+++ b/server/channel/src/ChannelServer.h
@@ -45,6 +45,9 @@
 namespace channel
 {
 
+typedef uint64_t ServerTime;
+typedef ServerTime (*GET_SERVER_TIME)();
+
 /**
  * Channel server that handles client packets in game.
  */
@@ -73,6 +76,12 @@ public:
      * @return true on success, false on failure
      */
     virtual bool Initialize();
+
+    /**
+     * Get the current time relative to the server.
+     * @return Current time relative to the server
+     */
+    static ServerTime GetServerTime();
 
     /**
      * Get the RegisteredChannel.
@@ -153,6 +162,24 @@ protected:
      */
     virtual std::shared_ptr<libcomp::TcpConnection> CreateConnection(
         asio::ip::tcp::socket& socket);
+
+    /**
+     * Get the current time relative to the server using the
+     * C++ standard steady_clock.
+     * @return Current time relative to the server
+     */
+    static ServerTime GetServerTimeSteady();
+
+    /**
+     * Get the current time relative to the server using the
+     * C++ standard high_resolution_clock.
+     * @return Current time relative to the server
+     */
+    static ServerTime GetServerTimeHighResolution();
+
+    /// Function pointer to the most accurate time detection code
+    /// available for the current machine.
+    static GET_SERVER_TIME sGetServerTime;
 
     /// Pointer to the manager in charge of connection messages.
     std::shared_ptr<ManagerConnection> mManagerConnection;

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -75,10 +75,10 @@ ClientTime ClientState::ToClientTime(ServerTime time) const
         return 0.0f;
     }
 
-    return static_cast<ClientTime>((time - mStartTime) / 1000000.0f);
+    return static_cast<ClientTime>((ClientTime)(time - mStartTime) / 1000000.0f);
 }
 
 ServerTime ClientState::ToServerTime(ClientTime time) const
 {
-    return static_cast<ServerTime>(((ServerTime)time * 1000000.0f) + mStartTime);
+    return static_cast<ServerTime>(((ServerTime)time * 1000000) + mStartTime);
 }

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -26,10 +26,17 @@
 
 #include "ClientState.h"
 
+// Standard C++11 Includes
+#include <ctime>
+
+// channel Includes
+#include "ChannelServer.h"
+
 using namespace channel;
 
 ClientState::ClientState() : objects::ClientStateObject(),
-    mCharacterState(std::shared_ptr<CharacterState>(new CharacterState))
+    mCharacterState(std::shared_ptr<CharacterState>(new CharacterState)),
+    mStartTime(0)
 {
 }
 
@@ -51,4 +58,27 @@ std::shared_ptr<CharacterState> ClientState::GetCharacterState()
 bool ClientState::Ready()
 {
     return GetAuthenticated() && mCharacterState->Ready();
+}
+
+void ClientState::SyncReceived()
+{
+    if(mStartTime == 0)
+    {
+        mStartTime = ChannelServer::GetServerTime();
+    }
+}
+
+ClientTime ClientState::ToClientTime(ServerTime time) const
+{
+    if(time <= mStartTime)
+    {
+        return 0.0f;
+    }
+
+    return static_cast<ClientTime>((time - mStartTime) / 1000000.0f);
+}
+
+ServerTime ClientState::ToServerTime(ClientTime time) const
+{
+    return static_cast<ServerTime>(((ServerTime)time * 1000000.0f) + mStartTime);
 }

--- a/server/channel/src/ClientState.h
+++ b/server/channel/src/ClientState.h
@@ -36,6 +36,9 @@
 namespace channel
 {
 
+typedef float ClientTime;
+typedef uint64_t ServerTime;
+
 /**
  * Contains the state of a game client currently connected to the
  * channel.
@@ -72,9 +75,36 @@ public:
      */
     bool Ready();
 
+    /**
+     * Handle any actions needed when the game client pings the
+     * server with a sync request.  If the start time has not been
+     * set, it will be set here.
+     */
+    void SyncReceived();
+
+    /**
+     * Convert time relative to the server to time relative to the
+     * game client.
+     * @param time Time relative to the server
+     * @return Time relative to the client
+     */
+    ClientTime ToClientTime(ServerTime time) const;
+
+    /**
+     * Convert time relative to the game client to time relative
+     * to the server.
+     * @param time Time relative to the client
+     * @return Time relative to the server
+     */
+    ServerTime ToServerTime(ClientTime time) const;
+
 private:
     /// State of the character associated to the client
     std::shared_ptr<CharacterState> mCharacterState;
+
+    /// Current time of the server set upon starting the client
+    /// communication.
+    ServerTime mStartTime;
 };
 
 } // namespace channel

--- a/server/channel/src/packets/game/Chat.cpp
+++ b/server/channel/src/packets/game/Chat.cpp
@@ -81,7 +81,7 @@ bool Parsers::Chat::Parse(libcomp::ManagerPacket *pPacketManager,
     auto state = client->GetClientState();
 
     libcomp::String line = p.ReadString16Little(
-        state->GetClientStringEncoding()).C();
+        state->GetClientStringEncoding(), true);
 
     std::smatch match;
     std::string input = line.C();

--- a/server/channel/src/packets/game/Login.cpp
+++ b/server/channel/src/packets/game/Login.cpp
@@ -51,7 +51,7 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
     libcomp::ReadOnlyPacket& p) const
 {
     // Classic authentication method: username followed by the session key
-    libcomp::String username = p.ReadString16(libcomp::Convert::ENCODING_UTF8).C();
+    libcomp::String username = p.ReadString16(libcomp::Convert::ENCODING_UTF8, true);
     uint32_t sessionKey = p.ReadU32Little();
 
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());

--- a/server/lobby/schema/lobbyconfig.xml
+++ b/server/lobby/schema/lobbyconfig.xml
@@ -7,5 +7,6 @@
         <member type="DatabaseConfigSQLite3*" name="SQLite3Config"/>
         <member type="DatabaseConfigCassandra*" name="CassandraConfig"/>
         <member type="u16" name="CharacterDeletionDelay" default="1440"/>
+        <member type="u32" name="CharacterTicketCost"/>
     </object>
 </objgen>

--- a/server/lobby/src/packets/game/Auth.cpp
+++ b/server/lobby/src/packets/game/Auth.cpp
@@ -66,7 +66,7 @@ bool Parsers::Auth::Parse(libcomp::ManagerPacket *pPacketManager,
 
     // Authentication token (session ID) provided by the web server.
     libcomp::String sid = p.ReadString16Little(
-        libcomp::Convert::ENCODING_UTF8).ToLower().C();
+        libcomp::Convert::ENCODING_UTF8, true).ToLower();
 
     LOG_DEBUG(libcomp::String("SID: %1\n").Arg(sid));
 

--- a/server/lobby/src/packets/game/CharacterList.cpp
+++ b/server/lobby/src/packets/game/CharacterList.cpp
@@ -57,6 +57,12 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
         return false;
     }
 
+    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
+    auto accountManager = server->GetAccountManager();
+    auto lobbyDB = server->GetMainDatabase();
+    auto lobbyConnection = std::dynamic_pointer_cast<LobbyClientConnection>(connection);
+    auto account = lobbyConnection->GetClientState()->GetAccount().Get();
+
     libcomp::Packet reply;
     reply.WritePacketCode(
         LobbyClientPacketCode_t::PACKET_CHARACTER_LIST_RESPONSE);
@@ -65,13 +71,7 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
     reply.WriteU32Little((uint32_t)time(0));
 
     // Number of character tickets.
-    reply.WriteU8(1);
-
-    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
-    auto accountManager = server->GetAccountManager();
-    auto lobbyDB = server->GetMainDatabase();
-    auto lobbyConnection = std::dynamic_pointer_cast<LobbyClientConnection>(connection);
-    auto account = lobbyConnection->GetClientState()->GetAccount().Get();
+    reply.WriteU8(account->GetTicketCount());
 
     std::list<std::shared_ptr<objects::Character>> characters;
     for(auto world : server->GetWorlds())

--- a/server/lobby/src/packets/game/PurchaseTicket.cpp
+++ b/server/lobby/src/packets/game/PurchaseTicket.cpp
@@ -27,12 +27,17 @@
 #include "Packets.h"
 
 // libcomp Includes
-#include <Decrypt.h>
 #include <Log.h>
+#include <ManagerPacket.h>
 #include <Packet.h>
 #include <PacketCodes.h>
 #include <ReadOnlyPacket.h>
-#include <TcpConnection.h>
+
+// lobby Includes
+#include "LobbyServer.h"
+
+// object Includes
+#include <Account.h>
 
 using namespace lobby;
 
@@ -45,6 +50,30 @@ bool Parsers::PurchaseTicket::Parse(libcomp::ManagerPacket *pPacketManager,
     if(p.Size() != 0)
     {
         return false;
+    }
+
+    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
+    auto lobbyDB = server->GetMainDatabase();
+    auto config = std::dynamic_pointer_cast<objects::LobbyConfig>(
+        server->GetConfig());
+    auto account = state(connection)->GetAccount();
+    auto ticketCost = config->GetCharacterTicketCost();
+
+    if(account->GetCP() >= ticketCost)
+    {
+        account->SetCP(account->GetCP() - ticketCost);
+        account->SetTicketCount(account->GetTicketCount() + 1);
+
+        if(!account->Update(lobbyDB))
+        {
+            LOG_ERROR(libcomp::String("Account purchased a character ticket but could"
+                " not be updated: %1").Arg(account->GetUUID().ToString()));
+        }
+    }
+    else
+    {
+        LOG_ERROR(libcomp::String("Account attempted to purchase a character ticket"
+            " without having enough CP available: %1").Arg(account->GetUUID().ToString()));
     }
 
     libcomp::Packet reply;

--- a/server/lobby/src/packets/game/PurchaseTicket.cpp
+++ b/server/lobby/src/packets/game/PurchaseTicket.cpp
@@ -61,8 +61,8 @@ bool Parsers::PurchaseTicket::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(account->GetCP() >= ticketCost)
     {
-        account->SetCP(account->GetCP() - ticketCost);
-        account->SetTicketCount(account->GetTicketCount() + 1);
+        account->SetCP(static_cast<uint32_t>(account->GetCP() - ticketCost));
+        account->SetTicketCount(static_cast<uint8_t>(account->GetTicketCount() + 1));
 
         if(!account->Update(lobbyDB))
         {

--- a/server/lobby/src/packets/internal/AccountLogout.cpp
+++ b/server/lobby/src/packets/internal/AccountLogout.cpp
@@ -44,7 +44,7 @@ bool Parsers::AccountLogout::Parse(libcomp::ManagerPacket *pPacketManager,
     (void)connection;
 
     libcomp::String username = p.ReadString16Little(
-        libcomp::Convert::Encoding_t::ENCODING_UTF8).C();
+        libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
 
     auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
     auto accountManager = server->GetAccountManager();

--- a/server/world/src/packets/AccountLogin.cpp
+++ b/server/world/src/packets/AccountLogin.cpp
@@ -185,7 +185,7 @@ bool Parsers::AccountLogin::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         uint32_t sesssionKey = p.ReadU32();
         libcomp::String username = p.ReadString16Little(
-            libcomp::Convert::Encoding_t::ENCODING_UTF8).C();
+            libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
         server->QueueWork(ChannelLogin, server, iConnection, sesssionKey, username);
     }
 

--- a/server/world/src/packets/AccountLogout.cpp
+++ b/server/world/src/packets/AccountLogout.cpp
@@ -77,7 +77,7 @@ bool Parsers::AccountLogout::Parse(libcomp::ManagerPacket *pPacketManager,
     (void)connection;
 
     libcomp::String username = p.ReadString16Little(
-        libcomp::Convert::Encoding_t::ENCODING_UTF8).C();
+        libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
 
     auto server = std::dynamic_pointer_cast<WorldServer>(pPacketManager->GetServer());
 


### PR DESCRIPTION
-Fixing the Sync packet parser by using client/server time tracking
-Adding optional param to ReadOnlyPacket to allow trimming a null terminator from strings read from the packet
-Implementing QueryPurchaseTicket and PurchaseTicket