### PR TITLE
Friends, parties and general world level character communication

### DIFF
--- a/libcomp/CMakeLists.txt
+++ b/libcomp/CMakeLists.txt
@@ -207,6 +207,7 @@ SET(${PROJECT_NAME}_SCHEMA
     schema/packet_login.xml
     schema/packet_login_reply.xml
     schema/packet_response_code.xml
+    schema/partymember.xml
     schema/registeredchannel.xml
     schema/registeredworld.xml
     schema/server_npc.xml
@@ -260,6 +261,8 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     ActionZoneChange.cpp
     Character.h
     Character.cpp
+    CharacterLogin.h
+    CharacterLogin.cpp
     CharacterProgress.h
     CharacterProgress.cpp
     DatabaseConfig.h
@@ -312,6 +315,8 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     EventStageEffect.cpp
     Expertise.h
     Expertise.cpp
+    FriendSettings.h
+    FriendSettings.cpp
     Hotbar.h
     Hotbar.cpp
     InheritedSkill.h
@@ -326,6 +331,10 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     PacketLoginReply.cpp
     PacketResponseCode.h
     PacketResponseCode.cpp
+    PartyCharacter.h
+    PartyCharacter.cpp
+    PartyMember.h
+    PartyMember.cpp
     Quest.h
     Quest.cpp
     RegisteredChannel.h

--- a/libcomp/schema/accountlogin.xml
+++ b/libcomp/schema/accountlogin.xml
@@ -2,10 +2,22 @@
 <objgen>
     <object name="AccountLogin" persistent="false">
         <member type="Account*" name="Account"/>
-        <member type="u8" name="CID" max="19"/>
-        <member type="s8" name="WorldID" default="-1"/>
-        <member type="s8" name="ChannelID" default="-1"/>
+        <member type="CharacterLogin*" name="CharacterLogin"/>
         <member type="string" name="SessionID" size="300"/>
         <member type="u32" name="SessionKey"/>
+    </object>
+    <object name="CharacterLogin" persistent="false">
+        <member type="s32" name="WorldCID"/>
+        <member type="Character*" name="Character"/>
+        <member type="s8" name="WorldID" default="-1"/>
+        <member type="s8" name="ChannelID" default="-1"/>
+        <member type="u32" name="ZoneID"/>
+        <member type="u32" name="PartyID"/>
+        <member type="enum" name="Status" underlying="int8_t">
+            <value num="0">OFFLINE</value>
+            <value num="1">AWAY</value>
+            <value num="2">BUSY</value>
+            <value num="3">ONLINE</value>
+        </member>
     </object>
 </objgen>

--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -63,6 +63,7 @@
         <!-- Sub-sections -->
         <member type="EntityStats*" name="CoreStats"/>
         <member type="CharacterProgress*" name="Progress"/>
+        <member type="FriendSettings*" name="FriendSettings"/>
     </object>
     <object name="EntityStats" location="world">
         <member type="ref" name="Entity" key="true" unique="true"/>
@@ -136,5 +137,13 @@
         <member type="array" name="CustomData" size="8">
             <element type="s32"/>
         </member>
+    </object>
+    <object name="FriendSettings" location="world">
+        <member type="Character*" name="Character" key="true" unique="true"/>
+        <member type="string" name="FriendMessage"/>
+        <member type="list" name="Friends">
+            <element type="ref"/>
+        </member>
+        <member type="bool" name="PublicToZone" default="true"/>
     </object>
 </objgen>

--- a/libcomp/schema/master.xml
+++ b/libcomp/schema/master.xml
@@ -29,6 +29,7 @@
     <include path="event_prompt.xml"/>
     <include path="event_stageeffect.xml"/>
     <include path="item.xml"/>
+    <include path="partymember.xml"/>
     <include path="registeredchannel.xml"/>
     <include path="registeredworld.xml"/>
 

--- a/libcomp/schema/partymember.xml
+++ b/libcomp/schema/partymember.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <object name="PartyMember" persistent="false">
+        <member type="u32" name="DemonType"/>
+        <member type="u16" name="HP"/>
+        <member type="u16" name="MaxHP"/>
+        <member type="u16" name="MP"/>
+        <member type="u16" name="MaxMP"/>
+    </object>
+    <object name="PartyCharacter" baseobject="PartyMember" persistent="false">
+        <member type="s32" name="WorldCID"/>
+        <member type="string" name="Name"/>
+        <member type="u8" name="Level"/>
+        <member type="PartyMember*" name="Demon"/>
+    </object>
+</objgen>

--- a/libcomp/src/Convert.cpp
+++ b/libcomp/src/Convert.cpp
@@ -305,7 +305,7 @@ String Convert::FromEncoding(Encoding_t encoding,
 
 String Convert::FromEncoding(Encoding_t encoding, const std::vector<char>& str)
 {
-    return FromEncoding(encoding, &str[0], (int)str.size());
+    return str.size() > 0 ? FromEncoding(encoding, &str[0], (int)str.size()) : String();
 }
 
 std::vector<char> Convert::ToEncoding(Encoding_t encoding, const String& str,

--- a/libcomp/src/DatabaseMariaDB.cpp
+++ b/libcomp/src/DatabaseMariaDB.cpp
@@ -196,7 +196,7 @@ std::list<std::shared_ptr<PersistentObject>> DatabaseMariaDB::LoadObjects(
     String sql = String("SELECT * FROM `%1`%2").Arg(
         metaObject->GetName()).Arg(
         (nullptr != pValue
-            ? String(" WHERE %1 = :%1").Arg(pValue->GetColumn())
+            ? String(" WHERE `%1` = :%1").Arg(pValue->GetColumn())
             : ""));
 
     DatabaseQuery query = Prepare(sql);

--- a/libcomp/src/ObjectReference.h
+++ b/libcomp/src/ObjectReference.h
@@ -211,7 +211,10 @@ public:
      */
     bool SetUUID(const libobjgen::UUID& uuid)
     {
-        SetReference(uuid);
+        if(mData->mUUID != uuid)
+        {
+            SetReference(uuid);
+        }
         return true;
     }
 

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -114,7 +114,20 @@ enum class ClientToChannelPacketCode_t : uint16_t
     PACKET_EVENT_RESPONSE = 0x00B7,  //!< Message that the player has responded to the current event.
     PACKET_VALUABLE_LIST = 0x00B8,  //!< Request for a list of obtained valuables.
     PACKET_OBJECT_INTERACTION = 0x00BA,  //!< An object has been clicked on.
-    PACKET_FRIEND_INFO = 0x00BD,  //!< Request for the current player's friend information.
+    PACKET_FRIEND_INFO = 0x00BD,  //!< Request for the current player's own friend information.
+    PACKET_FRIEND_REQUEST = 0x00C0,  //!< Request to ask a player to be added to the player's friend list.
+    PACKET_FRIEND_ADD = 0x00C3,  //!< Request to add the player and the requestor to both friend lists.
+    PACKET_FRIEND_REMOVE = 0x00C4,  //!< Request to remove the player and the target from both friend lists.
+    PACKET_FRIEND_DATA = 0x00C6,  //!< Request to update friend list specific data for the player.
+    PACKET_PARTY_INVITE = 0x00D2,  //!< Request to invite a player to join the player's party.
+    PACKET_PARTY_JOIN = 0x00D5,  //!< Request to join a party from which an invite was received.
+    PACKET_PARTY_CANCEL = 0x00D8,  //!< Request to cancel a party invite.
+    PACKET_PARTY_LEAVE = 0x00DA,  //!< Request to leave the player's current party.
+    PACKET_PARTY_DISBAND = 0x00DD,  //!< Request to disband the current party.
+    PACKET_PARTY_LEADER_UPDATE = 0x00E0,  //!< Request to update the current party's designated leader.
+    PACKET_PARTY_DROP_RULE = 0x00E3,  //!< Request to update the current party's drop rule setting.
+    PACKET_PARTY_MEMBER_UPDATE = 0x00E6,  //!< Response signifying whether a party member update was received correctly.
+    PACKET_PARTY_KICK = 0x00EB,  //!< Request to kick a player from the current party.
     PACKET_SYNC = 0x00F3,  //!< Request to retrieve the server time.
     PACKET_ROTATE = 0x00F8,  //!< Request to rotate an entity or object.
     PACKET_UNION_FLAG = 0x0100,  //!< Request to receive union information.
@@ -224,7 +237,30 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_EVENT_OPEN_MENU = 0x00AE,  //!< Request to the client to open a menu.
     PACKET_VALUABLE_LIST = 0x00B9,  //!< Response containing a list of obtained valuables.
     PACKET_EVENT_END = 0x00BB,  //!< Request to the client to end the current event.
-    PACKET_FRIEND_INFO = 0x00BE,  //!< Response containing the current player's friend information.
+    PACKET_FRIEND_INFO_SELF = 0x00BE,  //!< Response containing the current player's own friend information.
+    PACKET_FRIEND_INFO = 0x00BF,  //!< Message containing information about a friend on the friends list.
+    PACKET_FRIEND_REQUEST = 0x00C1,    //!< Response from a player to be added to the player's friend list.
+    PACKET_FRIEND_REQUESTED = 0x00C2,  //!< Notification that a friend request has been received.
+    PACKET_FRIEND_ADD_REMOVE = 0x00C5,  //!< Response to the client stating that a friend was added or removed.
+    PACKET_FRIEND_DATA = 0x00C7,  //!< Notification to update friend list specific data from a player.
+    PACKET_PARTY_INVITE = 0x00D3,  //!< Response to the request to invite a player to join the player's party.
+    PACKET_PARTY_INVITED = 0x00D4,  //!< Notification that a party invite has been received.
+    PACKET_PARTY_JOIN = 0x00D6,  //!< Response to the request to join a party.
+    PACKET_PARTY_MEMBER_INFO = 0x00D7,  //!< Message containing information about a party member.
+    PACKET_PARTY_CANCEL = 0x00D9,  //!< Response to the request to cancel a party invite.
+    PACKET_PARTY_LEAVE = 0x00DB,  //!< Response to the request to leave the player's current party.
+    PACKET_PARTY_LEFT = 0x00DC,  //!< Notification that a player has left the current party.
+    PACKET_PARTY_DISBAND = 0x00DE,  //!< Response to the request to disband the current party.
+    PACKET_PARTY_DISBANDED = 0x00DF,  //!< Notification that the current party has been disbanded.
+    PACKET_PARTY_LEADER_UPDATE = 0x00E1,  //!< Response to the request to update the current party's designated leader.
+    PACKET_PARTY_LEADER_UPDATED = 0x00E2,  //!< Notification that the current party's designated leader has changed.
+    PACKET_PARTY_DROP_RULE = 0x00E4,  //!< Response to the request to update the current party's drop rule setting.
+    PACKET_PARTY_DROP_RULE_SET = 0x00E5,  //!< Notification that the current party's drop rule has been changed.
+    PACKET_PARTY_MEMBER_UPDATE = 0x00E7,  //!< Notification containing a player character's info in the current party.
+    PACKET_PARTY_MEMBER_PARTNER = 0x00E8,  //!< Notification containing a parter demon's info in the current party.
+    PACKET_PARTY_MEMBER_ZONE = 0x00E9,  //!< Notification that a current party member has moved to a different zone.
+    PACKET_PARTY_MEMBER_ICON = 0x00EA,  //!< Notification that a current party member's icon state has changed.
+    PACKET_PARTY_KICK = 0x00EC,  //!< Notification that a player has been kicked from the current party.
     PACKET_SYNC = 0x00F4,  //!< Response containing the server time.
     PACKET_ROTATE = 0x00F9,    //!< Message containing entity or object rotation information.
     PACKET_RUN_SPEED = 0x00FB,    //!< Message containing an entity's updated running speed.
@@ -279,6 +315,9 @@ enum class InternalPacketCode_t : uint16_t
     PACKET_SET_CHANNEL_INFO = 0x1003,    //!< Request to update a server's channel information.
     PACKET_ACCOUNT_LOGIN = 0x1004,    //!< Pass login information between the servers.
     PACKET_ACCOUNT_LOGOUT = 0x1005,    //!< Pass logout information between the servers.
+    PACKET_CHARACTER_LOGIN = 0x1007,    //!< Pass character login information between the servers.
+    PACKET_FRIENDS_UPDATE = 0x1008,    //!< Pass friend information between the servers.
+    PACKET_PARTY_UPDATE = 0x1009,    //!< Pass party information between the servers.
 };
 
 /**
@@ -286,9 +325,39 @@ enum class InternalPacketCode_t : uint16_t
  */
 enum class InternalPacketAction_t : uint8_t
 {
-    PACKET_ACTION_ADD = 1,  //!< Packet action is an addition.
-    PACKET_ACTION_UPDATE,   //!< Packet action is an update.
-    PACKET_ACTION_REMOVE,   //!< Pacekt action is a removal.
+    PACKET_ACTION_ADD = 1,  //!< Indicates a contextual addition.
+    PACKET_ACTION_UPDATE,   //!< Indicates a contextual update.
+    PACKET_ACTION_REMOVE,   //!< Indicates a contextual removal.
+    PACKET_ACTION_YN_REQUEST,   //!< Indicates a contextual Yes/No request.
+    PACKET_ACTION_RESPONSE_YES, //!< Indicates a contextual "Yes" response.
+    PACKET_ACTION_RESPONSE_NO,  //!< Indicates a contextual "No" response.
+
+    PACKET_ACTION_FRIEND_LIST,  //!< Indicates that a friend list is being requested or sent.
+
+    PACKET_ACTION_PARTY_LEAVE,  //!< Indicates that a party update consists of "leave" information.
+    PACKET_ACTION_PARTY_DISBAND,    //!< Indicates that a party update consists of "disband" information.
+    PACKET_ACTION_PARTY_LEADER_UPDATE,  //!< Indicates that a party update consists of "leader update" information.
+    PACKET_ACTION_PARTY_DROP_RULE,  //!< Indicates that a party update consists of "drop rule" information.
+    PACKET_ACTION_PARTY_KICK,   //!< Indicates that a party update consists of "kick" information.
+};
+
+/**
+ * Flags used to indicate the type of information being sent in a PACKET_CHARACTER_LOGIN message.  Data
+ * signified to have been added to the packet should be written from lowest to highest value listed here.
+ */
+enum class CharacterLoginStateFlag_t : uint8_t
+{
+    CHARLOGIN_STATUS = 0x01,  //!< Indicates that a player's active status is contained in a packet.
+    CHARLOGIN_ZONE = 0x02,   //!< Indicates that a character's zone is contained in a packet.
+    CHARLOGIN_CHANNEL = 0x04,  //!< Indicates that a character's channel is contained in a packet.
+    CHARLOGIN_BASIC = 0x07,  //!< Indicates that basic information about a character is contained in a packet.
+    CHARLOGIN_FRIEND_MESSAGE = 0x08,  //!< Indicates that a character's friend message is contained in a packet.
+    CHARLOGIN_FRIEND_UNKNOWN = 0x10,  //!< Unknown. Indicates that some friend information is being sent.
+    CHARLOGIN_FRIEND_FLAGS = 0x1F,  //!< Indicates that one or many friend related pieces of data are contained in a packet.
+    CHARLOGIN_PARTY_INFO = 0x20,  //!< Indicates that player character party information is contained in a packet.
+    CHARLOGIN_PARTY_DEMON_INFO = 0x40,  //!< Indicates that partner demon party information is contained in a packet.
+    CHARLOGIN_PARTY_ICON = 0x80,  //!< Indicates that party icon information is contained in a packet.
+    CHARLOGIN_PARTY_FLAGS = 0xE2,  //!< Indicates that one or many party related pieces of data are contained in a packet.
 };
 
 /**

--- a/libcomp/src/PersistentObject.cpp
+++ b/libcomp/src/PersistentObject.cpp
@@ -42,6 +42,7 @@
 #include "DemonBox.h"
 #include "EntityStats.h"
 #include "Expertise.h"
+#include "FriendSettings.h"
 #include "Hotbar.h"
 #include "InheritedSkill.h"
 #include "Item.h"
@@ -337,6 +338,9 @@ bool PersistentObject::Initialize()
 
     RegisterType(typeid(objects::Expertise), objects::Expertise::GetMetadata(),
         []() {  return (PersistentObject*)new objects::Expertise(); });
+
+    RegisterType(typeid(objects::FriendSettings), objects::FriendSettings::GetMetadata(),
+        []() {  return (PersistentObject*)new objects::FriendSettings(); });
 
     RegisterType(typeid(objects::Hotbar), objects::Hotbar::GetMetadata(),
         []() {  return (PersistentObject*)new objects::Hotbar(); });

--- a/libcomp/src/PersistentObject.h
+++ b/libcomp/src/PersistentObject.h
@@ -247,13 +247,19 @@ public:
 
     /**
      * Create a new instance of a PersistentObject of the specified type.
+     * @param doRegister Register the pointer automatically on success.
      * @return Pointer to a new PersistentObject of the specified type
      */
-    template<class T> static std::shared_ptr<T> New()
+    template<class T> static std::shared_ptr<T> New(bool doRegister = false)
     {
         if(std::is_base_of<PersistentObject, T>::value)
         {
-            return std::dynamic_pointer_cast<T>(New(typeid(T).hash_code()));
+            auto result = std::dynamic_pointer_cast<T>(New(typeid(T).hash_code()));
+            if(doRegister)
+            {
+                result->Register(result);
+            }
+            return result;
         }
 
         return nullptr;

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -167,6 +167,17 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/game/ValuableList.cpp           # 0x00B8
     src/packets/game/ObjectInteraction.cpp      # 0x00BA
     src/packets/game/FriendInfo.cpp             # 0x00BD
+    src/packets/game/FriendRequest              # 0x00C0
+    src/packets/game/FriendAddRemove            # 0x00C3
+    src/packets/game/FriendData                 # 0x00C6
+    src/packets/game/PartyInvite                # 0x00D2
+    src/packets/game/PartyJoin                  # 0x00D5
+    src/packets/game/PartyCancel                # 0x00D8
+    src/packets/game/PartyLeave                 # 0x00DA
+    src/packets/game/PartyDisband               # 0x00DD
+    src/packets/game/PartyLeaderUpdate          # 0x00E0
+    src/packets/game/PartyDropRule              # 0x00E3
+    src/packets/game/PartyKick                  # 0x00EB
     src/packets/game/Sync.cpp                   # 0x00F3
     src/packets/game/Rotate.cpp                 # 0x00F8
     src/packets/game/UnionFlag.cpp              # 0x0100
@@ -202,6 +213,9 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/internal/SetWorldInfo.cpp          # 0x1002
     src/packets/internal/SetOtherChannelInfo.cpp   # 0x1003
     src/packets/internal/AccountLogin.cpp          # 0x1004
+    src/packets/internal/CharacterLogin.cpp        # 0x1007
+    src/packets/internal/FriendsUpdate.cpp         # 0x1008
+    src/packets/internal/PartyUpdate.cpp           # 0x1009
 )
 
 ADD_EXECUTABLE(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS}

--- a/server/channel/schema/clientstate.xml
+++ b/server/channel/schema/clientstate.xml
@@ -9,6 +9,7 @@
         <member type="EventState*" name="EventState"/>
         <member type="TradeSession*" name="TradeSession"/>
         <member type="s8" name="StatusIcon"/>
+        <member type="u32" name="PartyID"/>
     </object>
     <object name="EventState" persistent="false">
         <member type="EventInstance*" name="Current"/>

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -84,6 +84,12 @@ bool ChannelServer::Initialize()
         to_underlying(InternalPacketCode_t::PACKET_SET_CHANNEL_INFO));
     internalPacketManager->AddParser<Parsers::AccountLogin>(
         to_underlying(InternalPacketCode_t::PACKET_ACCOUNT_LOGIN));
+    internalPacketManager->AddParser<Parsers::CharacterLogin>(
+        to_underlying(InternalPacketCode_t::PACKET_CHARACTER_LOGIN));
+    internalPacketManager->AddParser<Parsers::FriendsUpdate>(
+        to_underlying(InternalPacketCode_t::PACKET_FRIENDS_UPDATE));
+    internalPacketManager->AddParser<Parsers::PartyUpdate>(
+        to_underlying(InternalPacketCode_t::PACKET_PARTY_UPDATE));
 
     //Add the managers to the main worker.
     mMainWorker.AddManager(internalPacketManager);
@@ -189,6 +195,30 @@ bool ChannelServer::Initialize()
         to_underlying(ClientToChannelPacketCode_t::PACKET_OBJECT_INTERACTION));
     clientPacketManager->AddParser<Parsers::FriendInfo>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_FRIEND_INFO));
