### PR TITLE
MariaDB adjustments, packet parser standardization, misc fixes

### DIFF
--- a/libcomp/src/DatabaseQueryMariaDB.cpp
+++ b/libcomp/src/DatabaseQueryMariaDB.cpp
@@ -158,10 +158,10 @@ bool DatabaseQueryMariaDB::Execute()
                     }
                     break;
                 case MYSQL_TYPE_BIT:
-                case MYSQL_TYPE_TINY:
                     {
                         mBufferBool.push_back(false);
                         b.buffer = &mBufferBool.back();
+                        b.buffer_length = field->length;
                     }
                     break;
                 default:
@@ -571,8 +571,7 @@ bool DatabaseQueryMariaDB::GetValue(const String& name, double& value)
 bool DatabaseQueryMariaDB::GetValue(size_t index, bool& value)
 {
     if(mResultColumnTypes.size() <= index
-        || (mResultColumnTypes[index] != MYSQL_TYPE_TINY
-            && mResultColumnTypes[index] != MYSQL_TYPE_BIT))
+        || mResultColumnTypes[index] != MYSQL_TYPE_BIT)
     {
         return false;
     }
@@ -682,6 +681,7 @@ bool DatabaseQueryMariaDB::GetRows(std::list<std::unordered_map<
                     }
                     break;
                 case MYSQL_TYPE_STRING:
+                case MYSQL_TYPE_VAR_STRING:
                     {
                         libcomp::String val;
                         GetValue(i, val);
@@ -691,7 +691,6 @@ bool DatabaseQueryMariaDB::GetRows(std::list<std::unordered_map<
                     }
                     break;
                 case MYSQL_TYPE_BIT:
-                case MYSQL_TYPE_TINY:
                     {
                         bool val;
                         GetValue(i, val);

--- a/libcomp/src/ManagerPacket.cpp
+++ b/libcomp/src/ManagerPacket.cpp
@@ -75,7 +75,20 @@ bool ManagerPacket::ProcessMessage(const libcomp::Message::Message *pMessage)
             return false;
         }
 
-        return it->second->Parse(this, pPacketMessage->GetConnection(), p);
+        auto connection = pPacketMessage->GetConnection();
+        if(!ValidateConnectionState(connection, code))
+        {
+            connection->Close();
+            return false;
+        }
+
+        if(!it->second->Parse(this, connection, p))
+        {
+            connection->Close();
+            return false;
+        }
+
+        return true;
     }
     else
     {
@@ -86,6 +99,15 @@ bool ManagerPacket::ProcessMessage(const libcomp::Message::Message *pMessage)
 std::shared_ptr<libcomp::BaseServer> ManagerPacket::GetServer()
 {
     return mServer.lock();
+}
+
+bool ManagerPacket::ValidateConnectionState(const std::shared_ptr<
+    libcomp::TcpConnection>& connection, CommandCode_t commandCode) const
+{
+    (void)connection;
+    (void)commandCode;
+
+    return true;
 }
 
 bool Parsers::Placeholder::Parse(ManagerPacket *pPacketManager,

--- a/libcomp/src/ManagerPacket.h
+++ b/libcomp/src/ManagerPacket.h
@@ -90,6 +90,9 @@ public:
     std::shared_ptr<libcomp::BaseServer> GetServer();
 
 protected:
+    virtual bool ValidateConnectionState(const std::shared_ptr<
+        libcomp::TcpConnection>& connection, CommandCode_t commandCode) const;
+
     /// Static list containing the packet message type to return via
     /// @ref ManagerPacket::GetSupportedTypes
     static std::list<libcomp::Message::MessageType> sSupportedTypes;

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(${PROJECT_NAME}_SRCS
     src/ChatManager.cpp
     src/ClientState.cpp
     src/EntityState.cpp
+    src/ManagerClientPacket.cpp
     src/ManagerConnection.cpp
     src/ManagerSystem.cpp
     src/SkillManager.cpp
@@ -56,6 +57,7 @@ SET(${PROJECT_NAME}_HDRS
     src/ChatManager.h
     src/ClientState.h
     src/EntityState.h
+    src/ManagerClientPacket.h
     src/ManagerConnection.h
     src/ManagerSystem.h
     src/Packets.h

--- a/server/channel/schema/clientstate.xml
+++ b/server/channel/schema/clientstate.xml
@@ -2,6 +2,7 @@
 <objgen>
     <object name="ClientStateObject" persistent="false">
         <member type="bool" name="Authenticated"/>
+        <member type="bool" name="LoggedIn"/>
         <member type="AccountLogin*" name="AccountLogin"/>
     </object>
 </objgen>

--- a/server/channel/src/AccountManager.cpp
+++ b/server/channel/src/AccountManager.cpp
@@ -115,6 +115,8 @@ void AccountManager::HandleLoginResponse(const std::shared_ptr<
         demonState->RecalculateStats(server->GetDefinitionManager());
 
         reply.WriteU32Little(1);
+
+        state->SetLoggedIn(true);
     }
     else
     {

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -134,11 +134,6 @@ const libobjgen::UUID ClientState::GetAccountUID() const
         mCharacterState->GetEntity()->GetAccount().GetUUID() : NULLUUID;
 }
 
-bool ClientState::Ready()
-{
-    return GetAuthenticated() && mCharacterState->Ready();
-}
-
 void ClientState::SyncReceived()
 {
     if(mStartTime == 0)

--- a/server/channel/src/ClientState.h
+++ b/server/channel/src/ClientState.h
@@ -126,13 +126,6 @@ public:
     const libobjgen::UUID GetAccountUID() const;
 
     /**
-     * Check if the client state has everything needed to start
-     * being used.
-     * @return true if the state is ready to use, otherwise false
-     */
-    bool Ready();
-
-    /**
      * Handle any actions needed when the game client pings the
      * server with a sync request.  If the start time has not been
      * set, it will be set here.

--- a/server/channel/src/ManagerClientPacket.cpp
+++ b/server/channel/src/ManagerClientPacket.cpp
@@ -1,0 +1,76 @@
+/**
+ * @file server/channel/src/ManagerClientPacket.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Manager to handle channel packet logic.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ManagerClientPacket.h"
+
+// channel Includes
+#include <ChannelClientConnection.h>
+
+// libcomp Includes
+#include <Log.h>
+#include <PacketCodes.h>
+
+using namespace channel;
+
+ManagerClientPacket::ManagerClientPacket(std::weak_ptr<libcomp::BaseServer> server)
+    : libcomp::ManagerPacket(server)
+{
+}
+
+ManagerClientPacket::~ManagerClientPacket()
+{
+}
+
+bool ManagerClientPacket::ValidateConnectionState(const std::shared_ptr<
+    libcomp::TcpConnection>& connection, libcomp::CommandCode_t commandCode) const
+{
+    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
+    auto state = client->GetClientState();
+
+    bool valid = false;
+    switch((ClientToChannelPacketCode_t)commandCode)
+    {
+        case ClientToChannelPacketCode_t::PACKET_LOGIN:
+        case ClientToChannelPacketCode_t::PACKET_KEEP_ALIVE:
+            valid = true;
+            break;
+        case ClientToChannelPacketCode_t::PACKET_AUTH:
+            if(!(valid = state->GetLoggedIn()))
+            {
+                LOG_ERROR("Client connection attempted to authenticate without logging in.\n");
+            }
+            break;
+        default:
+            if(!(valid = state->GetAuthenticated() && state->GetLoggedIn()))
+            {
+                LOG_ERROR("Client connection attempted to handle a request packet"
+                    " without authenticating and logging in first.\n");
+            }
+            break;
+    }
+
+    return valid;
+}

--- a/server/channel/src/ManagerClientPacket.h
+++ b/server/channel/src/ManagerClientPacket.h
@@ -1,0 +1,60 @@
+/**
+ * @file server/channel/src/ManagerClientPacket.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Manager to handle channel packet logic.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SERVER_CHANNEL_SRC_MANAGERCLIENTPACKET_H
+#define SERVER_CHANNEL_SRC_MANAGERCLIENTPACKET_H
+
+// libcomp Includes
+#include <ManagerPacket.h>
+
+namespace channel
+{
+
+/**
+ * Manager class responsible for handling client side packets.
+ */
+class ManagerClientPacket : public libcomp::ManagerPacket
+{
+public:
+    /**
+     * Create a new manager.
+     * @param server Pointer to the server that uses this manager
+     */
+    ManagerClientPacket(std::weak_ptr<libcomp::BaseServer> server);
+
+    /**
+     * Clean up the manager.
+     */
+    virtual ~ManagerClientPacket();
+
+protected:
+    virtual bool ValidateConnectionState(const std::shared_ptr<
+        libcomp::TcpConnection>& connection, libcomp::CommandCode_t commandCode) const;
+};
+
+} // namespace world
+
+#endif // SERVER_CHANNEL_SRC_MANAGERCLIENTPACKET_H

--- a/server/channel/src/packets/game/ActivateSkill.cpp
+++ b/server/channel/src/packets/game/ActivateSkill.cpp
@@ -82,7 +82,7 @@ bool Parsers::ActivateSkill::Parse(libcomp::ManagerPacket *pPacketManager,
                 LOG_ERROR(libcomp::String("Unknown skill target type encountered: %1\n")
                     .Arg(targetType));
                 skillManager->SendFailure(client, sourceEntityID, skillID);
-                return false;
+                return true;
             }
             break;
     }

--- a/server/channel/src/packets/game/COMPDemonData.cpp
+++ b/server/channel/src/packets/game/COMPDemonData.cpp
@@ -73,7 +73,7 @@ bool Parsers::COMPDemonData::Parse(libcomp::ManagerPacket *pPacketManager,
     else if(box != 0)
     {
         LOG_ERROR("Non-COMP demon boxes are currently not supported.\n");
-        return false;
+        return true;
     }
 
     auto server = std::dynamic_pointer_cast<ChannelServer>

--- a/server/channel/src/packets/game/ItemBox.cpp
+++ b/server/channel/src/packets/game/ItemBox.cpp
@@ -74,7 +74,7 @@ bool Parsers::ItemBox::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         /// @todo
         LOG_ERROR("Item box request sent for a non-inventory item box.\n");
-        return false;
+        return true;
     }
 
     return true;

--- a/server/channel/src/packets/game/ItemMove.cpp
+++ b/server/channel/src/packets/game/ItemMove.cpp
@@ -128,7 +128,7 @@ bool Parsers::ItemMove::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         /// @todo
         LOG_ERROR("Item move request sent using a non-inventory item box.\n");
-        return false;
+        return true;
     }
     
     std::shared_ptr<objects::ItemBox> destBox;
@@ -140,7 +140,7 @@ bool Parsers::ItemMove::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         /// @todo
         LOG_ERROR("Item move request sent using a non-inventory item box.\n");
-        return false;
+        return true;
     }
 
     if(nullptr != sourceBox && nullptr != destBox)

--- a/server/channel/src/packets/game/State.cpp
+++ b/server/channel/src/packets/game/State.cpp
@@ -54,12 +54,6 @@ bool Parsers::State::Parse(libcomp::ManagerPacket *pPacketManager,
     (void)p;
 
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
-    auto state = client->GetClientState();
-    if(!state->Ready())
-    {
-        return false;
-    }
-
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
 
     server->QueueWork(SendCharacterData, server, client);

--- a/server/lobby/CMakeLists.txt
+++ b/server/lobby/CMakeLists.txt
@@ -34,6 +34,7 @@ SET(${PROJECT_NAME}_SRCS
     src/LobbyClientConnection.cpp
     src/LobbyServer.cpp
     src/LoginWebHandler.cpp
+    src/ManagerClientPacket.cpp
     src/ManagerConnection.cpp
     src/SessionManager.cpp
     src/World.cpp
@@ -48,6 +49,7 @@ SET(${PROJECT_NAME}_HDRS
     src/LobbyClientConnection.h
     src/LobbyServer.h
     src/LoginWebHandler.h
+    src/ManagerClientPacket.h
     src/ManagerConnection.h
     src/SessionManager.h
     src/World.h

--- a/server/lobby/schema/clientstate.xml
+++ b/server/lobby/schema/clientstate.xml
@@ -2,6 +2,7 @@
 <objgen>
     <object name="ClientStateObject" persistent="false">
         <member type="bool" name="Authenticated"/>
+        <member type="bool" name="LoggedIn"/>
         <member type="Account*" name="Account"/>
     </object>
 </objgen>

--- a/server/lobby/src/LobbyServer.h
+++ b/server/lobby/src/LobbyServer.h
@@ -82,7 +82,7 @@ public:
      * Get a list of pointers to the connected worlds.
      * @return List of pointers to the connected worlds
      */
-    std::list<std::shared_ptr<lobby::World>> GetWorlds();
+    std::list<std::shared_ptr<lobby::World>> GetWorlds() const;
 
     /**
      * Get a world by ID.
@@ -108,6 +108,15 @@ public:
      */
     const std::shared_ptr<lobby::World> RegisterWorld(
         std::shared_ptr<lobby::World>& world);
+
+    /**
+     * Send the world list to either one or all client connections.
+     * @param connection Optional pointer to a specific connection to
+     *  send the world list to.  If not specified, all connections  will
+     *  be broadcast to instead.
+     */
+    void SendWorldList(const std::shared_ptr<
+        libcomp::TcpConnection>& connection) const;
 
     /**
      * Get the main database.

--- a/server/lobby/src/ManagerClientPacket.cpp
+++ b/server/lobby/src/ManagerClientPacket.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file server/lobby/src/ManagerClientPacket.cpp
+ * @ingroup lobby
+ *
+ * @author HACKfrost
+ *
+ * @brief Manager to handle lobby packet logic.
+ *
+ * This file is part of the Lobby Server (lobby).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ManagerClientPacket.h"
+
+// lobby Includes
+#include <LobbyClientConnection.h>
+
+// libcomp Includes
+#include <Log.h>
+#include <PacketCodes.h>
+
+using namespace lobby;
+
+ManagerClientPacket::ManagerClientPacket(std::weak_ptr<libcomp::BaseServer> server)
+    : libcomp::ManagerPacket(server)
+{
+}
+
+ManagerClientPacket::~ManagerClientPacket()
+{
+}
+
+bool ManagerClientPacket::ValidateConnectionState(const std::shared_ptr<
+    libcomp::TcpConnection>& connection, libcomp::CommandCode_t commandCode) const
+{
+    auto client = std::dynamic_pointer_cast<LobbyClientConnection>(connection);
+    auto state = client->GetClientState();
+
+    bool valid = false;
+    switch((ClientToLobbyPacketCode_t)commandCode)
+    {
+        case ClientToLobbyPacketCode_t::PACKET_LOGIN:
+            valid = true;
+            break;
+        case ClientToLobbyPacketCode_t::PACKET_AUTH:
+            if(!(valid = state->GetLoggedIn()))
+            {
+                LOG_ERROR("Client connection attempted to authenticate without logging in.\n");
+            }
+            break;
+        default:
+            if(!(valid = state->GetAuthenticated() && state->GetLoggedIn()))
+            {
+                LOG_ERROR("Client connection attempted to handle a request packet"
+                    " without authenticating and logging in first.\n");
+            }
+            break;
+    }
+
+    return valid;
+}

--- a/server/lobby/src/ManagerClientPacket.h
+++ b/server/lobby/src/ManagerClientPacket.h
@@ -1,10 +1,10 @@
 /**
- * @file server/lobby/src/packets/game/WorldList.cpp
+ * @file server/lobby/src/ManagerClientPacket.h
  * @ingroup lobby
  *
- * @author COMP Omega <compomega@tutanota.com>
+ * @author HACKfrost
  *
- * @brief Packet parser to return the lobby's world list.
+ * @brief Manager to handle lobby packet logic.
  *
  * This file is part of the Lobby Server (lobby).
  *
@@ -24,36 +24,37 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "Packets.h"
+#ifndef SERVER_LOBBY_SRC_MANAGERCLIENTPACKET_H
+#define SERVER_LOBBY_SRC_MANAGERCLIENTPACKET_H
 
 // libcomp Includes
-#include <Decrypt.h>
-#include <Log.h>
 #include <ManagerPacket.h>
-#include <Packet.h>
-#include <PacketCodes.h>
-#include <ReadOnlyPacket.h>
-#include <TcpConnection.h>
 
-// lobby Includes
-#include "LobbyServer.h"
-
-using namespace lobby;
-
-bool Parsers::WorldList::Parse(libcomp::ManagerPacket *pPacketManager,
-    const std::shared_ptr<libcomp::TcpConnection>& connection,
-    libcomp::ReadOnlyPacket& p) const
+namespace lobby
 {
-    if(p.Size() != 0)
-    {
-        return false;
-    }
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(LobbyToClientPacketCode_t::PACKET_WORLD_LIST);
+/**
+ * Manager class responsible for handling client side packets.
+ */
+class ManagerClientPacket : public libcomp::ManagerPacket
+{
+public:
+    /**
+     * Create a new manager.
+     * @param server Pointer to the server that uses this manager
+     */
+    ManagerClientPacket(std::weak_ptr<libcomp::BaseServer> server);
 
-    auto server = std::dynamic_pointer_cast<LobbyServer>(pPacketManager->GetServer());
-    server->SendWorldList(connection);
+    /**
+     * Clean up the manager.
+     */
+    virtual ~ManagerClientPacket();
 
-    return true;
-}
+protected:
+    virtual bool ValidateConnectionState(const std::shared_ptr<
+        libcomp::TcpConnection>& connection, libcomp::CommandCode_t commandCode) const;
+};
+
+} // namespace lobby
+
+#endif // SERVER_LOBBY_SRC_MANAGERCLIENTPACKET_H

--- a/server/lobby/src/ManagerConnection.cpp
+++ b/server/lobby/src/ManagerConnection.cpp
@@ -300,6 +300,8 @@ void ManagerConnection::RemoveWorld(std::shared_ptr<lobby::World>& world)
                             LOG_WARNING(libcomp::String("%1 user(s) forcefully logged out"
                                 " from world %2.\n").Arg(usernames.size()).Arg(worldID));
                         }
+
+                        lobbyServer->SendWorldList(nullptr);
                     }, server, svr->GetID());
             }
             else
