### PR TITLE
Modified handling of zone changes

### DIFF
--- a/server/channel/src/ActionManager.cpp
+++ b/server/channel/src/ActionManager.cpp
@@ -94,7 +94,7 @@ bool ActionManager::ZoneChange(
     zoneManager->LeaveZone(client);
 
     // Enter the new zone.
-    if(!zoneManager->EnterZone(client, zoneID))
+    if(!zoneManager->EnterZone(client, zoneID, x, y, rotation))
     {
         LOG_ERROR(libcomp::String("Failed to add client to zone"
             " %1. Closing the connection.\n").Arg(zoneID));
@@ -103,33 +103,6 @@ bool ActionManager::ZoneChange(
 
         return false;
     }
-
-    auto ticks = server->GetServerTime();
-
-    // Move the entity to the new location.
-    /// @todo Do this for the demon too?
-    cState->SetOriginX(x);
-    cState->SetOriginY(x);
-    cState->SetOriginRotation(x);
-    cState->SetOriginTicks(ticks);
-    cState->SetDestinationX(x);
-    cState->SetDestinationY(x);
-    cState->SetDestinationRotation(x);
-    cState->SetDestinationTicks(ticks);
-
-    auto instance = zoneManager->GetZoneInstance(client);
-    auto zoneDef = instance->GetDefinition();
-
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_ZONE_CHANGE);
-    reply.WriteU32Little(zoneDef->GetID());
-    reply.WriteU32Little(instance->GetID());
-    reply.WriteFloat(x);
-    reply.WriteFloat(y);
-    reply.WriteFloat(rotation);
-    reply.WriteU32Little(zoneDef->GetDynamicMapID());
-
-    client->SendPacket(reply);
-
+    
     return true;
 }

--- a/server/channel/src/ChatManager.cpp
+++ b/server/channel/src/ChatManager.cpp
@@ -464,7 +464,6 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
     auto cState = state->GetCharacterState();
     auto server = mServer.lock();
     auto zoneManager = server->GetZoneManager();
-
     uint32_t zoneID = 0;
     float xCoord = 0.00;
     float yCoord = 0.00;
@@ -474,30 +473,30 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
     if(args.empty())
     {
         return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String(
-            "Error: @Zone requires at least a zoneID, or a zoneID and (x,y) coordinates"));
+            "Error: @Zone requires at least a zoneID, or a zoneID and (x,y) coordinates."));
     }
     else
     {
+        GetIntegerArg<uint32_t>(zoneID, argsCopy);
+        auto zoneDefinition = server->GetServerDataManager()->GetZoneData(zoneID);
+        if(!zoneDefinition)
+        {
+            return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String("ERROR: INVALID ZONE ID.  Please enter a proper zoneID and try again."));
+        }
         zoneManager->LeaveZone(client);
         //copy zoneID from args.
-        GetIntegerArg<uint32_t>(zoneID, argsCopy);
         if(args.size() == 3)
         {
             //pull x coord
-            GetDecimalArg<float>(xCoord, argsCopy);
+            bool xTrue = GetDecimalArg<float>(xCoord, argsCopy);
             //pull y coord
-            GetDecimalArg<float>(yCoord, argsCopy);
+            bool yTrue = GetDecimalArg<float>(yCoord, argsCopy);
+            if(!xTrue||!yTrue)
+            {
+                return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String("ERROR: One of the inputs is not a number.  Please re-enter the command with proper inputs."));
+            }
         }
-        if(!zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation))
-        {
-            //in failure case, will send to home3 at position 0,0 with rotation value 0.
-            zoneManager->EnterZone(client, 20101, 0, 0, 0);
-            return true;
-        }
-        else
-        {
-            zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation);
-        }
+        zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation);
         
         return true;
     }

--- a/server/channel/src/ChatManager.cpp
+++ b/server/channel/src/ChatManager.cpp
@@ -465,7 +465,7 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
     auto server = mServer.lock();
     auto zoneManager = server->GetZoneManager();
 
-    uint32_t mapID = 0;
+    uint32_t zoneID = 0;
     float xCoord = 0.00;
     float yCoord = 0.00;
     float rotation =0.00;