+    clientPacketManager->AddParser<Parsers::FriendRequest>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_FRIEND_REQUEST));
+    clientPacketManager->AddParser<Parsers::FriendAddRemove>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_FRIEND_ADD));
+    clientPacketManager->AddParser<Parsers::FriendAddRemove>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_FRIEND_REMOVE));
+    clientPacketManager->AddParser<Parsers::FriendData>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_FRIEND_DATA));
+    clientPacketManager->AddParser<Parsers::PartyInvite>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_INVITE));
+    clientPacketManager->AddParser<Parsers::PartyJoin>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_JOIN));
+    clientPacketManager->AddParser<Parsers::PartyCancel>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_CANCEL));
+    clientPacketManager->AddParser<Parsers::PartyLeave>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_LEAVE));
+    clientPacketManager->AddParser<Parsers::PartyDisband>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_DISBAND));
+    clientPacketManager->AddParser<Parsers::PartyLeaderUpdate>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_LEADER_UPDATE));
+    clientPacketManager->AddParser<Parsers::PartyDropRule>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_DROP_RULE));
+    clientPacketManager->AddParser<Parsers::PartyKick>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_KICK));
     clientPacketManager->AddParser<Parsers::Sync>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_SYNC));
     clientPacketManager->AddParser<Parsers::Rotate>(
@@ -252,6 +282,8 @@ bool ChannelServer::Initialize()
 
     // Map the Unsupported packet parser to unsupported packets or packets that
     // the server does not need to react to
+    clientPacketManager->AddParser<Parsers::Unsupported>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_PARTY_MEMBER_UPDATE));
     clientPacketManager->AddParser<Parsers::Unsupported>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_UNSUPPORTED_0232));
     clientPacketManager->AddParser<Parsers::Unsupported>(

--- a/server/channel/src/CharacterManager.h
+++ b/server/channel/src/CharacterManager.h
@@ -129,17 +129,25 @@ public:
      * @param client Pointer to the client connection containing
      *  the character
      * @param demonID ID of the demon to summon
+     * @param updatePartyState true if the world should be updated
+     *  with the character's new party state, false if it will be updated
+     *  later
      */
     void SummonDemon(const std::shared_ptr<
-        channel::ChannelClientConnection>& client, int64_t demonID);
+        channel::ChannelClientConnection>& client, int64_t demonID,
+        bool updatePartyState = true);
 
     /**
      * Return the current demon of the client's character to the COMP.
      * @param client Pointer to the client connection containing
      *  the character
+     * @param updatePartyState true if the world should be updated
+     *  with the character's new party state, false if it will be updated
+     *  later
      */
     void StoreDemon(const std::shared_ptr<
-        channel::ChannelClientConnection>& client);
+        channel::ChannelClientConnection>& client,
+        bool updatePartyState = true);
 
     /**
      * Send information about the specified demon box to the client.

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -29,12 +29,21 @@
 // Standard C++11 Includes
 #include <ctime>
 
+// libcomp Includes
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <AccountLogin.h>
+#include <CharacterLogin.h>
+
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-std::unordered_map<int32_t, ClientState*> ClientState::sEntityClients;
+std::unordered_map<bool,
+    std::unordered_map<int32_t, ClientState*>> ClientState::sEntityClients;
 std::mutex ClientState::sLock;
 
 ClientState::ClientState() : objects::ClientStateObject(),
@@ -48,11 +57,13 @@ ClientState::~ClientState()
 {
     auto cEntityID = mCharacterState->GetEntityID();
     auto dEntityID = mDemonState->GetEntityID();
+    auto worldCID = GetAccountLogin()->GetCharacterLogin()->GetWorldCID();
     if(cEntityID != 0 || dEntityID != 0)
     {
         std::lock_guard<std::mutex> lock(sLock);
-        sEntityClients.erase(cEntityID);
-        sEntityClients.erase(dEntityID);
+        sEntityClients[false].erase(cEntityID);
+        sEntityClients[false].erase(dEntityID);
+        sEntityClients[true].erase(worldCID);
     }
 }
 
@@ -90,20 +101,22 @@ bool ClientState::Register()
 {
     auto cEntityID = mCharacterState->GetEntityID();
     auto dEntityID = mDemonState->GetEntityID();
-    if(cEntityID == 0 || dEntityID == 0)
+    auto worldCID = GetAccountLogin()->GetCharacterLogin()->GetWorldCID();
+    if(cEntityID == 0 || dEntityID == 0 || worldCID == 0)
     {
         return false;
     }
 
     std::lock_guard<std::mutex> lock(sLock);
-    if(sEntityClients.find(cEntityID) != sEntityClients.end() ||
-        sEntityClients.find(dEntityID) != sEntityClients.end())
+    if(sEntityClients[false].find(cEntityID) != sEntityClients[false].end() ||
+        sEntityClients[false].find(dEntityID) != sEntityClients[false].end())
     {
         return false;
     }
 
-    sEntityClients[cEntityID] = this;
-    sEntityClients[dEntityID] = this;
+    sEntityClients[false][cEntityID] = this;
+    sEntityClients[false][dEntityID] = this;
+    sEntityClients[true][worldCID] = this;
 
     return true;
 }
@@ -167,6 +180,65 @@ const libobjgen::UUID ClientState::GetAccountUID() const
         mCharacterState->GetEntity()->GetAccount().GetUUID() : NULLUUID;
 }
 
+std::shared_ptr<objects::PartyCharacter> ClientState::GetPartyCharacter(
+    bool includeDemon) const
+{
+    auto character = mCharacterState->GetEntity();
+    auto cStats = character->GetCoreStats();
+
+    auto member = std::make_shared<objects::PartyCharacter>();
+    member->SetWorldCID(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    member->SetName(character->GetName());
+    member->SetLevel((uint8_t)cStats->GetLevel());
+    member->SetHP((uint16_t)cStats->GetHP());
+    member->SetMaxHP((uint16_t)mCharacterState->GetMaxHP());
+    member->SetMP((uint16_t)cStats->GetMP());
+    member->SetMaxMP((uint16_t)mCharacterState->GetMaxMP());
+    if(includeDemon)
+    {
+        member->SetDemon(GetPartyDemon());
+    }
+    else
+    {
+        member->SetDemon(nullptr);
+    }
+
+    return member;
+}
+
+std::shared_ptr<objects::PartyMember> ClientState::GetPartyDemon() const
+{
+    auto demon = mDemonState->GetEntity();
+
+    auto dMember = std::make_shared<objects::PartyMember>();
+    if(demon)
+    {
+        auto dStats = demon->GetCoreStats();
+        dMember->SetDemonType(demon->GetType());
+        dMember->SetHP((uint16_t)dStats->GetHP());
+        dMember->SetMaxHP((uint16_t)mDemonState->GetMaxHP());
+        dMember->SetMP((uint16_t)dStats->GetMP());
+        dMember->SetMaxMP((uint16_t)mDemonState->GetMaxMP());
+    }
+    return dMember;
+}
+
+void ClientState::GetPartyCharacterPacket(libcomp::Packet& p) const
+{
+    p.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
+    p.WriteS32Little(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    p.WriteU8((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO);
+    GetPartyCharacter(false)->SavePacket(p, true);
+}
+
+void ClientState::GetPartyDemonPacket(libcomp::Packet& p) const
+{
+    p.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
+    p.WriteS32Little(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    p.WriteU8((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO);
+    GetPartyDemon()->SavePacket(p, true);
+}
+
 void ClientState::SyncReceived()
 {
     if(mStartTime == 0)
@@ -190,9 +262,10 @@ ServerTime ClientState::ToServerTime(ClientTime time) const
     return static_cast<ServerTime>(((ServerTime)time * 1000000) + mStartTime);
 }
 
-ClientState* ClientState::GetEntityClientState(int32_t entityID)
+ClientState* ClientState::GetEntityClientState(int32_t id, bool worldID)
 {
     std::lock_guard<std::mutex> lock(sLock);
-    auto it = sEntityClients.find(entityID);
-    return it != sEntityClients.end() ? it->second : nullptr;
+    std::unordered_map<int32_t, ClientState*>& m = sEntityClients[worldID];
+    auto it = m.find(id);
+    return it != m.end() ? it->second : nullptr;
 }

--- a/server/channel/src/ClientState.h
+++ b/server/channel/src/ClientState.h
@@ -34,6 +34,12 @@
 #include <Character.h>
 #include <ClientStateObject.h>
 #include <Demon.h>
+#include <PartyCharacter.h>
+
+namespace libcomp
+{
+class Packet;
+}
 
 namespace channel
 {
@@ -134,6 +140,37 @@ public:
     const libobjgen::UUID GetAccountUID() const;
 
     /**
+     * Get a current party character representation from the
+     *.associated CharacterState.
+     * @param includeDemon true if the demon state is set
+     *  on the member variable of the party character
+     * @return Pointer to a party character representation
+     */
+    std::shared_ptr<objects::PartyCharacter> GetPartyCharacter(
+        bool includeDemon) const;
+
+    /**
+     * Get a current party demon representation from the
+     * associated DemonState.
+     * @return Pointer to a party demon representation
+     */
+    std::shared_ptr<objects::PartyMember> GetPartyDemon() const;
+
+    /**
+     * Populate the supplied packet with an internal CharacterLogin
+     * packet containing character information.
+     * @param p Packet to populate
+     */
+    void GetPartyCharacterPacket(libcomp::Packet& p) const;
+
+    /**
+     * Populate the supplied packet with an internal CharacterLogin
+     * packet containing partner demon information.
+     * @param p Packet to populate
+     */
+    void GetPartyDemonPacket(libcomp::Packet& p) const;
+
+    /**
      * Handle any actions needed when the game client pings the
      * server with a sync request.  If the start time has not been
      * set, it will be set here.
@@ -158,15 +195,21 @@ public:
 
     /**
      * Get the client state associated to the supplied entity ID.
-     * @param entityID Entity ID associated to the client state to retrieve
-     * @return Pointer to the client state associated to the entity ID or
+     * @param id Entity ID or world ID associated to the client
+     *  state to retrieve
+     * @param worldID true if the ID is from the world, false if it is a
+     *  local entity ID
+     * @return Pointer to the client state associated to the ID or
      *  nullptr if it does not exist
      */
-    static ClientState* GetEntityClientState(int32_t entityID);
+    static ClientState* GetEntityClientState(int32_t id,
+        bool worldID = false);
 
 private:
-    /// Static registry of all client states by entity IDs associated
-    static std::unordered_map<int32_t, ClientState*> sEntityClients;
+    /// Static registry of all client states sorted as world (true) or
+    /// local entity IDs (false) and their respective IDs
+    static std::unordered_map<bool,
+        std::unordered_map<int32_t, ClientState*>> sEntityClients;
 
     /// Static lock for shared static resources
     static std::mutex sLock;

--- a/server/channel/src/Packets.h
+++ b/server/channel/src/Packets.h
@@ -84,6 +84,17 @@ PACKET_PARSER_DECL(EventResponse);          // 0x00B7
 PACKET_PARSER_DECL(ValuableList);           // 0x00B8
 PACKET_PARSER_DECL(ObjectInteraction);      // 0x00BA
 PACKET_PARSER_DECL(FriendInfo);             // 0x00BD
+PACKET_PARSER_DECL(FriendRequest);          // 0x00C0
+PACKET_PARSER_DECL(FriendAddRemove);        // 0x00C3
+PACKET_PARSER_DECL(FriendData);             // 0x00C6
+PACKET_PARSER_DECL(PartyInvite);            // 0x00D2
+PACKET_PARSER_DECL(PartyJoin);              // 0x00D5
+PACKET_PARSER_DECL(PartyCancel);            // 0x00D8
+PACKET_PARSER_DECL(PartyLeave);             // 0x00DA
+PACKET_PARSER_DECL(PartyDisband);           // 0x00DD
+PACKET_PARSER_DECL(PartyLeaderUpdate);      // 0x00E0
+PACKET_PARSER_DECL(PartyDropRule);          // 0x00E3
+PACKET_PARSER_DECL(PartyKick);              // 0x00EB
 PACKET_PARSER_DECL(Sync);                   // 0x00F3
 PACKET_PARSER_DECL(Rotate);                 // 0x00F8
 PACKET_PARSER_DECL(UnionFlag);              // 0x0100
@@ -118,6 +129,9 @@ PACKET_PARSER_DECL(DigitalizeAssist);       // 0x0418
 PACKET_PARSER_DECL(SetWorldInfo);        // 0x1002
 PACKET_PARSER_DECL(SetOtherChannelInfo); // 0x1003
 PACKET_PARSER_DECL(AccountLogin);        // 0x1004
+PACKET_PARSER_DECL(CharacterLogin);      // 0x1007
+PACKET_PARSER_DECL(FriendsUpdate);       // 0x1008
+PACKET_PARSER_DECL(PartyUpdate);         // 0x1009
 
 } // namespace Parsers
 

--- a/server/channel/src/packets/game/FriendAddRemove.cpp
+++ b/server/channel/src/packets/game/FriendAddRemove.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file server/channel/src/packets/game/FriendAddRemove.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Request from the client to add or remove a friend.  Since packet
+ *  sizes for this differ, this parser handles both functions.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// objects Includes
+#include <AccountLogin.h>
+#include <CharacterLogin.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+bool Parsers::FriendAddRemove::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 4)
+    {
+        return false;
+    }
+
+    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+    auto state = client->GetClientState();
+
+    bool add = p.Size() > 4;
+    if(add)
+    {
+        if(p.Size() != (uint32_t)(p.PeekU16Little() + 6))
+        {
+            return false;
+        }
+
+        libcomp::String targetName = p.ReadString16Little(
+            libcomp::Convert::Encoding_t::ENCODING_CP932, true);
+
+        // 0 = Accepted/add, 1 = rejected
+        int32_t mode = p.ReadS32Little();
+
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+        request.WriteU8(mode == 0
+            ? (int8_t)InternalPacketAction_t::PACKET_ACTION_ADD
+            : (int8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO);
+        request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+            ->GetWorldCID());
+        request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+            state->GetCharacterState()->GetEntity()->GetName(), true);
+        request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+            targetName, true);
+
+        server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
+    }
+    else
+    {
+        int32_t worldCID = p.ReadS32Little();
+
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+        request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_REMOVE);
+        request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+            ->GetWorldCID());
+        request.WriteS32Little(worldCID);
+
+        server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
+    }
+
+    return true;
+}

