### PR TITLE
[ADD] Config setup.xml to load accounts after database creation.

### DIFF
--- a/contrib/testing/setup.xml
+++ b/contrib/testing/setup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <object>
+        <member name="Accounts">
+            <element>
+                <member name="Username">test</member>
+                <member name="Password">hackMePls</member>
+            </element>
+            <element>
+                <member name="Username">omega</member>
+                <member name="DisplayName">COMP Omega</member>
+                <member name="Email">compomega@tutanota.com</member>
+                <member name="Password">testtest</member>
+                <member name="CP">9999</member><!-- It's over 9000! -->
+                <member name="TicketCount">20</member>
+                <member name="UserLevel">1000</member>
+                <member name="Enabled">true</member>
+                <member name="IsGM">true</member>
+            </element>
+        </member>
+    </object>
+</objgen>

--- a/server/lobby/CMakeLists.txt
+++ b/server/lobby/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(${PROJECT_NAME}_HDRS
 SET(${PROJECT_NAME}_SCHEMA
     schema/clientstate.xml
     schema/lobbyconfig.xml
+    schema/setupconfig.xml
 )
 
 SOURCE_GROUP("objgen" ${CMAKE_CURRENT_BINARY_DIR}/objgen/*)
@@ -78,6 +79,10 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     ClientStateObject.cpp
     LobbyConfig.h
     LobbyConfig.cpp
+    SetupAccount.h
+    SetupAccount.cpp
+    SetupConfig.h
+    SetupConfig.cpp
 )
 
 SOURCE_GROUP("Source Files\\Packets\\Game" src/packets/game/*)

--- a/server/lobby/schema/master.xml
+++ b/server/lobby/schema/master.xml
@@ -3,4 +3,5 @@
     <include path="../../libcomp/schema/master.xml"/>
     <include path="clientstate.xml"/>
     <include path="lobbyconfig.xml"/>
+    <include path="setupconfig.xml"/>
 </objgen>

--- a/server/lobby/schema/setupconfig.xml
+++ b/server/lobby/schema/setupconfig.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <object name="SetupAccount" persistent="false">
+        <member type="string" name="Username"/>
+        <member type="string" name="DisplayName"
+            default="AnonymousCoward"/>
+        <member type="string" name="Email"
+            default="no.thanks@bother_me_not.net"/>
+        <member type="string" name="Password"/>
+        <member type="u32" name="CP" caps="true" default="1000000"/>
+        <member type="u8" name="TicketCount" default="1"/>
+        <member type="s32" name="UserLevel" default="1000"/>
+        <member type="bool" name="Enabled" default="true"/>
+        <member type="bool" name="IsGM" default="true"/>
+    </object>
+    <object name="SetupConfig" persistent="false">
+        <member type="list" name="Accounts">
+            <element type="SetupAccount*"/>
+        </member>
+    </object>
+</objgen>

--- a/server/lobby/src/LobbyServer.h
+++ b/server/lobby/src/LobbyServer.h
@@ -37,6 +37,13 @@
 #include "SessionManager.h"
 #include "World.h"
 
+namespace objects
+{
+
+class SetupConfig;
+
+} // namespace objects
+
 namespace lobby
 {
 
@@ -154,6 +161,12 @@ protected:
      * @return true on success, false on failure
      */
     bool ResetRegisteredWorlds();
+
+    /**
+     * Setup the server based on the setup config.
+     * @return true on success, false on failure
+     */
+    bool Setup(const std::shared_ptr<objects::SetupConfig>& config);
 
     /**
      * Create a connection to a newly active socket.


### PR DESCRIPTION
See the example setup.xml for how to configure the accounts. Only username and password are required. All others will use a default unless overridden for the account. Copy the setup.xml into the same directory as the lobby.xml configuration file.