@@ -474,15 +474,13 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
     if(args.empty())
     {
         return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String(
-            "Error: @Zone requires at least a mapID, or a mapID and (x,y) coordinates"));
+            "Error: @Zone requires at least a zoneID, or a zoneID and (x,y) coordinates"));
     }
     else
     {
         zoneManager->LeaveZone(client);
-        //copy mapID from args.
-        GetIntegerArg<uint32_t>(mapID, argsCopy);
-        SendChatMessage (client, ChatType_t::CHAT_SELF, libcomp::String("Zoning to new map"));
-        //if there are 3 input args
+        //copy zoneID from args.
+        GetIntegerArg<uint32_t>(zoneID, argsCopy);
         if(args.size() == 3)
         {
             //pull x coord
@@ -490,7 +488,16 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
             //pull y coord
             GetDecimalArg<float>(yCoord, argsCopy);
         }
-        zoneManager->EnterZone(client, mapID, xCoord, yCoord, rotation);
+        if(!zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation))
+        {
+            //in failure case, will send to home3 at position 0,0 with rotation value 0.
+            zoneManager->EnterZone(client, 20101, 0, 0, 0);
+            return true;
+        }
+        else
+        {
+            zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation);
+        }
         
         return true;
     }

--- a/server/channel/src/ChatManager.cpp
+++ b/server/channel/src/ChatManager.cpp
@@ -477,25 +477,18 @@ bool ChatManager::GMCommand_Zone(const std::shared_ptr<
     }
     else
     {
-        GetIntegerArg<uint32_t>(zoneID, argsCopy);
-        auto zoneDefinition = server->GetServerDataManager()->GetZoneData(zoneID);
-        if(!zoneDefinition)
+        if(!GetIntegerArg<uint32_t>(zoneID, argsCopy) || !server->GetServerDataManager()->GetZoneData(zoneID))
         {
             return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String("ERROR: INVALID ZONE ID.  Please enter a proper zoneID and try again."));
         }
+
         zoneManager->LeaveZone(client);
-        //copy zoneID from args.
-        if(args.size() == 3)
+
+        if(args.size() == 3 && (!GetDecimalArg<float>(xCoord, argsCopy) || !GetDecimalArg<float>(yCoord, argsCopy)))
         {
-            //pull x coord
-            bool xTrue = GetDecimalArg<float>(xCoord, argsCopy);
-            //pull y coord
-            bool yTrue = GetDecimalArg<float>(yCoord, argsCopy);
-            if(!xTrue||!yTrue)
-            {
-                return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String("ERROR: One of the inputs is not a number.  Please re-enter the command with proper inputs."));
-            }
+            return SendChatMessage(client, ChatType_t::CHAT_SELF, libcomp::String("ERROR: One of the inputs is not a number.  Please re-enter the command with proper inputs."));
         }
+
         zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation);
         
         return true;

--- a/server/channel/src/ChatManager.h
+++ b/server/channel/src/ChatManager.h
@@ -185,7 +185,7 @@ private:
      * @param args List of arguments for the command
      * @return true if the command was handled properly, else false
      */
-    bool ChatManager::GMCommand_Zone(const std::shared_ptr<
+    bool GMCommand_Zone(const std::shared_ptr<
     channel::ChannelClientConnection>& client,
     const std::list<libcomp::String>& args);
 

--- a/server/channel/src/ChatManager.h
+++ b/server/channel/src/ChatManager.h
@@ -179,6 +179,16 @@ private:
         channel::ChannelClientConnection>& client,
         const std::list<libcomp::String>& args);
 