--- a/server/channel/src/packets/game/FriendData.cpp
+++ b/server/channel/src/packets/game/FriendData.cpp
@@ -1,0 +1,133 @@
+/**
+ * @file server/channel/src/packets/game/FriendData.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Request from the client to update friend list related data.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// objects Includes
+#include <AccountLogin.h>
+#include <CharacterLogin.h>
+#include <FriendSettings.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+bool Parsers::FriendData::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 2)
+    {
+        return false;
+    }
+
+    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+    auto state = client->GetClientState();
+    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
+    auto character = cLogin->GetCharacter().Get();
+    auto fSettings = character->GetFriendSettings().Get();
+
+    int8_t updateFlags = p.ReadS8();
+    
+    if(updateFlags & 0x01)
+    {
+        if(p.Left() < 1)
+        {
+            return false;
+        }
+
+        int8_t status = p.ReadS8();
+        cLogin->SetStatus((objects::CharacterLogin::Status_t)status);
+    }
+    
+    if(updateFlags & 0x02)
+    {
+        if(p.Left() < 2 || (p.Left() < (uint32_t)(2 + p.PeekU16Little())))
+        {
+            return false;
+        }
+
+        libcomp::String message = p.ReadString16Little(
+            libcomp::Convert::Encoding_t::ENCODING_CP932, true);
+        fSettings->SetFriendMessage(message);
+    }
+    
+    if(updateFlags & 0x04)
+    {
+        if(p.Left() < 2)
+        {
+            return false;
+        }
+
+        // Updates to zone privacy only affect local so no need to send out
+        int8_t privacySet = p.ReadS8();
+        int8_t publicToZone = p.ReadS8();
+        (void)privacySet;
+
+        fSettings->SetPublicToZone(publicToZone == 1);
+    }
+
+    fSettings->Update(server->GetWorldDatabase());
+
+    if(updateFlags != 0x04)
+    {
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
+        request.WriteS32Little(cLogin->GetWorldCID());
+
+        // Set empty flags for now
+        request.WriteU8(0);
+
+        uint8_t charLoginFlags = 0;
+        if(updateFlags & 0x01)
+        {
+            request.WriteS8((int8_t)cLogin->GetStatus());
+            charLoginFlags = (uint8_t)(charLoginFlags |
+                (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_STATUS);
+        }
+    
+        if(updateFlags & 0x02)
+        {
+            charLoginFlags = (uint8_t)(charLoginFlags |
+                (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_MESSAGE);
+        }
+
+        // Rewind and set the flags
+        request.Seek(6);
+        request.WriteU8(charLoginFlags);
+
+        server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
+    }
+
+    return true;
+}

--- a/server/channel/src/packets/game/FriendRequest.cpp
+++ b/server/channel/src/packets/game/FriendRequest.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/FriendRequest.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to add a player as a friend.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,54 +31,57 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::FriendRequest::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() < 2 || (p.Size() != (uint32_t)(2 + p.PeekU16Little())))
     {
         return false;
     }
 
+    libcomp::String targetName = p.ReadString16Little(
+        libcomp::Convert::Encoding_t::ENCODING_CP932, true);
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
     auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
+    auto worldDB = server->GetWorldDatabase();
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
+    auto target = objects::Character::LoadCharacterByName(worldDB, targetName);
+    if(target && target != character)
+    {
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+        request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_YN_REQUEST);
+        request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+            ->GetWorldCID());
+        request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+            character->GetName(), true);
+        request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+            targetName, true);
 
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
-    libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
-
-    server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
+        server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
+    }
+    else
+    {
+        libcomp::Packet reply;
+        reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_REQUEST);
+        reply.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+            targetName, true);
+        reply.WriteS32Little(-1);
+        client->SendPacket(reply);
+    }
 
     return true;
 }

--- a/server/channel/src/packets/game/PartyCancel.cpp
+++ b/server/channel/src/packets/game/PartyCancel.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyCancel.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to cancel joining a party.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,52 +31,43 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyCancel::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() < 2 || (p.Size() != (uint32_t)(6 + p.PeekU16Little())))
     {
         return false;
     }
 
+    libcomp::String targetName = p.ReadString16Little(
+        libcomp::Convert::Encoding_t::ENCODING_CP932, true);
+    uint32_t partyID = p.ReadU32Little();
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
     auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO);
+    request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+        ->GetWorldCID());
+    request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+        character->GetName(), true);
+    request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+        targetName, true);
+    request.WriteU32Little(partyID);
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/game/PartyDisband.cpp
+++ b/server/channel/src/packets/game/PartyDisband.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyDisband.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to disband a party.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,17 +31,16 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyDisband::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
@@ -53,30 +52,12 @@ bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
-    auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DISBAND);
+    request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+        ->GetWorldCID());
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/game/PartyDropRule.cpp
+++ b/server/channel/src/packets/game/PartyDropRule.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyDropRule.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to set up a party drop rule.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,52 +31,36 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyDropRule::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() != 1)
     {
         return false;
     }
 
+    uint8_t rule = p.ReadU8();
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
-    auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE);
+    request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+        ->GetWorldCID());
+    request.WriteU8(rule);
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/game/PartyJoin.cpp
+++ b/server/channel/src/packets/game/PartyJoin.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyJoin.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to join a party.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,52 +31,40 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyJoin::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() < 2 || (p.Size() != (uint32_t)(6 + p.PeekU16Little())))
     {
         return false;
     }
 
+    libcomp::String targetName = p.ReadString16Little(
+        libcomp::Convert::Encoding_t::ENCODING_CP932, true);
+    uint32_t partyID = p.ReadU32Little();
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
-    auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
+    auto member = state->GetPartyCharacter(true);
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES);
+    member->SavePacket(request, false);
+    request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+        targetName, true);
+    request.WriteU32Little(partyID);
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/game/PartyKick.cpp
+++ b/server/channel/src/packets/game/PartyKick.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyKick.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to kick someone from your party.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,52 +31,38 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyKick::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() != 8)
     {
         return false;
     }
 
+    int32_t entityID = p.ReadS32Little();
+    int32_t worldCID = p.ReadS32Little();
+    (void)entityID;
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
-    auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_KICK);
+    request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+        ->GetWorldCID());
+    request.WriteS32Little(worldCID);
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/game/PartyLeaderUpdate.cpp
+++ b/server/channel/src/packets/game/PartyLeaderUpdate.cpp
@@ -1,10 +1,10 @@
 /**
- * @file server/channel/src/packets/game/FriendInfo.cpp
+ * @file server/channel/src/packets/game/PartyLeaderUpdate.cpp
  * @ingroup channel
  *
  * @author HACKfrost
  *
- * @brief Request from the client for the current player's own friend info.
+ * @brief Request from the client to update the party leader.
  *
  * This file is part of the Channel Server (channel).
  *
@@ -31,52 +31,38 @@
 #include <Packet.h>
 #include <PacketCodes.h>
 
-// object Includes
+// objects Includes
 #include <AccountLogin.h>
 #include <CharacterLogin.h>
-#include <FriendSettings.h>
 
 // channel Includes
 #include "ChannelServer.h"
 
 using namespace channel;
 
-bool Parsers::FriendInfo::Parse(libcomp::ManagerPacket *pPacketManager,
+bool Parsers::PartyLeaderUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    if(p.Size() != 0)
+    if(p.Size() != 8)
     {
         return false;
     }
 
+    int32_t entityID = p.ReadS32Little();
+    int32_t worldCID = p.ReadS32Little();
+    (void)entityID;
+
     auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
     auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
     auto state = client->GetClientState();
-    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
-    auto character = state->GetCharacterState()->GetEntity();
-    auto fSettings = character->LoadFriendSettings(server->GetWorldDatabase());
 
-    libcomp::Packet reply;
-    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_INFO_SELF);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        character->GetName(), true);
-    reply.WriteU32Little((uint32_t)cLogin->GetWorldCID());
-    reply.WriteS8(0);
-    reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
-        fSettings->GetFriendMessage(), true);
-
-    auto privacySet = fSettings->GetPublicToZone();
-    reply.WriteU8(privacySet ? 1 : 0);
-    reply.WriteU8(fSettings->GetPublicToZone() ? 1 : 0);
-
-    connection->SendPacket(reply);
-
-    // Request current friend info from the world to send on reply
     libcomp::Packet request;
-    request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
-    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
-    request.WriteS32Little(cLogin->GetWorldCID());
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((int8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_LEADER_UPDATE);
+    request.WriteS32Little(state->GetAccountLogin()->GetCharacterLogin()
+        ->GetWorldCID());
+    request.WriteS32Little(worldCID);
 
     server->GetManagerConnection()->GetWorldConnection()->SendPacket(request);
 

--- a/server/channel/src/packets/internal/CharacterLogin.cpp
+++ b/server/channel/src/packets/internal/CharacterLogin.cpp
@@ -1,0 +1,308 @@
+/**
+ * @file server/channel/src/packets/internal/CharacterLogin.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle receiving character login information from
+ *  the world to the channel.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+#include <FriendSettings.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+bool Parsers::CharacterLogin::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    (void)connection;
+
+    if(p.Size() < 5)
+    {
+        LOG_ERROR("Invalid response received for CharacterLogin.\n");
+        return false;
+    }
+
+    uint8_t updateFlags = p.ReadU8();
+
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+
+    // Pull all the logins
+    auto worldDB = server->GetWorldDatabase();
+    auto login = std::make_shared<objects::CharacterLogin>();
+    if(!login->LoadPacket(p, false))
+    {
+        LOG_ERROR("Invalid character info received for CharacterLogin.\n");
+        return false;
+    }
+
+    auto member = std::make_shared<objects::PartyCharacter>();
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO &&
+        !member->LoadPacket(p, true))
+    {
+        LOG_ERROR("Invalid party member character received for CharacterLogin.\n");
+        return false;
+    }
+    
+    auto partyDemon = std::make_shared<objects::PartyMember>();
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO &&
+        !partyDemon->LoadPacket(p, true))
+    {
+        LOG_ERROR("Invalid party member demon received for CharacterLogin.\n");
+        return false;
+    }
+
+    // Affected CIDs are appended to the end
+    uint16_t cidCount = p.ReadU16Little();
+
+    if(p.Left() < (uint32_t)(cidCount * 4))
+    {
+        LOG_ERROR("Invalid CID count received for CharacterLogin.\n");
+        return false;
+    }
+
+    std::list<int32_t> cids;
+    for(uint16_t i = 0; i < cidCount; i++)
+    {
+        cids.push_back(p.ReadS32Little());
+    }
+
+    std::unordered_map<int32_t, std::shared_ptr<ChannelClientConnection>> connections;
+    for(int32_t cid : cids)
+    {
+        auto state = ClientState::GetEntityClientState(cid, true);
+        auto cState = state != nullptr ? state->GetCharacterState() : nullptr;
+        auto client = cState->GetEntity() != nullptr ?
+            server->GetManagerConnection()->GetClientConnection(
+                cState->GetEntity()->GetAccount()->GetUsername()) : nullptr;
+        if(client)
+        {
+            connections[cid] = client;
+        }
+    }
+
+    if(connections.size() == 0)
+    {
+        // Character(s) are not here anymore, exit now
+        return true;
+    }
+
+    // Update friend information
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_FLAGS)
+    {
+        auto fSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, login->GetCharacter());
+        if(!fSettings)
+        {
+            LOG_ERROR(libcomp::String("Character friend settings failed to load: %1\n")
+                .Arg(login->GetCharacter().GetUUID().ToString()));
+            return true;
+        }
+
+        auto friends = fSettings->GetFriends();
+        std::list<std::shared_ptr<libcomp::TcpConnection>> friendConnections;
+        for(auto cPair : connections)
+        {
+            auto uuid = cPair.second->GetClientState()->GetCharacterState()
+                ->GetEntity()->GetUUID();
+            for(auto f : friends)
+            {
+                if(f.GetUUID() == uuid)
+                {
+                    friendConnections.push_back(cPair.second);
+                    break;
+                }
+            }
+        }
+
+        libcomp::Packet packet;
+        packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_DATA);
+        packet.WriteS32Little(login->GetWorldCID());
+        packet.WriteU8(updateFlags);
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_STATUS)
+        {
+            packet.WriteS8((int8_t)login->GetStatus());
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE)
+        {
+            packet.WriteS32Little((int32_t)login->GetZoneID());
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_CHANNEL)
+        {
+            packet.WriteS8(login->GetChannelID());
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_MESSAGE)
+        {
+            packet.WriteString16Little(libcomp::Convert::ENCODING_CP932,
+                fSettings->GetFriendMessage(), true);
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_UNKNOWN)
+        {
+            packet.WriteU32Little((uint32_t)login->GetWorldCID());
+            packet.WriteS8(0);   // Unknown
+        }
+
+        libcomp::TcpConnection::BroadcastPacket(friendConnections, packet);
+    }
+    
+    // Update local party information
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_FLAGS
+        && login->GetPartyID())
+    {
+        // Pull the local state if it still exists
+        uint32_t zoneID = login->GetZoneID();
+        auto state = ClientState::GetEntityClientState(login->GetWorldCID(), true);
+        int32_t localEntityID = state ? state->GetCharacterState()->GetEntityID() : -1;
+        int32_t localDemonEntityID = state ? state->GetDemonState()->GetEntityID() : -1;
+
+        std::list<std::shared_ptr<libcomp::TcpConnection>> partyConnections;
+        std::list<std::shared_ptr<libcomp::TcpConnection>> sameZoneConnections;
+        std::list<std::shared_ptr<libcomp::TcpConnection>> differentZoneConnections;
+        for(auto cPair : connections)
+        {
+            auto otherState = cPair.second->GetClientState();
+            auto otherLogin = otherState->GetAccountLogin()->GetCharacterLogin();
+            if(otherState->GetPartyID() == login->GetPartyID())
+            {
+                partyConnections.push_back(cPair.second);
+                if(otherLogin->GetZoneID() == zoneID &&
+                    otherLogin->GetChannelID() == login->GetChannelID())
+                {
+                    sameZoneConnections.push_back(cPair.second);
+                }
+                else
+                {
+                    differentZoneConnections.push_back(cPair.second);
+                }
+            }
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE)
+        {
+            // Map connections by local entity visibility
+            std::unordered_map<bool, std::list<std::shared_ptr<libcomp::TcpConnection>>*> cMap;
+            cMap[true] = &sameZoneConnections;
+            cMap[false] = &differentZoneConnections;
+            for(auto pair : cMap)
+            {
+                if(pair.second->size() == 0) continue;
+
+                libcomp::Packet packet;
+                packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_ZONE);
+                packet.WriteS32Little(pair.first ? localEntityID : -1);
+                packet.WriteS32Little((int32_t)zoneID);
+                packet.WriteS32Little(login->GetWorldCID());
+
+                libcomp::TcpConnection::BroadcastPacket(*pair.second, packet);
+            }
+
+            if(differentZoneConnections.size() > 0)
+            {
+                libcomp::Packet packet;
+                packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_PARTNER);
+                packet.WriteS32Little(-1);
+                packet.WriteS32Little(-1);
+                packet.WriteU32Little(partyDemon->GetDemonType());
+                packet.WriteU16Little(0);
+                packet.WriteU16Little(0);
+                packet.WriteS32Little(login->GetWorldCID());
+
+                libcomp::TcpConnection::BroadcastPacket(differentZoneConnections, packet);
+            }
+        }
+
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO &&
+            sameZoneConnections.size() > 0)
+        {
+            libcomp::Packet packet;
+            packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_UPDATE);
+            packet.WriteS32Little(localEntityID);
+            packet.WriteU8(member->GetLevel());
+            packet.WriteU16Little(member->GetHP());
+            packet.WriteU16Little(member->GetMaxHP());
+            packet.WriteU16Little(member->GetMP());
+            packet.WriteU16Little(member->GetMaxMP());
+
+            int8_t unknownCount = 0;
+            packet.WriteS8(unknownCount);
+            for(int8_t i = 0; i < unknownCount; i++)
+            {
+                packet.WriteS32Little(0);    // Unknown
+            }
+
+            packet.WriteS32Little(login->GetWorldCID());
+            packet.WriteS8(0);  // Unknown
+
+            libcomp::TcpConnection::BroadcastPacket(sameZoneConnections, packet);
+        }
+        
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO &&
+            sameZoneConnections.size() > 0)
+        {
+            libcomp::Packet packet;
+            packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_PARTNER);
+            packet.WriteS32Little(localEntityID);
+            packet.WriteS32Little(localDemonEntityID);
+            packet.WriteU32Little(partyDemon->GetDemonType());
+            packet.WriteU16Little(partyDemon->GetHP());
+            packet.WriteU16Little(partyDemon->GetMaxHP());
+            packet.WriteS32Little(login->GetWorldCID());
+
+            libcomp::TcpConnection::BroadcastPacket(sameZoneConnections, packet);
+        }
+        
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_ICON)
+        {
+            libcomp::Packet packet;
+            packet.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_ICON);
+            packet.WriteS32Little(localEntityID);
+            packet.WriteU8(0);
+            packet.WriteU8(0);
+            packet.WriteU8(0);
+            packet.WriteS8(0);
+
+            libcomp::TcpConnection::BroadcastPacket(partyConnections, packet);
+        }
+    }
+
+    return true;
+}

--- a/server/channel/src/packets/internal/FriendsUpdate.cpp
+++ b/server/channel/src/packets/internal/FriendsUpdate.cpp
@@ -1,0 +1,248 @@
+/**
+ * @file server/channel/src/packets/internal/FriendsUpdate.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle all friend list focused actions between the
+ *  world and the channel.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+#include <FriendSettings.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+void SendFriendInfo(std::shared_ptr<ChannelServer> server,
+    std::shared_ptr<ChannelClientConnection> client,
+    std::vector<std::shared_ptr<objects::CharacterLogin>> friendLogins,
+    ChannelToClientPacketCode_t packetCode)
+{
+    auto worldDB = server->GetWorldDatabase();
+
+    int8_t friendCount = (int8_t)friendLogins.size();
+    for(int8_t i = 0; i < friendCount; i++)
+    {
+        auto login = friendLogins[(size_t)i];
+        auto character = login->GetCharacter();
+        if(!character.Get(worldDB))
+        {
+            LOG_ERROR(libcomp::String("Character failed to load: %1\n")
+                .Arg(character.GetUUID().ToString()));
+            return;
+        }
+
+        auto fSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, character);
+        if(!fSettings)
+        {
+            LOG_ERROR(libcomp::String("Character friend settings failed to load: %1\n")
+                .Arg(character.GetUUID().ToString()));
+            return;
+        }
+
+        libcomp::Packet reply;
+        reply.WritePacketCode(packetCode);
+        if(packetCode == ChannelToClientPacketCode_t::PACKET_FRIEND_INFO)
+        {
+            reply.WriteS8(friendCount);
+            reply.WriteS8(i);
+        }
+        else
+        {
+            reply.WriteS8(1);
+        }
+
+        reply.WriteS32Little(login->GetWorldCID());
+        reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
+            character->GetName(), true);
+        reply.WriteU32Little((uint32_t)login->GetWorldCID());
+        reply.WriteS8(0);   // Unknown
+        reply.WriteS8((int8_t)login->GetStatus());
+        reply.WriteS32Little((int32_t)login->GetZoneID());
+        reply.WriteS8(login->GetChannelID());
+        reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
+            fSettings->GetFriendMessage(), true);
+
+        client->QueuePacket(reply);
+    }
+
+    client->FlushOutgoing();
+}
+
+bool Parsers::FriendsUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    (void)connection;
+
+    if(p.Size() < 6)
+    {
+        LOG_ERROR("Invalid response received for CharacterLogin.\n");
+        return false;
+    }
+
+    uint8_t mode = p.ReadU8();
+    int32_t cid = p.ReadS32Little();
+
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+    auto state = ClientState::GetEntityClientState(cid, true);
+    auto cState = state != nullptr ? state->GetCharacterState() : nullptr;
+    auto client = cState->GetEntity() != nullptr ?
+        server->GetManagerConnection()->GetClientConnection(
+            cState->GetEntity()->GetAccount()->GetUsername()) : nullptr;
+    if(!client)
+    {
+        // Character is not here anymore, exit now
+        return true;
+    }
+
+    switch((InternalPacketAction_t)mode)
+    {
+    case InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST:
+        {
+            int8_t loginCount = p.ReadS8();
+
+            // Pull all the logins
+            std::vector<std::shared_ptr<objects::CharacterLogin>> logins;
+            for(int8_t i = 0; i < loginCount; i++)
+            {
+                auto login = std::make_shared<objects::CharacterLogin>();
+                if(!login->LoadPacket(p, false))
+                {
+                    LOG_ERROR("Invalid character info received for CharacterLogin.\n");
+                    return false;
+                }
+
+                logins.push_back(login);
+            }
+
+            if(logins.size() == 0)
+            {
+                // Nothing to send
+                return true;
+            }
+
+            server->QueueWork(SendFriendInfo, server, client, logins,
+                ChannelToClientPacketCode_t::PACKET_FRIEND_INFO);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_YN_REQUEST:
+        {
+            libcomp::Packet request;
+            request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_REQUESTED);
+
+            // Send the requesting character name
+            request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                p.ReadString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8, true),
+                true);
+
+            client->SendPacket(request);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES:
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO:
+        {
+            auto charName = p.ReadString16Little(
+                libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+            bool success = (InternalPacketAction_t)mode
+                == InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES;
+            if(success)
+            {
+                // Reload the updated friends info
+                objects::FriendSettings::LoadFriendSettingsByCharacter(
+                    server->GetWorldDatabase(), cState->GetEntity());
+
+                if(charName == cState->GetEntity()->GetName())
+                {
+                    // No need to send the success to the player who accepted
+                    return true;
+                }
+            }
+
+            libcomp::Packet reply;
+            reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_REQUEST);
+
+            // Send the reqeusted character name back
+            reply.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                charName, true);
+            reply.WriteS32Little(success ? 0 : -1);
+            client->SendPacket(reply);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_ADD:
+    case InternalPacketAction_t::PACKET_ACTION_REMOVE:
+        {
+            bool added = (InternalPacketAction_t)mode
+                == InternalPacketAction_t::PACKET_ACTION_ADD;
+
+            // Reload the updated friends info
+            objects::FriendSettings::LoadFriendSettingsByCharacter(
+                server->GetWorldDatabase(), cState->GetEntity());
+            
+            if(added)
+            {
+                auto login = std::make_shared<objects::CharacterLogin>();
+                if(!login->LoadPacket(p, false))
+                {
+                    LOG_ERROR("Invalid character info received for CharacterLogin.\n");
+                    return false;
+                }
+
+                std::vector<std::shared_ptr<objects::CharacterLogin>> logins;
+                logins.push_back(login);
+                server->QueueWork(SendFriendInfo, server, client, logins,
+                    ChannelToClientPacketCode_t::PACKET_FRIEND_ADD_REMOVE);
+            }
+            else
+            {
+                int32_t removedCID = p.ReadS32Little();
+
+                libcomp::Packet reply;
+                reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_FRIEND_ADD_REMOVE);
+                reply.WriteS8(0);
+                reply.WriteS32Little(removedCID);
+
+                client->SendPacket(reply);
+            }
+        }
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}

--- a/server/channel/src/packets/internal/PartyUpdate.cpp
+++ b/server/channel/src/packets/internal/PartyUpdate.cpp
@@ -1,0 +1,602 @@
+/**
+ * @file server/channel/src/packets/internal/PartyUpdate.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle all party focused actions between the world
+ *  and the channel.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+struct PartyMemberInfo
+{
+    std::shared_ptr<objects::PartyCharacter> Member;
+    uint32_t ZoneID;
+    bool IsLeader;
+};
+
+bool GatherPartyTargetConnections(const std::shared_ptr<ChannelServer>& server,
+    std::list<std::shared_ptr<libcomp::TcpConnection>>& connections, libcomp::ReadOnlyPacket& p)
+{
+    // Affected CIDs are appended to the end
+    std::list<int32_t> cids;
+    if(p.Left() == 4)
+    {
+        // No count, just one
+        cids.push_back(p.ReadS32Little());
+    }
+    else
+    {
+        uint16_t cidCount = p.ReadU16Little();
+
+        if(p.Left() < (uint32_t)(cidCount * 4))
+        {
+            LOG_ERROR("Invalid CID count received for CharacterLogin.\n");
+            return false;
+        }
+
+        for(uint16_t i = 0; i < cidCount; i++)
+        {
+            cids.push_back(p.ReadS32Little());
+        }
+    }
+
+    for(int32_t cid : cids)
+    {
+        auto state = ClientState::GetEntityClientState(cid, true);
+        auto cState = state != nullptr ? state->GetCharacterState() : nullptr;
+        auto client = cState->GetEntity() != nullptr ?
+            server->GetManagerConnection()->GetClientConnection(
+                cState->GetEntity()->GetAccount()->GetUsername()) : nullptr;
+        if(client)
+        {
+            connections.push_back(client);
+        }
+    }
+
+    return true;
+}
+
+void QueuePartyMemberInfo(std::shared_ptr<ChannelClientConnection> client,
+    PartyMemberInfo memberInfo)
+{
+    auto state = client->GetClientState();
+    auto cLogin = state->GetAccountLogin()->GetCharacterLogin();
+    auto member = memberInfo.Member;
+    auto partyDemon = member->GetDemon();
+
+    auto partyState = ClientState::GetEntityClientState(
+        member->GetWorldCID(), true);
+
+    libcomp::Packet reply;
+    reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_MEMBER_INFO);
+    if(memberInfo.ZoneID == cLogin->GetZoneID())
+    {
+        int32_t localEntityID = -1;
+        int32_t localDemonEntityID = -1;
+        if(partyState)
+        {
+            localEntityID = partyState->GetCharacterState()->GetEntityID();
+            if(partyState->GetDemonState()->GetEntity())
+            {
+                localDemonEntityID = partyState->GetDemonState()->GetEntityID();
+            }
+        }
+
+        reply.WriteS32Little(localEntityID);
+        reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
+            member->GetName(), true);
+        reply.WriteU8(memberInfo.IsLeader ? 1 : 0);
+        reply.WriteU8(member->GetLevel());
+        reply.WriteU16Little(member->GetHP());
+        reply.WriteU16Little(member->GetMaxHP());
+        reply.WriteU16Little(member->GetMP());
+        reply.WriteU16Little(member->GetMaxMP());
+
+        int8_t unknownCount = 0;
+        reply.WriteS8(unknownCount);
+        for(int8_t i = 0; i < unknownCount; i++)
+        {
+            reply.WriteS32Little(0);    // Unknown
+        }
+
+        reply.WriteS32Little(localDemonEntityID);
+        reply.WriteU32Little(partyDemon->GetDemonType());
+        reply.WriteU16Little(partyDemon->GetHP());
+        reply.WriteU16Little(partyDemon->GetMaxHP());
+
+        reply.WriteS32Little((int32_t)memberInfo.ZoneID);
+
+        /// @todo: figure out face icon values
+        reply.WriteU8(0);
+        reply.WriteU8(0);
+        reply.WriteU8(0);
+        reply.WriteU8(0);
+        reply.WriteS8(0);
+    }
+    else
+    {
+        // Not in the same zone, send minimal info
+        reply.WriteS32Little(-1);
+        reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
+            member->GetName(), true);
+        reply.WriteU8(memberInfo.IsLeader ? 1 : 0);
+        reply.WriteBlank(10);
+        reply.WriteS32Little(-1);   // Demon entity ID
+        reply.WriteU32Little(partyDemon->GetDemonType());
+        reply.WriteBlank(4);
+        reply.WriteS32Little((int32_t)memberInfo.ZoneID);
+        reply.WriteBlank(5);
+    }
+
+    reply.WriteS32Little(member->GetWorldCID());
+
+    client->QueuePacket(reply);
+}
+
+bool Parsers::PartyUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    (void)connection;
+
+    if(p.Size() < 1)
+    {
+        LOG_ERROR("Invalid response received for CharacterLogin.\n");
+        return false;
+    }
+
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+
+    uint8_t mode = p.ReadU8();
+
+    switch((InternalPacketAction_t)mode)
+    {
+    case InternalPacketAction_t::PACKET_ACTION_YN_REQUEST:
+        {
+            bool isResponse = p.ReadU8() == 1;
+            auto charName = p.ReadString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+            if(isResponse)
+            {
+                if(p.Left() < 6)
+                {
+                    return false;
+                }
+
+                uint16_t responseCode = p.ReadU16Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet response;
+                    response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_INVITE);
+                    response.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                        charName, true);
+                    response.WriteU16Little(responseCode);
+
+                    connections.front()->SendPacket(response);
+                }
+            }
+            else
+            {
+                if(p.Left() != 8)
+                {
+                    return false;
+                }
+
+                uint32_t partyID = p.ReadU32Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet request;
+                    request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_INVITED);
+                    request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                        charName, true);
+                    request.WriteU32Little(partyID);
+
+                    connections.front()->SendPacket(request);
+                }
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES:
+        {
+            auto charName = p.ReadString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+            uint16_t responseCode = p.ReadU16Little();
+            
+            std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+            if(!GatherPartyTargetConnections(server, connections, p))
+            {
+                return false;
+            }
+            else if(connections.size() == 1)
+            {
+                libcomp::Packet response;
+                response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_JOIN);
+                response.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                    charName, true);
+                response.WriteU16Little(responseCode);
+
+                auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connections.front());
+                client->SendPacket(response);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO:
+        {
+            auto charName = p.ReadString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+            
+            std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+            if(!GatherPartyTargetConnections(server, connections, p))
+            {
+                return false;
+            }
+            else if(connections.size() == 1)
+            {
+                libcomp::Packet response;
+                response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_CANCEL);
+                response.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_CP932,
+                    charName, true);
+
+                connections.front()->SendPacket(response);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_ADD:
+        {
+            std::list<PartyMemberInfo> members;
+
+            uint32_t partyID = p.ReadU32Little();
+            uint8_t memberCount = p.ReadU8();
+            for(uint8_t i = 0; i < memberCount; i++)
+            {
+                auto member = std::make_shared<objects::PartyCharacter>();
+                if(!member->LoadPacket(p, false) || p.Left() < 7)
+                {
+                    return false;
+                }
+
+                uint32_t zoneID = p.ReadU32Little();
+                bool leader = p.ReadU8() == 1;
+
+                PartyMemberInfo info;
+                info.Member = member;
+                info.ZoneID = zoneID;
+                info.IsLeader = leader;
+                members.push_back(info);
+            }
+            
+            std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+            if(!GatherPartyTargetConnections(server, connections, p))
+            {
+                return false;
+            }
+            
+            for(auto c : connections)
+            {
+                auto client = std::dynamic_pointer_cast<ChannelClientConnection>(c);
+                auto state = client->GetClientState();
+                if(!state->GetPartyID())
+                {
+                    state->SetPartyID(partyID);
+                }
+
+                for(auto info : members)
+                {
+                    QueuePartyMemberInfo(client, info);
+                }
+                client->FlushOutgoing();
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_LEAVE:
+        {
+            bool isResponse = p.ReadU8() == 1;
+
+            if(isResponse)
+            {
+                if(p.Left() < 6)
+                {
+                    return false;
+                }
+
+                uint16_t responseCode = p.ReadU16Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet response;
+                    response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_LEAVE);
+                    response.WriteU16Little(responseCode);
+
+                    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connections.front());
+
+                    // Whether leaving was "successful" or not, the party ID should now be empty
+                    client->GetClientState()->SetPartyID(0);
+                    client->SendPacket(response);
+                }
+            }
+            else
+            {
+                if(p.Left() < 8)
+                {
+                    return false;
+                }
+
+                int32_t worldCID = p.ReadS32Little();
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+
+                auto partyState = ClientState::GetEntityClientState(worldCID, true);
+
+                int32_t localEntityID = -1;
+                if(partyState)
+                {
+                    localEntityID = partyState->GetCharacterState()->GetEntityID();
+                }
+
+                libcomp::Packet request;
+                request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_LEFT);
+                request.WriteS32Little(localEntityID);
+                request.WriteS32Little(worldCID);
+
+                libcomp::TcpConnection::BroadcastPacket(connections, request);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_DISBAND:
+        {
+            bool isResponse = p.ReadU8() == 1;
+
+            if(isResponse)
+            {
+                if(p.Left() < 6)
+                {
+                    return false;
+                }
+
+                uint16_t responseCode = p.ReadU16Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet response;
+                    response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_DISBAND);
+                    response.WriteU16Little(responseCode);
+
+                    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connections.front());
+
+                    // Whether leaving was "successful" or not, the party ID should now be empty
+                    client->GetClientState()->SetPartyID(0);
+                    client->SendPacket(response);
+                }
+            }
+            else
+            {
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+
+                for(auto c : connections)
+                {
+                    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(c);
+                    client->GetClientState()->SetPartyID(0);
+                }
+
+                libcomp::Packet request;
+                request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_DISBANDED);
+
+                libcomp::TcpConnection::BroadcastPacket(connections, request);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_LEADER_UPDATE:
+        {
+            bool isResponse = p.ReadU8() == 1;
+
+            if(isResponse)
+            {
+                if(p.Left() < 6)
+                {
+                    return false;
+                }
+
+                uint16_t responseCode = p.ReadU16Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet response;
+                    response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_LEADER_UPDATE);
+                    response.WriteU16Little(responseCode);
+
+                    connections.front()->SendPacket(response);
+                }
+            }
+            else
+            {
+                if(p.Left() < 8)
+                {
+                    return false;
+                }
+
+                int32_t leaderCID = p.ReadS32Little();
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+
+                auto partyState = ClientState::GetEntityClientState(leaderCID, true);
+
+                int32_t localEntityID = -1;
+                if(partyState)
+                {
+                    localEntityID = partyState->GetCharacterState()->GetEntityID();
+                }
+
+                libcomp::Packet request;
+                request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_LEADER_UPDATED);
+                request.WriteS32Little(localEntityID);
+                request.WriteS32Little(leaderCID);
+
+                libcomp::TcpConnection::BroadcastPacket(connections, request);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE:
+        {
+            bool isResponse = p.ReadU8() == 1;
+
+            if(isResponse)
+            {
+                if(p.Left() < 6)
+                {
+                    return false;
+                }
+
+                uint16_t responseCode = p.ReadU16Little();
+                
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+                else if(connections.size() == 1)
+                {
+                    libcomp::Packet response;
+                    response.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_DROP_RULE);
+                    response.WriteU16Little(responseCode);
+
+                    connections.front()->SendPacket(response);
+                }
+            }
+            else
+            {
+                if(p.Left() < 5)
+                {
+                    return false;
+                }
+
+                uint8_t rule = p.ReadU8();
+                std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+                if(!GatherPartyTargetConnections(server, connections, p))
+                {
+                    return false;
+                }
+
+                libcomp::Packet request;
+                request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_DROP_RULE_SET);
+                request.WriteU8(rule);
+
+                libcomp::TcpConnection::BroadcastPacket(connections, request);
+            }
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_KICK:
+        {
+            if(p.Left() < 8)
+            {
+                return false;
+            }
+
+            int32_t targetCID = p.ReadS32Little();
+            std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+            if(!GatherPartyTargetConnections(server, connections, p))
+            {
+                return false;
+            }
+
+            auto partyState = ClientState::GetEntityClientState(targetCID, true);
+
+            int32_t localEntityID = -1;
+            if(partyState)
+            {
+                partyState->SetPartyID(0);
+                localEntityID = partyState->GetCharacterState()->GetEntityID();
+            }
+
+            libcomp::Packet request;
+            request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_KICK);
+            request.WriteS32Little(localEntityID);
+            request.WriteS32Little(targetCID);
+
+            libcomp::TcpConnection::BroadcastPacket(connections, request);
+
+            request.Clear();
+            request.WritePacketCode(ChannelToClientPacketCode_t::PACKET_PARTY_LEFT);
+            request.WriteS32Little(localEntityID);
+            request.WriteS32Little(targetCID);
+
+            libcomp::TcpConnection::BroadcastPacket(connections, request);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}

--- a/server/lobby/src/AccountManager.cpp
+++ b/server/lobby/src/AccountManager.cpp
@@ -34,7 +34,9 @@
 
 // objects Includes
 #include <Account.h>
+#include <AccountLogin.h>
 #include <Character.h>
+#include <CharacterLogin.h>
 
 // lobby Includes
 #include "LobbyServer.h"
@@ -74,7 +76,7 @@ bool AccountManager::IsLoggedIn(const libcomp::String& username,
     {
         result = true;
 
-        world = pair->second->GetWorldID();
+        world = pair->second->GetCharacterLogin()->GetWorldID();
     }
 
     return result;
@@ -150,7 +152,8 @@ bool AccountManager::LogoutUser(const libcomp::String& username, int8_t world)
 
     auto pair = mAccountMap.find(lookup);
 
-    if(mAccountMap.end() != pair && world == pair->second->GetWorldID())
+    if(mAccountMap.end() != pair && world == pair->second->
+        GetCharacterLogin()->GetWorldID())
     {
         (void)mAccountMap.erase(pair);
 
@@ -173,8 +176,9 @@ std::list<libcomp::String> AccountManager::LogoutUsersInWorld(int8_t world,
     std::list<libcomp::String> usernames;
     for(auto pair : mAccountMap)
     {
-        if(pair.second->GetWorldID() == world &&
-            (channel < 0 || pair.second->GetChannelID() == channel))
+        auto charLogin = pair.second->GetCharacterLogin();
+        if(charLogin->GetWorldID() == world &&
+            (channel < 0 || charLogin->GetChannelID() == channel))
         {
             usernames.push_back(pair.first);
         }

--- a/server/lobby/src/packets/game/Auth.cpp
+++ b/server/lobby/src/packets/game/Auth.cpp
@@ -40,6 +40,8 @@
 
 // object Includes
 #include <Account.h>
+#include <AccountLogin.h>
+#include <CharacterLogin.h>
 
 using namespace lobby;
 
@@ -79,9 +81,10 @@ static bool CompleteLogin(
             login = std::shared_ptr<objects::AccountLogin>(new objects::AccountLogin);
             login->SetAccount(account);
         }
-
-        login->SetWorldID(-1);
-        login->SetChannelID(-1);
+        else
+        {
+            login->SetCharacterLogin(std::make_shared<objects::CharacterLogin>());
+        }
 
         if(!accountManager->LoginUser(username, login))
         {

--- a/server/lobby/src/packets/game/StartGame.cpp
+++ b/server/lobby/src/packets/game/StartGame.cpp
@@ -38,6 +38,7 @@
 #include <Account.h>
 #include <AccountLogin.h>
 #include <Character.h>
+#include <CharacterLogin.h>
 
 // lobby Includes
 #include "AccountManager.h"
@@ -84,11 +85,11 @@ bool Parsers::StartGame::Parse(libcomp::ManagerPacket *pPacketManager,
     server->GetSessionManager()->ExpireSession(username, 0);
 
     auto login = accountManager->GetUserLogin(username);
-    login->SetCID(cid);
+    login->GetCharacterLogin()->SetCharacter(account->GetCharacters(cid));
 
     libcomp::Packet request;
     request.WritePacketCode(InternalPacketCode_t::PACKET_ACCOUNT_LOGIN);
-    login->SavePacket(request);
+    login->SavePacket(request, false);
 
     world->GetConnection()->SendPacket(request);
 

--- a/server/world/CMakeLists.txt
+++ b/server/world/CMakeLists.txt
@@ -30,6 +30,7 @@ FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/objgen)
 
 SET(${PROJECT_NAME}_SRCS
     src/AccountManager.cpp
+    src/CharacterManager.cpp
     src/ManagerConnection.cpp
     src/WorldServer.cpp
     src/main.cpp
@@ -37,11 +38,13 @@ SET(${PROJECT_NAME}_SRCS
 
 SET(${PROJECT_NAME}_HDRS
     src/AccountManager.h
+    src/CharacterManager.h
     src/ManagerConnection.h
     src/WorldServer.h
 )
 
 SET(${PROJECT_NAME}_SCHEMA
+    schema/party.xml
     schema/worldconfig.xml
 )
 
@@ -59,6 +62,8 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     ../../libcomp/schema
 
     # Output files
+    Party.h
+    Party.cpp
     WorldConfig.h
     WorldConfig.cpp
 )
@@ -70,6 +75,9 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/SetChannelInfo.cpp             # 0x1003
     src/packets/AccountLogin.cpp               # 0x1004
     src/packets/AccountLogout.cpp              # 0x1005
+    src/packets/CharacterLogin.cpp             # 0x1007
+    src/packets/FriendsUpdate.cpp              # 0x1008
+    src/packets/PartyUpdate.cpp                # 0x1009
 )
 
 ADD_EXECUTABLE(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS}

--- a/server/world/schema/master.xml
+++ b/server/world/schema/master.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objgen>
     <include path="../../libcomp/schema/master.xml"/>
+    <include path="party.xml"/>
     <include path="worldconfig.xml"/>
 </objgen>

--- a/server/world/schema/party.xml
+++ b/server/world/schema/party.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <object name="Party" persistent="false">
+        <member type="u32" name="ID"/>
+        <member type="s32" name="LeaderCID"/>
+        <member type="map" name="Members">
+            <key type="s32"/>
+            <value type="PartyCharacter*"/>
+        </member>
+        <member type="u8" name="DropRule"/>
+    </object>
+</objgen>

--- a/server/world/src/CharacterManager.cpp
+++ b/server/world/src/CharacterManager.cpp
@@ -1,0 +1,691 @@
+/**
+ * @file server/world/src/CharacterManager.h
+ * @ingroup world
+ *
+ * @author HACKfrost
+ *
+ * @brief Manager to handle world level character actions.
+ *
+ * This file is part of the World Server (world).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "CharacterManager.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Character.h>
+#include <FriendSettings.h>
+
+// world Includes
+#include "WorldServer.h"
+
+using namespace world;
+
+CharacterManager::CharacterManager(const std::weak_ptr<WorldServer>& server)
+    : mServer(server)
+{
+    // By default create the pending party
+    mParties[0] = std::make_shared<objects::Party>();
+
+    mMaxCID = 0;
+    mMaxPartyID = 0;
+}
+
+std::shared_ptr<objects::CharacterLogin> CharacterManager::RegisterCharacter(
+    std::shared_ptr<objects::CharacterLogin> cLogin)
+{
+    libcomp::String lookup = cLogin->GetCharacter().GetUUID().ToString();
+
+    std::lock_guard<std::mutex> lock(mLock);
+
+    auto pair = mCharacterMap.find(lookup);
+    if(pair != mCharacterMap.end())
+    {
+        cLogin = pair->second;
+    }
+    else
+    {
+        int32_t cid = ++mMaxCID;
+        cLogin->SetWorldCID(cid);
+        mCharacterMap[lookup] = cLogin;
+        mCharacterCIDMap[cid] = cLogin;
+    }
+
+    return cLogin;
+}
+
+std::shared_ptr<objects::CharacterLogin> CharacterManager::GetCharacterLogin(
+    const libobjgen::UUID& uuid)
+{
+    libcomp::String lookup = uuid.ToString();
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        auto it = mCharacterMap.find(lookup);
+        if (it != mCharacterMap.end())
+        {
+            return it->second;
+        }
+    }
+
+    // Register a new character login
+    auto cLogin = std::make_shared<objects::CharacterLogin>();
+    cLogin->SetCharacter(uuid);
+    cLogin = RegisterCharacter(cLogin);
+
+    return cLogin;
+}
+
+std::shared_ptr<objects::CharacterLogin> CharacterManager::GetCharacterLogin(
+    int32_t worldCID)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    auto it = mCharacterCIDMap.find(worldCID);
+    return it != mCharacterCIDMap.end() ? it->second : nullptr;
+}
+
+std::shared_ptr<objects::CharacterLogin> CharacterManager::GetCharacterLogin(
+    const libcomp::String& characterName)
+{
+    auto worldDB = mServer.lock()->GetWorldDatabase();
+    auto character = objects::Character::LoadCharacterByName(worldDB, characterName);
+
+    return character ? GetCharacterLogin(character->GetUUID()) : nullptr;
+}
+
+bool CharacterManager::SendToCharacters(libcomp::Packet& p,
+    const std::list<std::shared_ptr<objects::CharacterLogin>>& cLogins, bool appendCIDs)
+{
+    std::unordered_map<int8_t, std::list<int32_t>> channelMap;
+    for(auto c : cLogins)
+    {
+        int8_t channelID = c->GetChannelID();
+        if(channelID >= 0)
+        {
+            channelMap[channelID].push_back(c->GetWorldCID());
+        }
+    }
+
+    auto server = mServer.lock();
+    auto channels = server->GetChannels();
+    for(auto pair : channelMap)
+    {
+        auto channel = server->GetChannelConnectionByID(pair.first);
+
+        // If the channel is not valid, move on and clean it up later
+        if(!channel) continue;
+
+        // Make a copy and keep writing or send
+        libcomp::Packet p2(p);
+        if(appendCIDs)
+        {
+            // Write the list of CIDs to inform of the update
+            p2.WriteU16Little((uint16_t)pair.second.size());
+            for(int32_t fCID : pair.second)
+            {
+                p2.WriteS32Little(fCID);
+            }
+        }
+
+        channel->SendPacket(p2);
+    }
+
+    return true;
+}
+
+bool CharacterManager::SendToRelatedCharacters(libcomp::Packet& p,
+    int32_t worldCID, bool appendCIDs, bool friends, bool party, bool includeSelf,
+    bool zoneRestrict)
+{
+    auto server = mServer.lock();
+    auto cLogin = GetCharacterLogin(worldCID);
+    if(!cLogin)
+    {
+        LOG_ERROR(libcomp::String("Invalid world CID encountered: %1\n")
+            .Arg(worldCID));
+        return false;
+    }
+
+    auto cLogins = GetRelatedCharacterLogins(cLogin, friends, party);
+    if(zoneRestrict)
+    {
+        cLogins.remove_if([cLogin](const std::shared_ptr<objects::CharacterLogin>& l)
+            {
+                return l->GetZoneID() != cLogin->GetZoneID() ||
+                    l->GetChannelID() != cLogin->GetChannelID();
+            });
+    }
+
+    if(includeSelf)
+    {
+        cLogins.push_back(cLogin);
+    }
+
+    cLogins.unique();
+
+    return cLogins.size() == 0 || SendToCharacters(p, cLogins, appendCIDs);
+}
+
+std::list<std::shared_ptr<objects::CharacterLogin>>
+    CharacterManager::GetRelatedCharacterLogins(
+    std::shared_ptr<objects::CharacterLogin> cLogin, bool friends, bool party)
+{
+    auto server = mServer.lock();
+    auto worldDB = server->GetWorldDatabase();
+
+    std::list<int32_t> targetCIDs;
+    std::list<libobjgen::UUID> targetUUIDs;
+    if(friends)
+    {
+        auto fSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, cLogin->GetCharacter().GetUUID());
+        for(auto f : fSettings->GetFriends())
+        {
+            targetUUIDs.push_back(f.GetUUID());
+        }
+    }
+
+    if(party)
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        auto it = mParties.find(cLogin->GetPartyID());
+        if(it != mParties.end())
+        {
+            for(auto memberPair : it->second->GetMembers())
+            {
+                targetCIDs.push_back(memberPair.first);
+            }
+        }
+    }
+
+    std::list<std::shared_ptr<objects::CharacterLogin>> cLogins;
+    for(auto targetUUID : targetUUIDs)
+    {
+        if(targetUUID != cLogin->GetCharacter().GetUUID())
+        {
+            cLogins.push_back(GetCharacterLogin(targetUUID));
+        }
+    }
+
+    for(auto cid : targetCIDs)
+    {
+        if(cid != cLogin->GetWorldCID())
+        {
+            cLogins.push_back(GetCharacterLogin(cid));
+        }
+    }
+
+    return cLogins;
+}
+
+void CharacterManager::SendStatusToRelatedCharacters(
+    const std::list<std::shared_ptr<objects::CharacterLogin>>& cLogins, uint8_t updateFlags, bool zoneRestrict)
+{
+    for(auto cLogin : cLogins)
+    {
+        uint8_t outFlags = updateFlags;
+
+        libcomp::Packet reply;
+        if(GetStatusPacket(reply, cLogin, outFlags))
+        {
+            bool friendUpdate = 0 != (outFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_FLAGS);
+            bool partyUpdate = 0 != (outFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_FLAGS);
+
+            // If all that is being sent is zone visible stats, restrict to the same zone
+            bool partyStatsOnly = zoneRestrict &&
+                (0 == (outFlags & (uint8_t)(~((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO) |
+                (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO)));
+            SendToRelatedCharacters(reply, cLogin->GetWorldCID(), true, friendUpdate, partyUpdate, false,
+                partyStatsOnly);
+        }
+    }
+}
+
+bool CharacterManager::GetStatusPacket(libcomp::Packet& p,
+    const std::shared_ptr<objects::CharacterLogin>& cLogin, uint8_t& updateFlags)
+{
+    std::shared_ptr<objects::PartyCharacter> member;
+    if(0 != (updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_FLAGS))
+    {
+        member = GetPartyMember(cLogin);
+        if(!member)
+        {
+            // Drop the party flags
+            updateFlags = updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_FRIEND_FLAGS;
+        }
+    }
+
+    if(!updateFlags)
+    {
+        return false;
+    }
+
+    p.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
+    p.WriteU8(updateFlags);
+    cLogin->SavePacket(p, false);
+        
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO)
+    {
+        member->SavePacket(p, true);
+    }
+        
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO)
+    {
+        member->GetDemon()->SavePacket(p, true);
+    }
+
+    return true;
+}
+
+std::shared_ptr<objects::Party> CharacterManager::GetParty(uint32_t partyID)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    auto it = mParties.find(partyID);
+    if(it != mParties.end())
+    {
+        return it->second;
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<objects::PartyCharacter>
+    CharacterManager::GetPartyMember(std::shared_ptr<objects::CharacterLogin> cLogin)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    auto it = mParties.find(cLogin->GetPartyID());
+    if(it != mParties.end() && it->second->MembersKeyExists(cLogin->GetWorldCID()))
+    {
+        return it->second->GetMembers(cLogin->GetWorldCID());
+    }
+
+    return nullptr;
+}
+
+bool CharacterManager::AddToParty(std::shared_ptr<objects::PartyCharacter> member,
+    uint32_t partyID)
+{
+    auto login = GetCharacterLogin(member->GetWorldCID());
+
+    std::lock_guard<std::mutex> lock(mLock);
+    auto it = mParties.find(partyID);
+    if(it != mParties.end() && it->second->MembersCount() < 5
+        && (login->GetPartyID() == 0 || login->GetPartyID() == partyID))
+    {
+        mParties[0]->RemoveMembers(login->GetWorldCID());
+        login->SetPartyID(partyID);
+        it->second->SetMembers(login->GetWorldCID(), member);
+        return true;
+    }
+
+    return false;
+}
+
+bool CharacterManager::PartyJoin(std::shared_ptr<objects::PartyCharacter> member,
+    const libcomp::String targetName, uint32_t partyID,
+    std::shared_ptr<libcomp::TcpConnection> sourceConnection)
+{
+    bool newParty = false;
+    uint16_t responseCode = 201;  // Not available
+    std::shared_ptr<objects::CharacterLogin> targetLogin;
+    if(!targetName.IsEmpty())
+    {
+        // Request response
+        targetLogin = GetCharacterLogin(targetName);
+        if(targetLogin && targetLogin->GetChannelID() >= 0)
+        {
+            auto targetMember = GetPartyMember(targetLogin);
+            if(targetMember)
+            {
+                if(partyID == 0)
+                {
+                    partyID = CreateParty(targetMember);
+                    newParty = true;
+                }
+                else if(GetCharacterLogin(
+                    targetMember->GetWorldCID())->GetPartyID() != partyID)
+                {
+                    responseCode = 202; // In a different party
+                }
+
+                if(responseCode != 202 && AddToParty(member, partyID))
+                {
+                    responseCode = 200; // Success
+                }
+            }
+        }
+
+        libcomp::Packet response;
+        response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES);
+        response.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+            targetName, true);
+        response.WriteU16Little(responseCode);
+        response.WriteS32Little(member->GetWorldCID());
+
+        sourceConnection->QueuePacket(response);
+    }
+    else if(partyID)
+    {
+        // Rejoining from login
+        if(AddToParty(member, partyID))
+        {
+            responseCode = 200; // Success
+        }
+    }
+
+    if(responseCode == 200)
+    {
+        auto cLogin = GetCharacterLogin(member->GetWorldCID());
+        auto party = GetParty(partyID);
+        auto partyMembers = party->GetMembers();
+
+        // All members
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_ADD);
+        request.WriteU32Little(partyID);
+        request.WriteU8((uint8_t)partyMembers.size());
+        for(auto memberPair : partyMembers)
+        {
+            auto login = GetCharacterLogin(memberPair.first);
+            memberPair.second->SavePacket(request, false);
+            request.WriteU32Little(login->GetZoneID());
+            request.WriteU8(party->GetLeaderCID() == memberPair.first ? 1 : 0);
+        }
+
+        if(newParty)
+        {
+            // Send everyone to everyone
+            SendToRelatedCharacters(request, member->GetWorldCID(),
+                true, false, true, true);
+        }
+        else
+        {
+            // Send everyone to the new member
+            request.WriteS32Little(member->GetWorldCID());
+            sourceConnection->QueuePacket(request);
+
+            // Send new member to everyone else
+            request.Clear();
+            request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_ADD);
+            request.WriteU32Little(partyID);
+            request.WriteU8(1);
+            member->SavePacket(request, false);
+            request.WriteU32Little(cLogin->GetZoneID());
+            request.WriteU8(0);
+
+            SendToRelatedCharacters(request, member->GetWorldCID(),
+                true, false, true);
+        }
+
+        request.Clear();
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE);
+        request.WriteU8(0); // Not a response
+        request.WriteU8(party->GetDropRule());
+
+        // Send to everyone if the party is new
+        SendToRelatedCharacters(request, member->GetWorldCID(),
+            true, false, newParty, true);
+    }
+
+    sourceConnection->FlushOutgoing();
+
+    return responseCode == 200;
+}
+
+void CharacterManager::PartyLeave(std::shared_ptr<objects::CharacterLogin> cLogin,
+    std::shared_ptr<libcomp::TcpConnection> requestConnection, bool tempLeave)
+{
+    uint32_t partyID = cLogin->GetPartyID();
+    auto party = GetParty(partyID);
+    auto partyLogins = GetRelatedCharacterLogins(cLogin, false, true);
+
+    uint16_t responseCode = 201;    // Failure
+    if(RemoveFromParty(cLogin))
+    {
+        responseCode = 200; // Success
+        if(!tempLeave)
+        {
+            cLogin->SetPartyID(0);
+        }
+    }
+
+    if(requestConnection)
+    {
+        libcomp::Packet response;
+        response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_LEAVE);
+        response.WriteU8(1); // Is a response
+        response.WriteU16Little(responseCode);
+        response.WriteS32Little(cLogin->GetWorldCID());
+
+        requestConnection->QueuePacket(response);
+    }
+
+    if(responseCode == 200)
+    {
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_LEAVE);
+        request.WriteU8(0); // Not a response
+        request.WriteS32Little(cLogin->GetWorldCID());
+
+        partyLogins.push_back(cLogin);
+        SendToCharacters(request, partyLogins, true);
+
+        auto members = party->GetMembers();
+        if(members.size() <= 1)
+        {
+            // Cannot exist with one or zero members
+            PartyDisband(partyID, cLogin->GetWorldCID());
+        }
+        else if(cLogin->GetWorldCID() == party->GetLeaderCID())
+        {
+            // If the leader left, take the next person who joined
+            PartyLeaderUpdate(party->GetID(), cLogin->GetWorldCID(),
+                nullptr, members.begin()->first);
+        }
+    }
+    
+    if(requestConnection)
+    {
+        requestConnection->FlushOutgoing();
+    }
+}
+
+void CharacterManager::PartyDisband(uint32_t partyID, int32_t sourceCID,
+    std::shared_ptr<libcomp::TcpConnection> requestConnection)
+{
+    auto party = GetParty(partyID);
+
+    uint16_t responseCode = 200;    // Success
+    std::list<std::shared_ptr<objects::CharacterLogin>> partyLogins;
+    for(auto memberPair : party->GetMembers())
+    {
+        auto login = GetCharacterLogin(memberPair.first);
+        if(login)
+        {
+            partyLogins.push_back(login);
+
+            if(RemoveFromParty(login))
+            {
+                login->SetPartyID(0);
+            }
+            else
+            {
+                responseCode = 201; // Failure
+                break;
+            }
+        }
+    }
+
+    if(requestConnection)
+    {
+        libcomp::Packet response;
+        response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DISBAND);
+        response.WriteU8(1); // Is a response
+        response.WriteU16Little(responseCode);
+        response.WriteS32Little(sourceCID);
+
+        requestConnection->QueuePacket(response);
+    }
+
+    if(responseCode == 200)
+    {
+        {
+            std::lock_guard<std::mutex> lock(mLock);
+            mParties.erase(party->GetID());
+        }
+
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DISBAND);
+        request.WriteU8(0); // Not a response
+
+        SendToCharacters(request, partyLogins, true);
+    }
+
+    if(requestConnection)
+    {
+        requestConnection->FlushOutgoing();
+    }
+}
+
+void CharacterManager::PartyLeaderUpdate(uint32_t partyID, int32_t sourceCID,
+    std::shared_ptr<libcomp::TcpConnection> requestConnection, int32_t targetCID)
+{
+    auto party = GetParty(partyID);
+
+    uint16_t responseCode = 201;    // Failure
+    if(party->MembersKeyExists(targetCID))
+    {
+        party->SetLeaderCID(targetCID);
+        responseCode = 200; // Success
+    }
+
+    if(requestConnection)
+    {
+        libcomp::Packet response;
+        response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_LEADER_UPDATE);
+        response.WriteU8(1); // Is a response
+        response.WriteU16Little(responseCode);
+        response.WriteS32Little(sourceCID);
+
+        requestConnection->QueuePacket(response);
+    }
+
+    if(responseCode == 200)
+    {
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_LEADER_UPDATE);
+        request.WriteU8(0); // Not a response
+        request.WriteS32Little(targetCID);
+
+        std::list<std::shared_ptr<objects::CharacterLogin>> partyLogins;
+        for(auto pair : party->GetMembers())
+        {
+            partyLogins.push_back(GetCharacterLogin(pair.first));
+        }
+
+        SendToCharacters(request, partyLogins, true);
+    }
+    
+    if(requestConnection)
+    {
+        requestConnection->FlushOutgoing();
+    }
+}
+
+void CharacterManager::PartyKick(std::shared_ptr<objects::CharacterLogin> cLogin,
+    int32_t targetCID)
+{
+    auto party = GetParty(cLogin->GetPartyID());
+    if(!party)
+    {
+        return;
+    }
+
+    auto partyLogins = GetRelatedCharacterLogins(cLogin, false, true);
+    if(party->MembersKeyExists(targetCID))
+    {
+        party->RemoveMembers(targetCID);
+    }
+
+    auto targetLogin = GetCharacterLogin(targetCID);
+    if(targetLogin)
+    {
+        targetLogin->SetPartyID(0);
+    }
+
+    libcomp::Packet request;
+    request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_KICK);
+    request.WriteS32Little(targetCID);
+
+    partyLogins.push_back(cLogin);
+    SendToCharacters(request, partyLogins, true);
+
+    auto members = party->GetMembers();
+    if(members.size() <= 1)
+    {
+        PartyDisband(party->GetID());
+    }
+}
+
+uint32_t CharacterManager::CreateParty(std::shared_ptr<objects::PartyCharacter> member)
+{
+    auto login = GetCharacterLogin(member->GetWorldCID());
+
+    std::lock_guard<std::mutex> lock(mLock);
+    uint32_t partyID = login->GetPartyID();
+    if(!partyID)
+    {
+        mParties[0]->RemoveMembers(login->GetWorldCID());
+        partyID = ++mMaxPartyID;
+        login->SetPartyID(partyID);
+
+        auto party = std::make_shared<objects::Party>();
+        party->SetID(partyID);
+        party->SetLeaderCID(login->GetWorldCID());
+        party->SetMembers(login->GetWorldCID(), member);
+        mParties[partyID] = party;
+    }
+
+    return partyID;
+}
+
+bool CharacterManager::RemoveFromParty(std::shared_ptr<objects::CharacterLogin> cLogin)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    auto it = mParties.find(cLogin->GetPartyID());
+    if(it != mParties.end() && it->second->MembersKeyExists(cLogin->GetWorldCID()))
+    {
+        it->second->RemoveMembers(cLogin->GetWorldCID());
+        return true;
+    }
+
+    return false;
+}

--- a/server/world/src/CharacterManager.h
+++ b/server/world/src/CharacterManager.h
@@ -1,0 +1,293 @@
+/**
+ * @file server/world/src/CharacterManager.h
+ * @ingroup world
+ *
+ * @author HACKfrost
+ *
+ * @brief Manager to handle world level character actions.
+ *
+ * This file is part of the World Server (world).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef SERVER_WORLD_SRC_CHARACTERMANAGER_H
+#define SERVER_WORLD_SRC_CHARACTERMANAGER_H
+
+// Standard C++11 Includes
+#include <unordered_map>
+
+// object Includes
+#include <CharacterLogin.h>
+#include <Party.h>
+#include <PartyCharacter.h>
+
+namespace libcomp
+{
+class Packet;
+class TcpConnection;
+}
+
+namespace world
+{
+
+class WorldServer;
+
+/**
+ * Manages world level character actions.
+ */
+class CharacterManager
+{
+public:
+    /**
+     * Create a new CharacterManager
+     * @param server Pointer back to the world server this
+     *  belongs to
+     */
+    CharacterManager(const std::weak_ptr<WorldServer>& server);
+
+    /**
+     * Register a CharacterLogin with the manager. Characters registered here will
+     * remain until the server restarts.
+     * @param cLogin CharacterLogins to register
+     * @return Pointer to the CharacterLogin registered with the server. null is
+     *  never returned and the value sent back should always replace the value
+     *  passed in to keep the servers in sync
+     */
+    std::shared_ptr<objects::CharacterLogin> RegisterCharacter(
+        std::shared_ptr<objects::CharacterLogin> cLogin);
+
+    /**
+     * Retrieve a CharacterLogin registered with the server by UUID
+     * @param uuid UUID associated to the character
+     * @return Pointer to the CharacterLogin registered with the server
+     */
+    std::shared_ptr<objects::CharacterLogin> GetCharacterLogin(
+        const libobjgen::UUID& uuid);
+
+    /**
+     * Retrieve a CharacterLogin registered with the server by world CID
+     * @param worldCID World CID associated to the character
+     * @return Pointer to the CharacterLogin registered with the server
+     */
+    std::shared_ptr<objects::CharacterLogin> GetCharacterLogin(int32_t worldCID);
+
+    /**
+     * Retrieve a CharacterLogin registered with the server by name
+     * @param characterName Name of the character
+     * @return Pointer to the CharacterLogin registered with the server
+     */
+    std::shared_ptr<objects::CharacterLogin> GetCharacterLogin(
+        const libcomp::String& characterName);
+
+    /**
+     * Send a packet to the specified logins
+     * @param p Packet to send
+     * @param cLogins CharacterLogins to map channel connections to when sending
+     *  the packet
+     * @param appendCIDs true if the list of world CIDs from the associated logins
+     *  should be appended to the end of the packet, false if it should be sent
+     *  as is
+     * @return false if an error occurs
+     */
+    bool SendToCharacters(libcomp::Packet& p,
+        const std::list<std::shared_ptr<objects::CharacterLogin>>& cLogins,
+        bool appendCIDs);
+
+    /**
+     * Send a packet to various characters related to the supplied world CID
+     * @param p Packet to send
+     * @param worldCID World CID used to find related characters
+     * @param appendCIDs true if the list of world CIDs from the characters found
+     *  should be appended to the end of the packet, false if it should be sent as is
+     * @param friends true if characters from the related friend list should be included
+     * @param party true if characters from the same party should be included
+     * @param includeSelf Optional parameter to include the character associated
+     *  to the world CID. Defaults to false.
+     * @param zoneRestrict Optional parameter to restrict the characters being
+     *  retrieved to ones in the same zone as the supplied CID. Defaults to false.
+     * @return false if an error occurs
+     */
+    bool SendToRelatedCharacters(libcomp::Packet& p, int32_t worldCID,
+        bool appendCIDs, bool friends, bool party, bool includeSelf = false,
+        bool zoneRestrict = false);
+
+    /**
+     * Retrieves characters related to the supplied CharacterLogin
+     * @param cLogin CharacterLogin to find related characters for
+     * @param friends true if characters from the related friend list should be included
+     * @param party true if characters from the same party should be included
+     * @return List of pointers to the related CharacterLogins
+     */
+    std::list<std::shared_ptr<objects::CharacterLogin>>
+        GetRelatedCharacterLogins(std::shared_ptr<objects::CharacterLogin> cLogin,
+            bool friends, bool party);
+
+    /**
+     * Send packets containing CharacterLogin information about the supplied logins
+     * contextual to other related characters
+     * @param cLogins CharacterLogins to send information about
+     * @param updateFlags CharacterLogin packet specific flags indicating what is
+     *  being sent.  Information will be filtered out in this function as needed.
+     *  For example if party information is being sent but the character is not in
+     *  a party, that specific character's part information will not be sent.  If
+     *  the filtering results in no flags, no data will be sent.
+     * @param zoneRestrict Optional parameter to restrict the characters being
+     *  notified to ones in the same zone as the supplied CID. Defaults to false.
+     */
+    void SendStatusToRelatedCharacters(
+        const std::list<std::shared_ptr<objects::CharacterLogin>>& cLogins,
+        uint8_t updateFlags, bool zoneRestrict = false);
+
+    /**
+     * Builds a status packet associated to the supplied CharacterLogin to be sent
+     * to related characters
+     * @param p Packet to write the data to
+     * @param cLogin CharacterLogin to send information about
+     * @param updateFlags CharacterLogin packet specific flags indicating what is
+     *  being sent.  Information will be filtered out in this function as needed.
+     * @return true if data was written, false if no data applied
+     */
+    bool GetStatusPacket(libcomp::Packet& p,
+        const std::shared_ptr<objects::CharacterLogin>& cLogin, uint8_t& updateFlags);
+
+    /**
+     * Get an active party by ID
+     * @param partyID ID of the party to retrieve
+     * @return Pointer to the active party
+     */
+    std::shared_ptr<objects::Party> GetParty(uint32_t partyID);
+
+    /**
+     * Get an active or pending party member by CharacterLogin
+     * @param cLogin CharacterLogin to retrieve the party member by
+     * @return Pointer to the party member
+     */
+    std::shared_ptr<objects::PartyCharacter>
+        GetPartyMember(std::shared_ptr<objects::CharacterLogin> cLogin);
+
+    /**
+     * Add a party member to the specified party
+     * @param member Pointer to the party member to add
+     * @param partyID ID of the party to add the member to
+     * @return true on success, false on failure
+     */
+    bool AddToParty(std::shared_ptr<objects::PartyCharacter> member,
+        uint32_t partyID);
+
+    /**
+     * Attempt to have a party member join the specified party
+     * @param member Pointer to the party member that will join. All
+     * necessary packet communication is handled within.
+     * @param targetName Name of a character that sent a join request,
+     *  can be left blank if joining directly
+     * @param partyID ID of the party to add the member to
+     * @param sourceConnection Connection associated to the member
+     *  joining the party
+     * @return true on success, false on failure
+     */
+    bool PartyJoin(std::shared_ptr<objects::PartyCharacter> member,
+        const libcomp::String targetName, uint32_t partyID,
+        std::shared_ptr<libcomp::TcpConnection> sourceConnection);
+
+    /**
+     * Attempt to have a party member leave their current party. All
+     * necessary packet communication is handled within.
+     * @param member Pointer to the CharacterLogin representation of
+     *  the party member leaving
+     * @param requestConnection Optional parameter for the connection
+     *  that sent the request
+     * @param tempLeave If true, the character will be able to join again
+     *  if the party remains.  Useful for handling log out joining.
+     */
+    void PartyLeave(std::shared_ptr<objects::CharacterLogin> cLogin,
+        std::shared_ptr<libcomp::TcpConnection> requestConnection, bool tempLeave);
+
+    /**
+     * Attempt to disband the specified party. All necessary packet
+     * communication is handled within.
+     * @param partyID ID of the party to disband
+     * @param sourceCID Optional ID of character who is disbanding the party
+     * @param requestConnection Optional parameter for the connection
+     *  that sent the request
+     */
+    void PartyDisband(uint32_t partyID, int32_t sourceCID = 0,
+        std::shared_ptr<libcomp::TcpConnection> requestConnection = nullptr);
+
+    /**
+     * Attempt to set the leader of the specified party. All necessary packet
+     * communication is handled within.
+     * @param partyID ID of the party to update
+     * @param sourceCID Optional ID of character who is setting the leader
+     * @param requestConnection Optional parameter for the connection
+     *  that sent the request
+     * @param targetCID CID of the new leader to set
+     */
+    void PartyLeaderUpdate(uint32_t partyID, int32_t sourceCID,
+        std::shared_ptr<libcomp::TcpConnection> requestConnection, int32_t targetCID);
+
+    /**
+     * Attempt to kick a player from their current party. All necessary packet
+     * communication is handled within.
+     * @param cLogin CharacterLogin of the character who sent the request
+     * @param targetCID CID of the character being kicked
+     */
+    void PartyKick(std::shared_ptr<objects::CharacterLogin> cLogin, int32_t targetCID);
+
+private:
+    /**
+     * Create a new party and set the supplied member as the leader
+     * @param member Party member to designate as the leader of a new party
+     * @return The ID of a the new party, 0 upon failure
+     */
+    uint32_t CreateParty(std::shared_ptr<objects::PartyCharacter> member);
+
+    /**
+     * Remove the supplied CharacterLogin from their current party
+     * @param cLogin CharacterLogin to remove
+     * @return true on succes, false if they were not in a party
+     */
+    bool RemoveFromParty(std::shared_ptr<objects::CharacterLogin> cLogin);
+
+    /// Pointer back to theworld server this belongs to
+    std::weak_ptr<WorldServer> mServer;
+
+    /// Map of character login information by UUID
+    std::unordered_map<libcomp::String,
+        std::shared_ptr<objects::CharacterLogin>> mCharacterMap;
+
+    /// Map of character login information by world CID
+    std::unordered_map<int32_t,
+        std::shared_ptr<objects::CharacterLogin>> mCharacterCIDMap;
+
+    /// Map of party IDs to parties registered with the server.
+    /// The party ID 0 is used for characters awaiting a join request
+    /// response
+    std::unordered_map<uint32_t, std::shared_ptr<objects::Party>> mParties;
+
+    /// Highest CID registered for a logged in character
+    int32_t mMaxCID;
+
+    /// Highest party ID registered with the server
+    uint32_t mMaxPartyID;
+
+    /// Server lock for shared resources
+    std::mutex mLock;
+};
+
+} // namespace world
+
+#endif // SERVER_WORLD_SRC_CHARACTERMANAGER_H