@@ -326,6 +328,19 @@ const std::shared_ptr<LobbyClientConnection> ManagerConnection::GetClientConnect
 {
     auto iter = mClientConnections.find(username);
     return iter != mClientConnections.end() ? iter->second : nullptr;
+}
+
+const std::list<std::shared_ptr<libcomp::TcpConnection>>
+    ManagerConnection::GetClientConnections() const
+{
+    std::list<std::shared_ptr<libcomp::TcpConnection>> retval;
+    auto connectionCopy = mClientConnections;
+    for(auto kv : connectionCopy)
+    {
+        retval.push_back(kv.second);
+    }
+
+    return retval;
 }
 
 void ManagerConnection::SetClientConnection(const std::shared_ptr<

--- a/server/lobby/src/ManagerConnection.h
+++ b/server/lobby/src/ManagerConnection.h
@@ -132,6 +132,13 @@ public:
         const libcomp::String& username) const;
 
     /**
+     * Get all client connections.
+     * @return List of pointers to all client connections
+     */
+    const std::list<std::shared_ptr<libcomp::TcpConnection>>
+        GetClientConnections() const;
+
+    /**
      * Set an active client connection after its account has
      * been detected.
      * @param connection Pointer to the client connection

--- a/server/lobby/src/packets/game/Auth.cpp
+++ b/server/lobby/src/packets/game/Auth.cpp
@@ -90,6 +90,8 @@ static bool CompleteLogin(
         }
     }
 
+    state(connection)->SetAuthenticated(true);
+
     libcomp::Packet reply;
     reply.WritePacketCode(LobbyToClientPacketCode_t::PACKET_AUTH);
 

--- a/server/lobby/src/packets/game/Login.cpp
+++ b/server/lobby/src/packets/game/Login.cpp
@@ -108,6 +108,8 @@ bool Parsers::Login::Parse(libcomp::ManagerPacket *pPacketManager,
             ErrorCodes_t::SUCCESS));
         reply.SetChallenge(0xCAFEBABE); /// @todo generate, save, and use.
         reply.SetSalt(account->GetSalt());
+
+        state(connection)->SetLoggedIn(true);
     }
 
     return connection->SendObject(reply);

--- a/server/lobby/src/packets/internal/SetChannelInfo.cpp
+++ b/server/lobby/src/packets/internal/SetChannelInfo.cpp
@@ -89,5 +89,8 @@ bool Parsers::SetChannelInfo::Parse(libcomp::ManagerPacket *pPacketManager,
         world->RegisterChannel(svr);
     }
 
+    // Now update the world list for all connections
+    server->SendWorldList(nullptr);
+
     return true;
 }

--- a/server/lobby/src/packets/internal/SetWorldInfo.cpp
+++ b/server/lobby/src/packets/internal/SetWorldInfo.cpp
@@ -117,6 +117,9 @@ bool SetWorldInfoFromPacket(libcomp::ManagerPacket *pPacketManager,
 
     server->RegisterWorld(world);
 
+    // Now update the world list for all connections
+    server->SendWorldList(nullptr);
+
     return true;
 }
 


### PR DESCRIPTION
- MariaDB case sensitivity fixes during schema validation that should work on both Windows and Linux, as well as fix to boolean loading
- Standardizing and placing guardrails around packet parser return values
- Re-sending the world list when worlds or channels are updated on the lobby
- Adjusting world clock accuracy to match the old server timestamp for a new moon (after realizing http://www.digitaldevildb.com/tokei.html slips by 2 game seconds per day)

Fixes #187 
Fixes #192