+    /*
+     * GM command to zone to a new map.
+     * @param client Pointer to the client that sent the command
+     * @param args List of arguments for the command
+     * @return true if the command was handled properly, else false
+     */
+    bool ChatManager::GMCommand_Zone(const std::shared_ptr<
+    channel::ChannelClientConnection>& client,
+    const std::list<libcomp::String>& args);
+
     /**
      * GM command to increase the XP of a character or demon.
      * @param client Pointer to the client that sent the command

--- a/server/channel/src/ZoneManager.h
+++ b/server/channel/src/ZoneManager.h
@@ -79,11 +79,14 @@ public:
      * Associate a client connection to a zone
      * @param client Client connection to connect to a zone
      * @param zoneID Definition ID of a zone to add the client to
+     * @param xCoord: Float that defines x-coordinate to send character to.
+     * @param yCoord: Float that defines y-coordinate to send character to.
+     * @param rotation: Float that defines character rotation.
      * @return true if the client entered the zone properly, false if they
      *  did not
      */
     bool EnterZone(const std::shared_ptr<ChannelClientConnection>& client,
-        uint32_t zoneID);
+        uint32_t zoneID, float xCoord, float yCoord, float rotation);
 
     /**
      * Remove a client connection from a zone

--- a/server/channel/src/ZoneManager.h
+++ b/server/channel/src/ZoneManager.h
@@ -79,9 +79,9 @@ public:
      * Associate a client connection to a zone
      * @param client Client connection to connect to a zone
      * @param zoneID Definition ID of a zone to add the client to
-     * @param xCoord: Float that defines x-coordinate to send character to.
-     * @param yCoord: Float that defines y-coordinate to send character to.
-     * @param rotation: Float that defines character rotation.
+     * @param xCoord: x-coordinate to send character to.
+     * @param yCoord: y-coordinate to send character to.
+     * @param rotation: character rotation.
      * @return true if the client entered the zone properly, false if they
      *  did not
      */

--- a/server/channel/src/ZoneManager.h
+++ b/server/channel/src/ZoneManager.h
@@ -79,9 +79,9 @@ public:
      * Associate a client connection to a zone
      * @param client Client connection to connect to a zone
      * @param zoneID Definition ID of a zone to add the client to
-     * @param xCoord: x-coordinate to send character to.
-     * @param yCoord: y-coordinate to send character to.
-     * @param rotation: character rotation.
+     * @param xCoord x-coordinate to send character to.
+     * @param yCoord y-coordinate to send character to.
+     * @param rotation character rotation.
      * @return true if the client entered the zone properly, false if they
      *  did not
      */

--- a/server/channel/src/packets/game/SendData.cpp
+++ b/server/channel/src/packets/game/SendData.cpp
@@ -44,30 +44,19 @@ void SendZoneChange(std::shared_ptr<ChannelServer> server,
 {
     auto zoneManager = server->GetZoneManager();
     auto cState = client->GetClientState()->GetCharacterState();
+    float xCoord = cState->GetOriginX();
+    float yCoord = cState->GetOriginY();
+    float rotation = cState->GetOriginRotation();
 
     /// @todo: replace with last zone information
     uint32_t zoneID = 0x00004E85;
-    if(!zoneManager->EnterZone(client, zoneID))
+    if(!zoneManager->EnterZone(client, zoneID, xCoord, yCoord, rotation))
     {
         LOG_ERROR(libcomp::String("Failed to add client to zone"
             " %1. Closing the connection.\n").Arg(zoneID));
         client->Close();
         return;
     }
-
-    auto instance = zoneManager->GetZoneInstance(client);
-    auto def = instance->GetDefinition();
-
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_ZONE_CHANGE);
-    reply.WriteU32Little(zoneID);
-    reply.WriteU32Little(instance->GetID());
-    reply.WriteFloat(cState->GetOriginX());
-    reply.WriteFloat(cState->GetOriginY());
-    reply.WriteFloat(cState->GetOriginRotation());
-    reply.WriteU32Little(def->GetDynamicMapID());
-
-    client->SendPacket(reply);
 }
 
 bool Parsers::SendData::Parse(libcomp::ManagerPacket *pPacketManager,


### PR DESCRIPTION
@zone now works.

ZoneManager's EnterZone() now handles packet creation for zone changes (moved code from ActionManager.cpp to ZoneManager.cpp, with minor changes). 

It now takes in an additional 3 floats;
x-coordinate to send character to
y-coordinate to send character to
rotation value to set character (at?)

ToDo: exception handling for improper zoneID. <--- IMPORTANT