--- a/server/world/src/Packets.h
+++ b/server/world/src/Packets.h
@@ -40,6 +40,9 @@ PACKET_PARSER_DECL(GetWorldInfo);      // 0x1001
 PACKET_PARSER_DECL(SetChannelInfo);    // 0x1003
 PACKET_PARSER_DECL(AccountLogin);      // 0x1004
 PACKET_PARSER_DECL(AccountLogout);     // 0x1005
+PACKET_PARSER_DECL(CharacterLogin);    // 0x1007
+PACKET_PARSER_DECL(FriendsUpdate);     // 0x1008
+PACKET_PARSER_DECL(PartyUpdate);       // 0x1009
 
 } // namespace Parsers
 

--- a/server/world/src/WorldServer.h
+++ b/server/world/src/WorldServer.h
@@ -42,6 +42,7 @@
 
 // world Includes
 #include "AccountManager.h"
+#include "CharacterManager.h"
 
 namespace world
 {
@@ -95,6 +96,18 @@ public:
     std::shared_ptr<objects::RegisteredChannel> GetChannel(
         const std::shared_ptr<libcomp::InternalConnection>& connection) const;
 
+    /**
+     * Get channel connection associated to the specified ID.
+     * @param channelID ID of the channel to retrieve
+     * @return Pointer to the channel connnection
+     */
+    std::shared_ptr<libcomp::InternalConnection> GetChannelConnectionByID(
+        int8_t channelID) const;
+
+    /**
+     * Get all channels by connection.
+     * @return Map of channels by connection
+     */
     std::map<std::shared_ptr<libcomp::InternalConnection>,
         std::shared_ptr<objects::RegisteredChannel>> GetChannels() const;
 
@@ -162,6 +175,12 @@ public:
      */
     AccountManager* GetAccountManager();
 
+    /**
+     * Get the character manager for the server.
+     * @return Character manager for the server.
+     */
+    CharacterManager* GetCharacterManager();
+
 protected:
     /**
      * Create a connection to a newly active socket.
@@ -189,6 +208,9 @@ protected:
 
     /// Account manager for the server.
     AccountManager mAccountManager;
+
+    /// Character manager for the server.
+    CharacterManager* mCharacterManager;
 };
 
 } // namespace world

--- a/server/world/src/packets/AccountLogin.cpp
+++ b/server/world/src/packets/AccountLogin.cpp
@@ -37,6 +37,7 @@
 #include <Account.h>
 #include <AccountLogin.h>
 #include <Character.h>
+#include <CharacterLogin.h>
 
 // world Includes
 #include "AccountManager.h"
@@ -52,7 +53,7 @@ void LobbyLogin(std::shared_ptr<WorldServer> server,
     //The lobby is requesting a channel to log into
     bool ok = true;
 
-    auto accountManager = server->GetAccountManager();
+    auto cLogin = login->GetCharacterLogin();
     auto lobbyDB = server->GetLobbyDatabase();
     auto worldDB = server->GetWorldDatabase();
     auto account = login->GetAccount().Get(lobbyDB, true);
@@ -65,13 +66,12 @@ void LobbyLogin(std::shared_ptr<WorldServer> server,
     }
     else
     {
-        auto cid = login->GetCID();
-        auto characters = account->GetCharacters();
-        if(characters[cid].IsNull() ||
-            nullptr == characters[cid].Get(worldDB, true))
+        auto cUUID = cLogin->GetCharacter().GetUUID();
+        if(cUUID.IsNull() ||
+            nullptr == cLogin->GetCharacter().Get(worldDB, true))
         {
-            LOG_ERROR(libcomp::String("Character ID '%1' is not valid"
-                " for this world.\n").Arg(cid));
+            LOG_ERROR(libcomp::String("Character UUID '%1' is not valid"
+                " for this world.\n").Arg(cUUID.ToString()));
             ok = false;
         }
     }
@@ -88,24 +88,25 @@ void LobbyLogin(std::shared_ptr<WorldServer> server,
             auto worldID = std::dynamic_pointer_cast<objects::WorldConfig>(
                 server->GetConfig())->GetID();
             auto channelID = channel->GetID();
+            auto characterManager = server->GetCharacterManager();
 
-            login->SetWorldID((int8_t)worldID);
-            login->SetChannelID((int8_t)channelID);
+            // Login now to get the session key
+            server->GetAccountManager()->LoginUser(login);
 
-            //Login now to get the session key
-            accountManager->LoginUser(account->GetUsername(), login);
-            login->SetSessionKey(login->GetSessionKey());
+            // Get the cached character login or register a new one
+            cLogin = characterManager->RegisterCharacter(cLogin);
+            cLogin->SetWorldID((int8_t)worldID);
+            cLogin->SetChannelID((int8_t)channelID);
 
-            login->SavePacket(channelReply);
+            // Check if they were part of a party that was disbanded
+            if(cLogin->GetPartyID() &&
+                !characterManager->GetParty(cLogin->GetPartyID()))
+            {
+                cLogin->SetPartyID(0);
+            }
 
-            //Update the lobby with the new connection info
-            auto lobbyConnection = server->GetLobbyConnection();
-            libcomp::Packet lobbyMessage;
-            lobbyMessage.WritePacketCode(
-                InternalPacketCode_t::PACKET_ACCOUNT_LOGIN);
-
-            login->SavePacket(lobbyMessage);
-            lobbyConnection->SendPacket(lobbyMessage);
+            login->SetCharacterLogin(cLogin);
+            login->SavePacket(channelReply, false);
         }
     }
 
@@ -121,6 +122,7 @@ void ChannelLogin(std::shared_ptr<WorldServer> server,
     auto channel = server->GetChannel(connection);
     auto accountManager = server->GetAccountManager();
     auto login = accountManager->GetUserLogin(username);
+    auto cLogin = login != nullptr ? login->GetCharacterLogin() : nullptr;
     if(nullptr == channel)
     {
         LOG_ERROR("AccountLogin request received"
@@ -133,13 +135,13 @@ void ChannelLogin(std::shared_ptr<WorldServer> server,
         LOG_ERROR("No username passed to AccountLogin from the channel.\n");
         return;
     }
-    else if(nullptr == login)
+    else if(nullptr == login || nullptr == cLogin)
     {
         LOG_ERROR(libcomp::String("Account with username '%1'"
             " is not logged in to this world.\n").Arg(username));
         ok = false;
     }
-    else if(channel->GetID() != (uint8_t)login->GetChannelID())
+    else if(channel->GetID() != (uint8_t)cLogin->GetChannelID())
     {
         LOG_ERROR("AccountLogin request received from a channel"
             " not matching the account's current login information.\n");
@@ -158,7 +160,18 @@ void ChannelLogin(std::shared_ptr<WorldServer> server,
 
     if(ok)
     {
-        login->SavePacket(reply);
+        cLogin->SetWorldID((int8_t)server->GetRegisteredWorld()->GetID());
+        cLogin->SetStatus(objects::CharacterLogin::Status_t::ONLINE);
+        login->SavePacket(reply, false);
+
+        //Update the lobby with the new connection info
+        auto lobbyConnection = server->GetLobbyConnection();
+        libcomp::Packet lobbyMessage;
+        lobbyMessage.WritePacketCode(
+            InternalPacketCode_t::PACKET_ACCOUNT_LOGIN);
+
+        login->SavePacket(lobbyMessage, false);
+        lobbyConnection->SendPacket(lobbyMessage);
     }
 
     connection->SendPacket(reply);
@@ -174,7 +187,7 @@ bool Parsers::AccountLogin::Parse(libcomp::ManagerPacket *pPacketManager,
     if(connection == server->GetLobbyConnection())
     {
         auto login = std::shared_ptr<objects::AccountLogin>(new objects::AccountLogin);
-        if(!login->LoadPacket(p))
+        if(!login->LoadPacket(p, false))
         {
             return false;
         }

--- a/server/world/src/packets/CharacterLogin.cpp
+++ b/server/world/src/packets/CharacterLogin.cpp
@@ -1,0 +1,192 @@
+/**
+ * @file server/world/src/packets/CharacterLogin.cpp
+ * @ingroup world
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle communicating character login information from
+ *  the world to the channels.
+ *
+ * This file is part of the World Server (world).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+
+// world Includes
+#include "WorldServer.h"
+
+using namespace world;
+
+bool Parsers::CharacterLogin::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 5)
+    {
+        LOG_ERROR("Invalid packet data sent to CharacterLogin\n");
+        return false;
+    }
+
+    int32_t cid = p.ReadS32Little();
+    uint8_t updateFlags = p.ReadU8();
+   
+    auto server = std::dynamic_pointer_cast<WorldServer>(pPacketManager->GetServer());
+    auto cLogin = server->GetCharacterManager()->GetCharacterLogin(cid);
+    auto characterManager = server->GetCharacterManager();
+    if(!cLogin)
+    {
+        LOG_ERROR(libcomp::String("Invalid world CID sent to CharacterLogin: %1\n").Arg(cid));
+        return false;
+    }
+
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_STATUS)
+    {
+        if(p.Left() < 1)
+        {
+            LOG_ERROR("CharacterLogin status update sent with no status specified\n");
+            return false;
+        }
+
+        int8_t statusID = p.ReadS8();
+        cLogin->SetStatus((objects::CharacterLogin::Status_t)statusID);
+    }
+
+    uint32_t previousZoneID = cLogin->GetZoneID();
+    int8_t previousChannelID = cLogin->GetChannelID();
+    if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE)
+    {
+        if(p.Left() < 4)
+        {
+            LOG_ERROR("CharacterLogin zone update sent with no zone specified\n");
+            return false;
+        }
+
+        uint32_t zoneID = p.ReadU32Little();
+        cLogin->SetZoneID(zoneID);
+    }
+
+    bool isRejoin = false;
+    auto member = characterManager->GetPartyMember(cLogin);
+    if(!member && cLogin->GetPartyID() &&
+        (updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO ||
+         updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO))
+    {
+        // Should be a first login, attempt to rejoin the same party
+        isRejoin = true;
+        member = std::make_shared<objects::PartyCharacter>();
+    }
+
+    if(member)
+    {
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO)
+        {
+            if(!member->LoadPacket(p, true))
+            {
+                LOG_ERROR("CharacterLogin party member info failed to load\n");
+                return false;
+            }
+        }
+        
+        if(updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO)
+        {
+            auto partyDemon = member->GetDemon();
+            if(!partyDemon->LoadPacket(p, true))
+            {
+                LOG_ERROR("CharacterLogin party demon info failed to load\n");
+                return false;
+            }
+        }
+    }
+
+    if(isRejoin)
+    {
+        if(!characterManager->PartyJoin(member, "", cLogin->GetPartyID(), connection))
+        {
+            // Rejoin failed, clean up
+            characterManager->PartyLeave(cLogin, nullptr, false);
+        }
+    }
+
+    // Everything has been updated on the world, figure out what to send back
+    bool partyMove = updateFlags & (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE &&
+        cLogin->GetPartyID();
+
+    // Send all party flags if in a party and changing zones to members in that zone
+    if(partyMove)
+    {
+        updateFlags = updateFlags | (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_FLAGS;
+    }
+
+    // Send the updates
+    std::list<std::shared_ptr<objects::CharacterLogin>> logins = { cLogin };
+    characterManager->SendStatusToRelatedCharacters(logins, updateFlags, true);
+    
+    // If changing zones and in a party, update party member visibility (inverse of previous)
+    if(partyMove)
+    {
+        auto partyMembers = characterManager->GetRelatedCharacterLogins(
+            cLogin, false, true);
+
+        // Send all up to date info on party members in the zone they just entered or the left
+        bool queued = false;
+        for(auto login : partyMembers)
+        {
+            bool previousZone = login->GetZoneID() == previousZoneID &&
+                login->GetChannelID() == previousChannelID;
+            if((login->GetZoneID() != cLogin->GetZoneID() ||
+                login->GetChannelID() != cLogin->GetChannelID()) && !previousZone)
+            {
+                continue;
+            }
+
+            uint8_t outFlags = previousZone
+                ? ((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE
+                    | (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO)
+                : (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_FLAGS;
+
+            libcomp::Packet reply;
+            if(characterManager->GetStatusPacket(reply, login, outFlags) &&
+                (previousZone || outFlags != (uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_ZONE))
+            {
+                reply.WriteU16Little(1);
+                reply.WriteS32Little(cLogin->GetWorldCID());
+                connection->QueuePacket(reply);
+                queued = true;
+            }
+        }
+
+        if(queued)
+        {
+            connection->FlushOutgoing();
+        }
+    }
+
+    return true;
+}

--- a/server/world/src/packets/FriendsUpdate.cpp
+++ b/server/world/src/packets/FriendsUpdate.cpp
@@ -1,0 +1,415 @@
+/**
+ * @file server/world/src/packets/FriendsUpdate.cpp
+ * @ingroup world
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle all friend list focused actions between the
+ *  world and the channels.
+ *
+ * This file is part of the World Server (world).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+#include <FriendSettings.h>
+
+// world Includes
+#include "WorldServer.h"
+
+using namespace world;
+
+void FriendRequestCancel(const std::shared_ptr<libcomp::TcpConnection>& connection,
+    const libcomp::String otherName,
+    std::shared_ptr<objects::CharacterLogin> cLogin)
+{
+    libcomp::Packet reply;
+    reply.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+    reply.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO);
+    reply.WriteS32Little(cLogin->GetWorldCID());
+    reply.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+        otherName, true);
+
+    connection->SendPacket(reply);
+}
+
+void FriendList(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> connection,
+    std::shared_ptr<objects::CharacterLogin> cLogin)
+{
+    auto characterManager = server->GetCharacterManager();
+
+    auto fLogins = characterManager->GetRelatedCharacterLogins(
+        cLogin, true, false);
+    if(fLogins.size() == 0)
+    {
+        // No friend info to send
+        return;
+    }
+
+    libcomp::Packet reply;
+    reply.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+    reply.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST);
+    reply.WriteS32Little(cLogin->GetWorldCID());
+    reply.WriteS8((int8_t)fLogins.size());
+    for(auto fLogin : fLogins)
+    {
+        fLogin->SavePacket(reply);
+    }
+
+    connection->SendPacket(reply);
+}
+
+void FriendRequest(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> sourceConnection,
+    std::shared_ptr<objects::CharacterLogin> cLogin,
+    const libcomp::String sourceName, const libcomp::String targetName)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto targetLogin = characterManager->GetCharacterLogin(targetName);
+
+    // Check that the target character exists and is online
+    bool failed = !targetLogin || targetLogin->GetChannelID() < 0;
+    if(!failed)
+    {
+        auto worldDB = server->GetWorldDatabase();
+        auto sourceFSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, cLogin->GetCharacter());
+        for(auto f : sourceFSettings->GetFriends())
+        {
+            if(f.GetUUID() == targetLogin->GetCharacter().GetUUID())
+            {
+                // Already in the friends list
+                failed = true;
+            }
+        }
+
+        auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+        if(!failed && channel)
+        {
+            libcomp::Packet request;
+            request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_YN_REQUEST);
+            request.WriteS32Little(targetLogin->GetWorldCID());
+            request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+                sourceName, true);
+
+            channel->SendPacket(request);
+        }
+        else
+        {
+            failed = true;
+        }
+    }
+
+    if(failed)
+    {
+        FriendRequestCancel(sourceConnection, targetName, cLogin);
+    }
+}
+
+void FriendRequestAccepted(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> sourceConnection,
+    std::shared_ptr<objects::CharacterLogin> cLogin,
+    const libcomp::String sourceName, const libcomp::String targetName)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto targetLogin = characterManager->GetCharacterLogin(targetName);
+
+    // Check that the target character exists and is online
+    bool failed = !targetLogin || targetLogin->GetChannelID() < 0;
+    if(!failed)
+    {
+        auto worldDB = server->GetWorldDatabase();
+        auto sourceFSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, cLogin->GetCharacter());
+        auto targetFSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, targetLogin->GetCharacter());
+
+        if(sourceFSettings && targetFSettings)
+        {
+            if(sourceFSettings->FriendsCount() >= 100 ||
+                targetFSettings->FriendsCount() >= 100)
+            {
+                failed = true;
+            }
+            else
+            {
+                sourceFSettings->AppendFriends(targetLogin->GetCharacter().GetUUID());
+                targetFSettings->AppendFriends(cLogin->GetCharacter().GetUUID());
+                failed = !sourceFSettings->Update(worldDB) ||
+                    !targetFSettings->Update(worldDB);
+            }
+        }
+        else
+        {
+            failed = true;
+        }
+
+        auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+        if(!failed)
+        {
+            libcomp::Packet request;
+            request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES);
+            request.WriteS32Little(targetLogin->GetWorldCID());
+            request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+                sourceName, true);
+
+            sourceConnection->QueuePacket(request);
+            
+            request.Clear();
+            request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_ADD);
+            request.WriteS32Little(cLogin->GetWorldCID());
+            targetLogin->SavePacket(request);
+
+            sourceConnection->SendPacket(request);
+            
+            if(channel)
+            {
+                request.Clear();
+                request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+                request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_ADD);
+                request.WriteS32Little(targetLogin->GetWorldCID());
+                cLogin->SavePacket(request);
+
+                channel->SendPacket(request);
+            }
+            else
+            {
+                failed = true;
+            }
+        }
+        else
+        {
+            failed = true;
+            if(channel)
+            {
+                // Inform the other player too
+                FriendRequestCancel(channel, sourceName, targetLogin);
+            }
+        }
+    }
+
+    if(failed)
+    {
+        FriendRequestCancel(sourceConnection, targetName, cLogin);
+    }
+}
+
+void FriendRequestCancelled(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> sourceConnection,
+    std::shared_ptr<objects::CharacterLogin> cLogin,
+    const libcomp::String sourceName, const libcomp::String targetName)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto targetLogin = characterManager->GetCharacterLogin(targetName);
+
+    // Check that the target character exists and is online
+    bool failed = !targetLogin || targetLogin->GetChannelID() < 0;
+    if(!failed)
+    {
+        auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+        if(channel)
+        {
+            FriendRequestCancel(channel, sourceName, targetLogin);
+        }
+        else
+        {
+            failed = true;
+        }
+    }
+
+    if(failed)
+    {
+        FriendRequestCancel(sourceConnection, targetName, cLogin);
+    }
+}
+
+void FriendRemoved(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> sourceConnection,
+    std::shared_ptr<objects::CharacterLogin> cLogin,
+    int32_t targetCID)
+{
+    auto targetLogin = server->GetCharacterManager()->GetCharacterLogin(targetCID);
+
+    // Check that the target character exists
+    bool failed = !targetLogin;
+    if(!failed)
+    {
+        auto sourceUUID = cLogin->GetCharacter().GetUUID();
+        auto targetUUID = targetLogin->GetCharacter().GetUUID();
+
+        auto worldDB = server->GetWorldDatabase();
+        auto sourceFSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, sourceUUID);
+        auto targetFSettings = objects::FriendSettings::LoadFriendSettingsByCharacter(
+            worldDB, targetUUID);
+
+        if(sourceFSettings && targetFSettings)
+        {
+            for(size_t i = 0; i < sourceFSettings->FriendsCount(); i++)
+            {
+                auto f = sourceFSettings->GetFriends(i);
+                if(f.GetUUID() == targetUUID)
+                {
+                    sourceFSettings->RemoveFriends(i);
+                    break;
+                }
+            }
+            
+            for(size_t i = 0; i < targetFSettings->FriendsCount(); i++)
+            {
+                auto f = targetFSettings->GetFriends(i);
+                if(f.GetUUID() == sourceUUID)
+                {
+                    targetFSettings->RemoveFriends(i);
+                    break;
+                }
+            }
+
+            failed = !sourceFSettings->Update(worldDB) ||
+                !targetFSettings->Update(worldDB);
+        }
+        else
+        {
+            failed = true;
+        }
+
+        if(!failed)
+        {
+            libcomp::Packet request;
+            request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_REMOVE);
+            request.WriteS32Little(cLogin->GetWorldCID());
+            request.WriteS32Little(targetLogin->GetWorldCID());
+
+            sourceConnection->SendPacket(request);
+            
+            auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+            if(channel)
+            {
+                request.Clear();
+                request.WritePacketCode(InternalPacketCode_t::PACKET_FRIENDS_UPDATE);
+                request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_REMOVE);
+                request.WriteS32Little(targetLogin->GetWorldCID());
+                request.WriteS32Little(cLogin->GetWorldCID());
+
+                channel->SendPacket(request);
+            }
+        }
+    }
+
+    // Nothing to send to the client on failure
+}
+
+bool Parsers::FriendsUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 5)
+    {
+        LOG_ERROR("Invalid packet data sent to FriendsUpdate\n");
+        return false;
+    }
+
+    uint8_t mode = p.ReadU8();
+    int32_t cid = p.ReadS32Little();
+   
+    auto server = std::dynamic_pointer_cast<WorldServer>(pPacketManager->GetServer());
+    auto cLogin = server->GetCharacterManager()->GetCharacterLogin(cid);
+    if(!cLogin)
+    {
+        LOG_ERROR(libcomp::String("Invalid world CID sent to FriendsUpdate: %1\n").Arg(cid));
+        return false;
+    }
+
+    if((InternalPacketAction_t)mode == InternalPacketAction_t::PACKET_ACTION_FRIEND_LIST)
+    {
+        server->QueueWork(FriendList, server, connection, cLogin);
+    }
+    else if((InternalPacketAction_t)mode == InternalPacketAction_t::PACKET_ACTION_REMOVE)
+    {
+        if(p.Left() < 4)
+        {
+            LOG_ERROR(libcomp::String("Missing target CID parameter"
+                " for command %1\n").Arg(mode));
+            return false;
+        }
+
+        int32_t targetCID = p.ReadS32Little();
+        server->QueueWork(FriendRemoved, server, connection, cLogin, targetCID);
+    }
+    else
+    {
+        if(p.Left() < 2 || (p.Left() < (uint32_t)(2 + p.PeekU16Little())))
+        {
+            LOG_ERROR(libcomp::String("Missing source name parameter"
+                " for command %1\n").Arg(mode));
+            return false;
+        }
+
+        libcomp::String sourceName = p.ReadString16Little(
+            libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+        if(p.Left() < 2 || (p.Left() != (uint32_t)(2 + p.PeekU16Little())))
+        {
+            LOG_ERROR(libcomp::String("Missing target name parameter"
+                " for command %1\n").Arg(mode));
+            return false;
+        }
+
+        libcomp::String targetName = p.ReadString16Little(
+            libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+        switch((InternalPacketAction_t)mode)
+        {
+        case InternalPacketAction_t::PACKET_ACTION_YN_REQUEST:
+            server->QueueWork(FriendRequest, server, connection, cLogin,
+                sourceName, targetName);
+            break;
+        case InternalPacketAction_t::PACKET_ACTION_ADD:
+        case InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES:
+            server->QueueWork(FriendRequestAccepted, server, connection, cLogin,
+                sourceName, targetName);
+            break;
+        case InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO:
+            server->QueueWork(FriendRequestCancelled, server, connection, cLogin,
+                sourceName, targetName);
+            break;
+        default:
+            LOG_ERROR(libcomp::String("Unknown mode sent to FriendsUpdate: %1\n").Arg(mode));
+            return false;
+            break;
+        }
+    }
+
+    return true;
+}

--- a/server/world/src/packets/PartyUpdate.cpp
+++ b/server/world/src/packets/PartyUpdate.cpp
@@ -1,0 +1,310 @@
+/**
+ * @file server/world/src/packets/PartyUpdate.cpp
+ * @ingroup world
+ *
+ * @author HACKfrost
+ *
+ * @brief Parser to handle all party focused actions between the world
+ *  and the channels.
+ *
+ * This file is part of the World Server (world).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// object Includes
+#include <Account.h>
+#include <AccountLogin.h>
+#include <Character.h>
+#include <CharacterLogin.h>
+
+// world Includes
+#include "WorldServer.h"
+
+using namespace world;
+
+void PartyInvite(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> requestConnection,
+    std::shared_ptr<objects::PartyCharacter> member, const libcomp::String targetName)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto cLogin = characterManager->GetCharacterLogin(member->GetName());
+    auto targetLogin = characterManager->GetCharacterLogin(targetName);
+
+    uint16_t responseCode = 201;  // Not available
+    if(cLogin && targetLogin && targetLogin->GetChannelID() >= 0)
+    {
+        if(targetLogin->GetPartyID() != 0)
+        {
+            responseCode = 202;  // Already in a party
+        }
+        else
+        {
+            characterManager->AddToParty(member, 0);
+            auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+            if(channel)
+            {
+                libcomp::Packet request;
+                request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+                request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_YN_REQUEST);
+                request.WriteU8(0); // Not a response
+                request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+                    member->GetName(), true);
+                request.WriteU32Little(cLogin->GetPartyID());
+                request.WriteS32Little(targetLogin->GetWorldCID());
+
+                channel->SendPacket(request);
+
+                responseCode = 200; // Success
+            }
+        }
+    }
+
+    libcomp::Packet response;
+    response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_YN_REQUEST);
+    response.WriteU8(1); // Is a response
+    response.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+        targetName, true);
+    response.WriteU16Little(responseCode);
+    response.WriteS32Little(cLogin->GetWorldCID());
+
+    requestConnection->SendPacket(response);
+}
+
+void PartyCancel(std::shared_ptr<WorldServer> server,
+    const libcomp::String sourceName, const libcomp::String targetName, uint32_t partyID)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto targetLogin = characterManager->GetCharacterLogin(targetName);
+
+    if(targetLogin && targetLogin->GetChannelID() >= 0 && partyID == targetLogin->GetPartyID())
+    {
+        auto channel = server->GetChannelConnectionByID(targetLogin->GetChannelID());
+        if(channel)
+        {
+            libcomp::Packet request;
+            request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+            request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO);
+            request.WriteString16Little(libcomp::Convert::Encoding_t::ENCODING_UTF8,
+                sourceName, true);
+            request.WriteS32Little(targetLogin->GetWorldCID());
+
+            channel->SendPacket(request);
+        }
+    }
+}
+
+
+void PartyDropRule(std::shared_ptr<WorldServer> server,
+    std::shared_ptr<libcomp::TcpConnection> requestConnection,
+    std::shared_ptr<objects::CharacterLogin> cLogin, uint8_t rule)
+{
+    auto characterManager = server->GetCharacterManager();
+    auto party = characterManager->GetParty(cLogin->GetPartyID());
+
+    uint16_t responseCode = 201;    // Failure
+    if(party)
+    {
+        party->SetDropRule(rule);
+        responseCode = 200; // Success
+    }
+    
+    libcomp::Packet response;
+    response.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+    response.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE);
+    response.WriteU8(1); // Is a response
+    response.WriteU16Little(responseCode);
+    response.WriteS32Little(cLogin->GetWorldCID());
+
+    requestConnection->QueuePacket(response);
+
+    if(responseCode == 200)
+    {
+        libcomp::Packet request;
+        request.WritePacketCode(InternalPacketCode_t::PACKET_PARTY_UPDATE);
+        request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE);
+        request.WriteU8(0); // Not a response
+        request.WriteU8(party->GetDropRule());
+
+        server->GetCharacterManager()->SendToRelatedCharacters(request,
+            cLogin->GetWorldCID(), true, false, true, true);
+    }
+
+    requestConnection->FlushOutgoing();
+}
+
+bool Parsers::PartyUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    if(p.Size() < 5)
+    {
+        LOG_ERROR("Invalid packet data sent to PartyUpdate\n");
+        return false;
+    }
+
+    uint8_t mode = p.ReadU8();
+
+    auto server = std::dynamic_pointer_cast<WorldServer>(pPacketManager->GetServer());
+    switch((InternalPacketAction_t)mode)
+    {
+    case InternalPacketAction_t::PACKET_ACTION_YN_REQUEST:
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_YES:
+        {
+            auto member = std::make_shared<objects::PartyCharacter>();
+            if(!member->LoadPacket(p, false))
+            {
+                LOG_ERROR(libcomp::String("Party member data failed to load"
+                    " for command %1\n").Arg(mode));
+                return false;
+            }
+
+            if(p.Left() < 2 || (p.Left() < (uint32_t)(2 + p.PeekU16Little())))
+            {
+                LOG_ERROR(libcomp::String("Missing target name parameter"
+                    " for command %1\n").Arg(mode));
+                return false;
+            }
+
+            libcomp::String targetName = p.ReadString16Little(
+                libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+            if((InternalPacketAction_t)mode == InternalPacketAction_t::PACKET_ACTION_YN_REQUEST)
+            {
+                // Party invite
+                PartyInvite(server, connection, member, targetName);
+            }
+            else
+            {
+                // Party invite accept
+                if(p.Left() != 4)
+                {
+                    LOG_ERROR("Missing party ID parameter for party invite accept command\n");
+                    return false;
+                }
+
+                uint32_t partyID = p.ReadU32Little();
+                server->GetCharacterManager()->PartyJoin(member, targetName, partyID, connection);
+            }
+            
+            return true;
+        }
+        break;
+    default:
+        // Check for later party based requests
+        break;
+    }
+
+    int32_t cid = p.ReadS32Little();
+   
+    auto cLogin = server->GetCharacterManager()->GetCharacterLogin(cid);
+    if(!cLogin)
+    {
+        LOG_ERROR(libcomp::String("Invalid world CID sent to PartyUpdate: %1\n").Arg(cid));
+        return false;
+    }
+
+    switch((InternalPacketAction_t)mode)
+    {
+    case InternalPacketAction_t::PACKET_ACTION_RESPONSE_NO:
+        {
+            if(p.Left() < 2 || (p.Left() < (uint32_t)(2 + p.PeekU16Little())))
+            {
+                LOG_ERROR("Missing source name parameter for party invite cancel command\n");
+                return false;
+            }
+
+            libcomp::String sourceName = p.ReadString16Little(
+                libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+            if(p.Left() < 2 || (p.Left() < (uint32_t)(2 + p.PeekU16Little())))
+            {
+                LOG_ERROR("Missing target name parameter for party invite cancel command\n");
+                return false;
+            }
+
+            libcomp::String targetName = p.ReadString16Little(
+                libcomp::Convert::Encoding_t::ENCODING_UTF8, true);
+
+            if(p.Left() != 4)
+            {
+                LOG_ERROR(libcomp::String("Missing party ID parameter"
+                    " for command %1\n").Arg(mode));
+                return false;
+            }
+
+            uint32_t partyID = p.ReadU32Little();
+            PartyCancel(server, sourceName, targetName, partyID);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_LEAVE:
+        server->GetCharacterManager()->PartyLeave(cLogin, connection, false);
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_DISBAND:
+        server->GetCharacterManager()->PartyDisband(cLogin->GetPartyID(), cLogin->GetWorldCID(), connection);
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_LEADER_UPDATE:
+        {
+            if(p.Left() != 4)
+            {
+                LOG_ERROR("Missing leader CID parameter for party leader update command\n");
+                return false;
+            }
+
+            int32_t targetCID = p.ReadS32Little();
+            server->GetCharacterManager()->PartyLeaderUpdate(cLogin->GetPartyID(), cLogin->GetWorldCID(),
+                connection, targetCID);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_DROP_RULE:
+        {
+            if(p.Left() != 1)
+            {
+                LOG_ERROR("Missing rule parameter for party drop rule command\n");
+                return false;
+            }
+
+            uint8_t rule = p.ReadU8();
+            PartyDropRule(server, connection, cLogin, rule);
+        }
+        break;
+    case InternalPacketAction_t::PACKET_ACTION_PARTY_KICK:
+        {
+            if(p.Left() != 4)
+            {
+                LOG_ERROR("Missing target CID parameter for party kick command\n");
+                return false;
+            }
+
+            int32_t targetCID = p.ReadS32Little();
+            server->GetCharacterManager()->PartyKick(cLogin, targetCID);
+        }
+        break;
+    default:
+        break;
+    }
+
+    return true;
+}


### PR DESCRIPTION
Also contains fixes for loading by database keyword field names in MariaDB (ex: Character) as well as reference updates on reload dropping persistent objects that were otherwise not being referenced.

Fixes #210 
Fixes #213 
