### PR TITLE
Status effects, character revival and configurable timeouts

### DIFF
--- a/contrib/testing/channel.xml
+++ b/contrib/testing/channel.xml
@@ -25,6 +25,6 @@
         <member name="WorldIP">127.0.0.1</member>
         <member name="WorldPort">18666</member>
         <member name="ExternalIP">127.0.0.1</member>
-        <member name="TimeoutEnabled">false</member>
+        <member name="Timeout">0</member>
     </object>
 </objgen>

--- a/libcomp/CMakeLists.txt
+++ b/libcomp/CMakeLists.txt
@@ -231,6 +231,7 @@ SET(${PROJECT_NAME}_SCHEMA
     schema/binarydata/shopproductdata.xml
     schema/binarydata/skilldata.xml
     schema/binarydata/spotdata.xml
+    schema/binarydata/statusdata.xml
     schema/binarydata/zonedata.xml
 )
 
@@ -377,6 +378,8 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     MiBattleDamageData.h
     MiBreakData.cpp
     MiBreakData.h
+    MiCancelData.cpp
+    MiCancelData.h
     MiCastBasicData.cpp
     MiCastBasicData.h
     MiCastCancelData.cpp
@@ -417,8 +420,12 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     MiDevilReunionConditionData.h
     MiDischargeData.cpp
     MiDischargeData.h
+    MiDoTDamageData.cpp
+    MiDoTDamageData.h
     MiDynamicMapData.h
     MiDynamicMapData.cpp
+    MiEffectData.cpp
+    MiEffectData.h
     MiEffectiveRangeData.cpp
     MiEffectiveRangeData.h
     MiExpertClassData.cpp
@@ -481,6 +488,10 @@ OBJGEN_XML(${PROJECT_NAME}_STRUCTS
     MiSkillSpecialParams.h
     MiSkillTbl.h
     MiSkillTbl.cpp
+    MiStatusBasicData.cpp
+    MiStatusBasicData.h
+    MiStatusData.cpp
+    MiStatusData.h
     MiSummonData.cpp
     MiSummonData.h
     MiTargetData.cpp

--- a/libcomp/schema/binarydata/shared.xml
+++ b/libcomp/schema/binarydata/shared.xml
@@ -1,12 +1,229 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <objgen>
     <object name="MiCategoryData" persistent="false" scriptenabled="true">
-        <member type="u8" name="unk1"/>
-        <member type="u8" name="unk2"/>
-        <member type="u16" name="unk3"/>
+        <member type="u8" name="mainCategory"/>
+        <member type="u8" name="subCategory"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiCorrectTbl" persistent="false" scriptenabled="true">
-        <member type="u8" name="ID"/>
+        <member type="enum" name="ID" underlying="uint8_t">
+            <!-- 力 - Strength -->
+            <value num="0">STR</value>
+            <!-- 魔力 - Magic Power -->
+            <value num="1">MAGIC</value>
+            <!-- 体力 - Vitality -->
+            <value num="2">VIT</value>
+            <!-- 知力 - Intelligence -->
+            <value num="3">INT</value>
+            <!-- 速さ - Speed -->
+            <value num="4">SPEED</value>
+            <!-- 運 - Luck -->
+            <value num="5">LUCK</value>
+            <!-- 最大HP - Max HP -->
+            <value num="6">HP_MAX</value>
+            <!-- 最大MP - Max MP -->
+            <value num="7">MP_MAX</value>
+            <!-- ＨＰ自然回復量 - HP Regen -->
+            <value num="8">HP_REGEN</value>
+            <!-- ＭＰ自然回復量 - MP Regen -->
+            <value num="9">MP_REGEN</value>
+            <!-- 移動速度 - Movement Speed 1 -->
+            <value num="10">MOVE1</value>
+            <!-- 移動速度 - Movement Speed 2 -->
+            <value num="11">MOVE2</value>
+            <!-- 近接 - Melee -->
+            <value num="12">CLSR</value>
+            <!-- 射撃 - Gun -->
+            <value num="13">LNGR</value>
+            <!-- 魔法 - Magic -->
+            <value num="14">SPELL</value>
+            <!-- 援助 - Support -->
+            <value num="15">SUPPORT</value>
+            <!-- 必殺発生 - Crit Chance -->
+            <value num="16">CRITICAL</value>
+            <!-- 召喚速度 - Summoning Speed -->
+            <value num="17">SUMMON_SPEED</value>
+            <!-- 物理防御 - Physical Defense -->
+            <value num="19">PDEF</value>
+            <!-- 魔法防御 - Magic Defense -->
+            <value num="20">MDEF</value>
+            <!-- 必殺抑止 - Critical Defense -->
+            <value num="21">CRIT_DEF</value>
+            <!-- 武器依存耐性 - Weapon Resistance -->
+            <value num="27">RES_WEAPON</value>
+            <!-- 斬撃耐性 - Slash Resistance -->
+            <value num="28">RES_SLASH</value>
+            <!-- 突撃耐性 - Thrust Resistance -->
+            <value num="29">RES_THRUST</value>
+            <!-- 打撃耐性 - Strike Resistance -->
+            <value num="30">RES_STRIKE</value>
+            <!-- 射撃耐性 - Gun Resistance -->
+            <value num="31">RES_LNGR</value>
+            <!-- 貫通耐性 - Pierce Resistance -->
+            <value num="32">RES_PIERCE</value>
+            <!-- 散弾耐性 - Spread Resistance -->
+            <value num="33">RES_SPREAD</value>
+            <!-- 火炎耐性 - Fire Resistance -->
+            <value num="34">RES_FIRE</value>
+            <!-- 氷結耐性 - Ice Resistance -->
+            <value num="35">RES_ICE</value>
+            <!-- 電撃耐性 - Elec Resistance -->
+            <value num="36">RES_ELEC</value>
+            <!-- 万能耐性 - Almighy Resistance -->
+            <value num="37">RES_ALMIGHTY</value>
+            <!-- 衝撃耐性 - Force Resistance -->
+            <value num="38">RES_FORCE</value>
+            <!-- 破魔耐性 - Expel Resistance -->
+            <value num="39">RES_EXPEL</value>
+            <!-- 呪殺耐性 - Curse Resistance -->
+            <value num="40">RES_CURSE</value>
+            <!-- 回復耐性 - Healing Resistance -->
+            <value num="41">RES_HEAL</value>
+            <!-- 援助耐性 - Support Resistance -->
+            <value num="42">RES_SUPPORT</value>
+            <!-- 魔力耐性 - Sorcery Resistance -->
+            <value num="43">RES_MAGICFORCE</value>
+            <!-- 神経耐性 - Nerve Resistance -->
+            <value num="44">RES_NERVE</value>
+            <!-- 精神耐性 - Mental Resistance -->
+            <value num="45">RES_MIND</value>
+            <!-- 言霊耐性 - Word Resistance -->
+            <value num="46">RES_WORD</value>
+            <!-- 特殊耐性 - Special Resistance -->
+            <value num="47">RES_SPECIAL</value>
+            <!-- 自爆耐性 - Self-Destruct Resistance -->
+            <value num="48">RES_SUICIDE</value>
+            <!-- 火炎(無効/反射/吸収) - Null/Reflect/Absorb Fire (Rarely Used) -->
+            <value num="50">NRA_FIRE_2</value>
+            <!-- 斬撃(無効/反射/吸収) - Null/Reflect/Absorb Slash -->
+            <value num="51">NRA_SLASH</value>
+            <!-- 突撃(無効/反射/吸収) - Null/Reflect/Absorb Thrust -->
+            <value num="52">NRA_THRUST</value>
+            <!-- 打撃(無効/反射/吸収) - Null/Reflect/Absorb Strike -->
+            <value num="53">NRA_STRIKE</value>
+            <!-- 射撃(無効/反射/吸収) - Null/Reflect/Absorb Gun -->
+            <value num="54">NRA_LNGR</value>
+            <!-- 貫通(無効/反射/吸収) - Null/Reflect/Absorb Pierce -->
+            <value num="55">NRA_PIERCE</value>
+            <!-- 散弾(無効/反射/吸収) - Null/Reflect/Absorb Spread -->
+            <value num="56">NRA_SPREAD</value>
+            <!-- 火炎(無効/反射/吸収) - Null/Reflect/Absorb Fire -->
+            <value num="57">NRA_FIRE</value>
+            <!-- 氷結(無効/反射/吸収) - Null/Reflect/Absorb Ice -->
+            <value num="58">NRA_ICE</value>
+            <!-- 電撃(無効/反射/吸収) - Null/Reflect/Absorb Elec -->
+            <value num="59">NRA_ELEC</value>
+            <!-- 万能(無効/反射/吸収) - Null/Reflect/Absorb Almighty -->
+            <value num="60">NRA_ALMIGHTY</value>
+            <!-- 衝撃(無効/反射/吸収) - Null/Reflect/Absorb Force -->
+            <value num="61">NRA_FORCE</value>
+            <!-- 破魔(無効/反射/吸収) - Null/Reflect/Absorb Expel -->
+            <value num="62">NRA_EXPEL</value>
+            <!-- 呪殺(無効/反射/吸収) - Null/Reflect/Absorb Curse -->
+            <value num="63">NRA_CURSE</value>
+            <!-- 回復(無効/反射/吸収) - Null/Reflect/Absorb Healing -->
+            <value num="64">NRA_HEAL</value>
+            <!-- 援助(無効/反射/吸収) - Null/Reflect/Absorb Support -->
+            <value num="65">NRA_SUPPORT</value>
+            <!-- 魔力(無効/反射/吸収) - Null/Reflect/Absorb Sorcery -->
+            <value num="66">NRA_MAGICFORCE</value>
+            <!-- 神経(無効/反射/吸収) - Null/Reflect/Absorb Nerve -->
+            <value num="67">NRA_NERVE</value>
+            <!-- 精神(無効/反射/吸収) - Null/Reflect/Absorb Mental -->
+            <value num="68">NRA_MIND</value>
+            <!-- 言霊(無効/反射/吸収) - Null/Reflect/Absorb Word -->
+            <value num="69">NRA_WORD</value>
+            <!-- 特殊(無効/反射/吸収) - Null/Reflect/Absorb Special -->
+            <value num="70">NRA_SPECIAL</value>
+            <!-- 特殊(無効/反射/吸収) - Null/Reflect/Absorb Self-Destruct -->
+            <value num="71">NRA_SUICIDE</value>
+            <!-- 魔法(無効/反射/吸収) - Null/Reflect/Absorb Magic -->
+            <value num="72">NRA_MAG</value>
+            <!-- 物理(無効/反射/吸収) - Null/Reflect/Absorb Physical -->
+            <value num="73">NRA_PHYS</value>
+            <!-- クールタイム - Cool time -->
+            <value num="78">COOLDOWN_TIME</value>
+            <!-- 状態変化抵抗 - Resistance to Status Effects -->
+            <value num="79">RES_STATUS</value>
+            <!-- 経験値獲得量 - Experience Acquisition Rate -->
+            <value num="80">UP_EXP</value>
+            <!-- マグネタイト獲得量 - Magnetite Acquisition Rate -->
+            <value num="81">UP_MAG</value>
+            <!-- マッカ獲得量 - Makka Acquisition Rate -->
+            <value num="82">UP_MACCA</value>
+            <!-- エキスパート獲得量 - Expertise Acquisition Rate -->
+            <value num="83">UP_EXPERTISE</value>
+            <!-- 与近接ダメージ - Physical Damage Dealt -->
+            <value num="84">UP_CLSR</value>
+            <!-- 与射撃ダメージ - Gun Damage Dealt -->
+            <value num="85">UP_LNGR</value>
+            <!-- 与魔法ダメージ - Magic Damage Dealt -->
+            <value num="86">UP_SPELL</value>
+            <!-- 与援助ダメージ - Support "Damage" Dealt -->
+            <value num="87">UP_SUPPORT</value>
+            <!-- 回復高揚:効果 - Healing Effect Up -->
+            <value num="88">UP_HEAL</value>
+            <!-- 被近接ダメージ - Physical Damage Received -->
+            <value num="89">UP_CLSR_TAKEN</value>
+            <!-- 被射撃ダメージ - Gun Damage Received -->
+            <value num="90">UP_LNGR_TAKEN</value>
+            <!-- 被魔法ダメージ - Magic Damage Received -->
+            <value num="91">UP_MAGIC_TAKEN</value>
+            <!-- 被援助ダメージ - Support "Damage" Dealt -->
+            <value num="92">UP_SUPPORT_TAKEN</value>
+            <!-- 被回復量 - Healing Amount Up -->
+            <value num="95">UP_HEAL_AMOUNT</value>
+            <!-- 斬撃高揚 - Slash Boost -->
+            <value num="96">BOOST_SLASH</value>
+            <!-- 突撃高揚 - Thrust Boost -->
+            <value num="97">BOOST_THRUST</value>
+            <!-- 打撃高揚 - Strike Boost -->
+            <value num="98">BOOST_STRIKE</value>
+            <!-- 射撃高揚 - Gun Boost -->
+            <value num="99">BOOST_LNGR</value>
+            <!-- 貫通高揚 - Pierce Boost -->
+            <value num="100">BOOST_PIERCE</value>
+            <!-- 散弾高揚 - Spread Boost -->
+            <value num="101">BOOST_SPREAD</value>
+            <!-- 火炎高揚 - Fire Boost -->
+            <value num="102">BOOST_FIRE</value>
+            <!-- 氷結高揚 - Ice Boost -->
+            <value num="103">BOOST_ICE</value>
+            <!-- 電撃高揚 - Elect Boost -->
+            <value num="104">BOOST_ELEC</value>
+            <!-- 万能高揚 - Almighty Boost -->
+            <value num="105">BOOST_ALMIGHTY</value>
+            <!-- 衝撃高揚 - Force Boost -->
+            <value num="106">BOOST_FORCE</value>
+            <!-- 破魔高揚 - Expel Boost -->
+            <value num="107">BOOST_EXPEL</value>
+            <!-- 呪殺高揚 - Curse Boost -->
+            <value num="108">BOOST_CURSE</value>
+            <!-- 回復高揚 - Healing Boost -->
+            <value num="109">BOOST_HEAL</value>
+            <!-- 援助高揚 - Support Boost -->
+            <value num="110">BOOST_SUPPORT</value>
+            <!-- 魔力高揚 - Sorcery Boost -->
+            <value num="111">BOOST_MAGICFORCE</value>
+            <!-- 神経高揚 - Nerve Boost -->
+            <value num="112">BOOST_NERVE</value>
+            <!-- 精神高揚 - Mental Boost -->
+            <value num="113">BOOST_MIND</value>
+            <!-- 言霊高揚 - Word Boost -->
+            <value num="114">BOOST_WORD</value>
+            <!-- 特殊高揚 - Special Boost -->
+            <value num="115">BOOST_SPECIAL</value>
+            <!-- 自爆高揚 - Self-Destruct Boost -->
+            <value num="116">BOOST_SUICIDE</value>
+            <!-- リミットブレイク発生確率 - Limit Break Chance -->
+            <value num="117">BOOST_LB_CHANCE</value>
+            <!-- リミットブレイク威力補正 - Limit Break Damage -->
+            <value num="118">BOOST_LB_DAMAGE</value>
+            <!-- 最終クリティカル率補正 - Total Crit Chance -->
+            <value num="119">CRIT_CHANCE_TOTAL</value>
+            <!-- 防御拡張２ - Defense Expansion 2 -->
+            <value num="120">DEFENSE_EXPAND_2</value>
+        </member>
         <member type="enum" name="Type" underlying="uint8_t" default="NUMERIC">
             <value>NUMERIC</value>
             <value>PERCENT</value>
@@ -18,8 +235,8 @@
         <member type="u32" name="id" caps="true"/>
         <member type="MiCategoryData*" name="category"/>
         <member type="u8" name="affinity"/>
-        <member type="u8" name="common1"/>
-        <member type="u16" name="common2"/>
+        <member type="u8" name="unused1"/>
+        <member type="u16" name="unused2"/>
         <member type="list" name="correctTbl">
             <element type="MiCorrectTbl*"/>
         </member>

--- a/libcomp/schema/binarydata/skilldata.xml
+++ b/libcomp/schema/binarydata/skilldata.xml
@@ -10,7 +10,7 @@
         <member type="u8" name="basic5"/>
         <member type="u8" name="basic6"/>
         <member type="u8" name="basic7"/>
-        <member type="u8" name="basic8"/>
+        <member type="u8" name="unused"/>
         <member type="u32" name="cooldownID"/>
     </object>
     <object name="MiRestrictionData" persistent="false">
@@ -62,12 +62,12 @@
         <member type="u32" name="chargeTime"/>
         <member type="u8" name="stackCount"/>
         <member type="u8" name="cast3"/>
-        <member type="u16" name="cast4"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiCastCancelData" persistent="false">
         <member type="bool" name="damageCancel"/>
         <member type="bool" name="knockbackCancel"/>
-        <member type="u16" name="cancel3"/>
+        <member type="u16" name="unused"/>
         <member type="u32" name="autoCancelTime"/>
     </object>
     <object name="MiCastData" persistent="false">
@@ -91,7 +91,7 @@
             <value num="13">ALLY_DEMON</value>
             <value num="14">PLAYER</value>
         </member>
-        <member type="u8" name="target3"/>
+        <member type="u8" name="unused"/>
     </object>
     <object name="MiDischargeData" persistent="false">
         <member type="u32" name="discharge1"/>
@@ -99,8 +99,8 @@
         <member type="u32" name="discharge3"/>
         <member type="u32" name="stiffness"/>
         <member type="bool" name="discharge5"/>
-        <member type="u8" name="discharge6"/>
-        <member type="u16" name="discharge7"/>
+        <member type="u8" name="unused1"/>
+        <member type="u16" name="unused2"/>
     </object>
     <object name="MiEffectiveRangeData" persistent="false">
         <member type="enum" name="areaType" underlying="uint8_t">
@@ -122,7 +122,7 @@
             <value num="4">SOURCE</value>
             <value num="6">DEAD_PARTY</value>
         </member>
-        <member type="u16" name="range3"/>
+        <member type="u16" name="unused"/>
         <member type="s32" name="aoeRange"/>
         <member type="s32" name="aoeTargetMax"/>
     </object>
@@ -142,12 +142,12 @@
         </member>
         <member type="u8" name="battleDamage2"/>
         <member type="u8" name="castRange"/>
-        <member type="u8" name="battleDamage4"/>
+        <member type="u8" name="unused1"/>
         <member type="u16" name="modifier1"/>
         <member type="u16" name="modifier2"/>
         <member type="u8" name="HPDrainPercent"/>
         <member type="u8" name="MPDrainPercent"/>
-        <member type="u16" name="battleDamage9"/>
+        <member type="u16" name="unused2"/>
     </object>
     <object name="MiNegotiationDamageData" persistent="false">
         <member type="s8" name="negotiationDamage1"/>
@@ -166,12 +166,12 @@
     </object>
     <object name="MiAddStatusTbl" persistent="false">
         <member type="u32" name="statusID"/>
-        <member type="s8" name="addStatus2"/>
-        <member type="s8" name="addStatus3"/>
-        <member type="u8" name="addStatus4"/>
-        <member type="bool" name="isCancel"/>
+        <member type="s8" name="maxStack"/>
+        <member type="s8" name="minStack"/>
+        <member type="u8" name="onKnockback"/>
+        <member type="bool" name="isReplace"/>
         <member type="u16" name="successRate"/>
-        <member type="u16" name="addStatus7"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiDamageData" persistent="false">
         <member type="MiBattleDamageData*" name="battleDamage"/>
@@ -182,13 +182,13 @@
         <member type="list" name="addStatuses">
             <element type="MiAddStatusTbl*"/>
         </member>
-        <member type="u16" name="damage1"/>
-        <member type="u16" name="damage2"/>
+        <member type="u16" name="functionID"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiAcquisitionData" persistent="false">
         <member type="u8" name="acquisition1"/>
         <member type="s8" name="acquisition2"/>
-        <member type="u16" name="acquisition3"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiExpertGrowthTbl" persistent="false">
         <member type="u8" name="expertiseID"/>
@@ -212,7 +212,7 @@
             <value>PVP_ONLY</value>
         </member>
         <member type="u8" name="pvp2"/>
-        <member type="u16" name="pvp3"/>
+        <member type="u16" name="unused"/>
     </object>
     <object name="MiSkillData" persistent="false">
         <member type="MiSkillItemStatusCommonData*" name="common"/>

--- a/libcomp/schema/binarydata/statusdata.xml
+++ b/libcomp/schema/binarydata/statusdata.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<objgen>
+    <include path="binarydata/shared.xml"/>
+    
+    <object name="MiStatusBasicData" persistent="false">
+        <member type="u8" name="maxStack"/>
+        <member type="u8" name="stackType"/>
+        <member type="u8" name="applicationLogic"/>
+        <member type="u8" name="unknown"/>
+        <member type="u16" name="groupID"/>
+        <member type="u8" name="groupRank"/>
+        <member type="u8" name="unused"/>
+        <member type="u32" name="functionID"/>
+    </object>
+    <object name="MiDoTDamageData" persistent="false">
+        <member type="s16" name="HPDamage"/>
+        <member type="s16" name="MPDamage"/>
+    </object>
+    <object name="MiEffectData" persistent="false">
+        <member type="u32" name="restrictions"/>
+        <member type="MiDoTDamageData*" name="damage"/>
+    </object>
+    <object name="MiCancelData" persistent="false">
+        <member type="u32" name="duration"/>
+        <member type="enum" name="durationType" underlying="uint8_t">
+            <value num="0">MS</value>
+            <value num="1">DAY</value>
+            <value num="3">NONE</value>
+            <value num="4">HOUR</value>
+            <value num="5">DAY_SET</value>
+            <value num="6">MS_SET</value>
+        </member>
+        <member type="u8" name="cancelTypes"/>
+        <member type="u16" name="unused"/>
+    </object>
+    <object name="MiStatusData" persistent="false">
+        <member type="MiSkillItemStatusCommonData*" name="common"/>
+        <member type="MiStatusBasicData*" name="basic"/>
+        <member type="MiEffectData*" name="effect"/>
+        <member type="MiCancelData*" name="cancel"/>
+    </object>
+</objgen>

--- a/libcomp/schema/character.xml
+++ b/libcomp/schema/character.xml
@@ -89,7 +89,7 @@
     <object name="StatusEffect" location="world">
         <member type="u32" name="Effect"/>
         <member type="ref" name="Entity" key="true" unique="false"/>
-        <member type="u64" name="Duration"/>
+        <member type="u32" name="Expiration"/>
         <member type="u8" name="Stack"/>
     </object>
     <object name="CharacterProgress" location="world">

--- a/libcomp/schema/master.xml
+++ b/libcomp/schema/master.xml
@@ -58,5 +58,6 @@
     <include path="binarydata/shopproductdata.xml"/>
     <include path="binarydata/skilldata.xml"/>
     <include path="binarydata/spotdata.xml"/>
+    <include path="binarydata/statusdata.xml"/>
     <include path="binarydata/zonedata.xml"/>
 </objgen>

--- a/libcomp/src/Constants.h
+++ b/libcomp/src/Constants.h
@@ -221,36 +221,6 @@ namespace libcomp
 /// Magnetite item ID
 #define ITEM_MAGNETITE (800)
 
-/// Known index values contained in the binary structure Correct tables
-enum CorrectData : unsigned char
-{
-    CORRECT_STR = 0,
-    CORRECT_MAGIC = 1,
-    CORRECT_VIT = 2,
-    CORRECT_INTEL = 3,
-    CORRECT_SPEED = 4,
-    CORRECT_LUCK = 5,
-    CORRECT_MAXHP = 6,
-    CORRECT_MAXMP = 7,
-    CORRECT_HP_REGEN = 8,
-    CORRECT_MP_REGEN = 9,
-
-    CORRECT_MOVE_SPEED = 11,
-    CORRECT_CLSR = 12,
-    CORRECT_LNGR = 13,
-    CORRECT_SPELL = 14,
-    CORRECT_SUPPORT = 15,
-    CORRECT_CRITICAL = 16,
-
-    CORRECT_PDEF = 19,
-    CORRECT_MDEF = 20,
-
-    CORRECT_ACQUIRE_EXP = 80,
-    CORRECT_ACQUIRE_MAG = 81,
-    CORRECT_ACQUIRE_MACCA = 82,
-    CORRECT_ACQUIRE_EXPERTISE = 83,
-};
-
 /// Experience required to proceed from the indexed level to the next
 const unsigned long long LEVEL_XP_REQUIREMENTS[] = {
     0ULL,               // 0->1

--- a/libcomp/src/DefinitionManager.cpp
+++ b/libcomp/src/DefinitionManager.cpp
@@ -47,6 +47,7 @@
 #include <MiShopProductData.h>
 #include <MiSkillData.h>
 #include <MiSkillItemStatusCommonData.h>
+#include <MiStatusData.h>
 #include <MiZoneData.h>
 #include <MiZoneBasicData.h>
 
@@ -127,6 +128,11 @@ const std::shared_ptr<objects::MiSkillData> DefinitionManager::GetSkillData(uint
     return GetRecordByID<objects::MiSkillData>(id, mSkillData);
 }
 
+const std::shared_ptr<objects::MiStatusData> DefinitionManager::GetStatusData(uint32_t id)
+{
+    return GetRecordByID<objects::MiStatusData>(id, mStatusData);
+}
+
 const std::shared_ptr<objects::MiZoneData> DefinitionManager::GetZoneData(uint32_t id)
 {
     return GetRecordByID<objects::MiZoneData>(id, mZoneData);
@@ -156,6 +162,7 @@ bool DefinitionManager::LoadAllData(gsl::not_null<DataStore*> pDataStore)
     success &= LoadONPCData(pDataStore);
     success &= LoadShopProductData(pDataStore);
     success &= LoadSkillData(pDataStore);
+    success &= LoadStatusData(pDataStore);
     success &= LoadZoneData(pDataStore);
 
     if(success)
@@ -335,6 +342,19 @@ bool DefinitionManager::LoadSkillData(gsl::not_null<DataStore*> pDataStore)
         mSkillData[record->GetCommon()->GetID()] = record;
     }
 
+    return success;
+}
+
+bool DefinitionManager::LoadStatusData(gsl::not_null<DataStore*> pDataStore)
+{
+    std::list<std::shared_ptr<objects::MiStatusData>> records;
+    bool success = LoadBinaryData<objects::MiStatusData>(pDataStore,
+        "Shield/StatusData.sbin", true, 1, records);
+    for(auto record : records)
+    {
+        mStatusData[record->GetCommon()->GetID()] = record;
+    }
+    
     return success;
 }
 

--- a/libcomp/src/DefinitionManager.h
+++ b/libcomp/src/DefinitionManager.h
@@ -34,6 +34,7 @@
 #include "CString.h"
 #include "DataStore.h"
 #include "Decrypt.h"
+#include "MiCorrectTbl.h"
 #include "Object.h"
 
 // Standard C++11 Includes
@@ -52,6 +53,7 @@ class MiItemData;
 class MiONPCData;
 class MiShopProductData;
 class MiSkillData;
+class MiStatusData;
 class MiZoneData;
 }
 
@@ -158,6 +160,13 @@ public:
     const std::shared_ptr<objects::MiSkillData> GetSkillData(uint32_t id);
 
     /**
+     * Get the status definition corresponding to an ID
+     * @param id Status ID to retrieve
+     * @return Pointer to the matching skill definition, null if it does not exist
+     */
+    const std::shared_ptr<objects::MiStatusData> GetStatusData(uint32_t id);
+
+    /**
      * Get the zone definition corresponding to an ID
      * @param id Zone ID to retrieve
      * @return Pointer to the matching zone definition, null if it does not exist
@@ -261,6 +270,13 @@ public:
      * @return true on success, false on failure
      */
     bool LoadSkillData(gsl::not_null<DataStore*> pDataStore);
+
+    /**
+     * Load the status binary data definitions
+     * @param pDataStore Pointer to the datastore to load binary file from
+     * @return true on success, false on failure
+     */
+    bool LoadStatusData(gsl::not_null<DataStore*> pDataStore);
 
     /**
      * Load the zone binary data definitions
@@ -436,6 +452,10 @@ private:
     /// Map of skill definitions by ID
     std::unordered_map<uint32_t,
         std::shared_ptr<objects::MiSkillData>> mSkillData;
+
+    /// Map of status definitions by ID
+    std::unordered_map<uint32_t,
+        std::shared_ptr<objects::MiStatusData>> mStatusData;
 
     /// Map of zone definitions by ID
     std::unordered_map<uint32_t,

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -89,6 +89,7 @@ enum class ClientToChannelPacketCode_t : uint16_t
     PACKET_DEMON_BOX = 0x005C,  //!< Demon box list request.
     PACKET_DEMON_BOX_DATA = 0x005E,  //!< Demon box demon data request.
     PACKET_CHANNEL_LIST = 0x0063,  //!< Request for the list of channels connected to the world.
+    PACKET_REVIVE_CHARACTER = 0x0067,  //!< Request to revive the client's character.
     PACKET_STOP_MOVEMENT = 0x006F,  //!< Request to stop the movement of an entity or object.
     PACKET_SPOT_TRIGGERED = 0x0071,  //!< A spot has been triggered by the client.
     PACKET_WORLD_TIME = 0x0072,  //!< Request for the server's current world time.
@@ -136,6 +137,7 @@ enum class ClientToChannelPacketCode_t : uint16_t
     PACKET_QUEST_ACTIVE_LIST = 0x010B,  //!< Request for the player's active quest list.
     PACKET_QUEST_COMPLETED_LIST = 0x010C,  //!< Request for the player's completed quest list.
     PACKET_CLAN_INFO = 0x0150,  //!< Request for the current player's clan information.
+    PACKET_SYNC_CHARACTER = 0x017E,  //!< Request to sync the player character's basic information.
     PACKET_MAP_FLAG = 0x0197,  //!< Request to receive map information.
     PACKET_DEMON_COMPENDIUM = 0x019B,  //!< Request for the Demon Compendium.
     PACKET_DUNGEON_RECORDS = 0x01C4,  //!< Request for the current player's dungeon challenge records.
@@ -191,11 +193,15 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_SKILL_EXECUTING = 0x0036, //!< Response from skill activation request to execute a skill.
     PACKET_SKILL_FAILED = 0x0037,  //!< Response from skill activation request that execution has failed.
     PACKET_SKILL_REPORTS = 0x0038,  //!< Response from skill activation reporting what has been updated.
+    PACKET_DO_TDAMAGE = 0x0043, //!< Notifies the client that "time" damage has been dealt to an entity.
+    PACKET_ADD_STATUS_EFFECT = 0x0044, //!< Notifies the client that an entity has gained a status effect.
+    PACKET_REMOVE_STATUS_EFFECT = 0x0045, //!< Notifies the client that an entity has lost a status effect.
     PACKET_XP_UPDATE = 0x0046, //!< Notifies the client of an entity's XP value.
     PACKET_CHARACTER_LEVEL_UP = 0x0047, //!< Notifies the client that a character has leveled up.
     PACKET_PARTNER_LEVEL_UP = 0x0048, //!< Notifies the client that a partner demon has leveled up.
     PACKET_ALLOCATE_SKILL_POINT = 0x004A, //!< Response from the request to allocate a skill point for a character.
     PACKET_EQUIPMENT_CHANGED = 0x004B, //!< Notifies the client that a character's equipment has changed.
+    PACKET_ENTITY_STATS = 0x004C,  //!< Notifies the client of a character or parter demon's calculated stats.
     PACKET_EXPERTISE_POINT_UPDATE = 0x004D, //!< Notifies the client that a character's expertise points have been updated.
     PACKET_EXPERTISE_RANK_UP = 0x004E, //!< Notifies the client that a character's expertise has ranked up.
     PACKET_TOGGLE_EXPERTISE = 0x0050, //!< Notifies the client to enable or disable an expertise.
@@ -208,6 +214,7 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_PARTNER_SUMMONED = 0x0060,  //!< Notifies the client that a partner demon has been summoned.
     PACKET_POP_ENTITY_FOR_PRODUCTION = 0x0061,  //!< Sets up an entity that will spawn in via PACKET_SHOW_ENTITY.
     PACKET_CHANNEL_LIST = 0x0064,  //!< Message containing the list of channels connected to the world.
+    PACKET_REVIVE_ENTITY = 0x006E,  //!< Notification that an entity has been revived.
     PACKET_STOP_MOVEMENT = 0x0070,  //!< Message containing entity or object movement stopping information.
     PACKET_WORLD_TIME = 0x0073,  //!< Response for the server's current world time.
     PACKET_ITEM_BOX = 0x0075,  //!< Response for info about a specific item box.
@@ -274,6 +281,7 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_EVENT_STAGE_EFFECT = 0x0127,  //!< Request to the client to render a stage effect.
     PACKET_CLAN_INFO = 0x0151,  //!< Response containing the current player's clan information.
     PACKET_EVENT_DIRECTION = 0x015D,  //!< Request to the client to signify a direction to the player.
+    PACKET_SYNC_CHARACTER = 0x017F,  //!< Response to the request to sync the player character's basic information.
     PACKET_BAZAAR_DATA = 0x0183,  //!< Message containing data about a bazaar in a zone.
     PACKET_STATUS_ICON = 0x0195,  //!< Message containing the icon to show for the client's character.
     PACKET_STATUS_ICON_OTHER = 0x0196,  //!< Message containing the icon to show for another player's character.

--- a/libobjgen/res/VariableArrayLoad.cpp
+++ b/libobjgen/res/VariableArrayLoad.cpp
@@ -1,5 +1,6 @@
 ([&]() -> bool
 {
+    @PERSIST_COPY@
     for(auto& element : @VAR_NAME@)
     {
         if(!(@VAR_LOAD_CODE@))

--- a/libobjgen/res/VariableListLoad.cpp
+++ b/libobjgen/res/VariableListLoad.cpp
@@ -8,17 +8,18 @@
     uint16_t elementCount = @STREAM@.dynamicSizes.front();
     @STREAM@.dynamicSizes.pop_front();
 
+    @PERSIST_COPY@
     @VAR_NAME@.clear();
     for(uint16_t i = 0; i < elementCount; ++i)
     {
-            @VAR_TYPE@ element;
+        @VAR_TYPE@ element;
 
-            if(!(@VAR_LOAD_CODE@))
-            {
-                return false;
-            }
+        if(!(@VAR_LOAD_CODE@))
+        {
+            return false;
+        }
 
-            @VAR_NAME@.push_back(element);
+        @VAR_NAME@.push_back(element);
     }
 
     return @STREAM@.stream.good();

--- a/libobjgen/res/VariableListLoadRaw.cpp
+++ b/libobjgen/res/VariableListLoadRaw.cpp
@@ -10,6 +10,7 @@
         return false;
     }
 
+    @PERSIST_COPY@
     @VAR_NAME@.clear();
     for(uint32_t i = 0; i < elementCount; ++i)
     {

--- a/libobjgen/res/VariableMapLoad.cpp
+++ b/libobjgen/res/VariableMapLoad.cpp
@@ -8,6 +8,7 @@
     uint16_t elementCount = @STREAM@.dynamicSizes.front();
     @STREAM@.dynamicSizes.pop_front();
 
+    @PERSIST_COPY@
     @VAR_NAME@.clear();
     for(uint16_t i = 0; i < elementCount; ++i)
     {

--- a/libobjgen/res/VariableMapLoadRaw.cpp
+++ b/libobjgen/res/VariableMapLoadRaw.cpp
@@ -10,6 +10,7 @@
         return false;
     }
 
+    @PERSIST_COPY@
     @VAR_NAME@.clear();
     for(uint32_t i = 0; i < elementCount; ++i)
     {

--- a/libobjgen/src/Generator.cpp
+++ b/libobjgen/src/Generator.cpp
@@ -28,6 +28,7 @@
 
 // libobjgen Includes
 #include "MetaVariable.h"
+#include "MetaVariableReference.h"
 #include "ResourceTemplate.h"
 
 // Standard C++11 Includes
@@ -206,6 +207,20 @@ bool Generator::GetXmlAttributeBoolean(const std::string& attr)
     auto lower = attr;
     std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
     return "1" == lower || "true" == lower || "on" == lower || "yes" == lower;
+}
+
+std::string Generator::GetPersistentRefCopyCode(
+    const std::shared_ptr<MetaVariable>& var, const std::string& name)
+{
+    auto ref = std::dynamic_pointer_cast<MetaVariableReference>(var);
+    if(ref && ref->IsPersistentReference())
+    {
+        return "auto " + name + "Copy = " + name + "; // Keep copy of references";
+    }
+    else
+    {
+        return "";
+    }
 }
 
 std::string Generator::Escape(const std::string& str)

--- a/libobjgen/src/Generator.h
+++ b/libobjgen/src/Generator.h
@@ -74,6 +74,9 @@ public:
 
     static bool GetXmlAttributeBoolean(const std::string& attr);
 
+    static std::string GetPersistentRefCopyCode(
+        const std::shared_ptr<MetaVariable>& var, const std::string& name);
+
     static std::string Escape(const std::string& str);
 
     static bool LoadString(std::istream& stream, std::string& s);

--- a/libobjgen/src/MetaVariableArray.cpp
+++ b/libobjgen/src/MetaVariableArray.cpp
@@ -273,6 +273,8 @@ std::string MetaVariableArray::GetLoadCode(const Generator& generator,
             replacements["@VAR_NAME@"] = name;
             replacements["@VAR_LOAD_CODE@"] = code;
             replacements["@STREAM@"] = stream + std::string(".stream");
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mElementType, name);
 
             code = generator.ParseTemplate(0, "VariableArrayLoad",
                 replacements);
@@ -327,6 +329,8 @@ std::string MetaVariableArray::GetLoadRawCode(const Generator& generator,
             replacements["@VAR_NAME@"] = name;
             replacements["@VAR_LOAD_CODE@"] = code;
             replacements["@STREAM@"] = stream;
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mElementType, name);
 
             code = generator.ParseTemplate(0, "VariableArrayLoad",
                 replacements);

--- a/libobjgen/src/MetaVariableList.cpp
+++ b/libobjgen/src/MetaVariableList.cpp
@@ -190,6 +190,8 @@ std::string MetaVariableList::GetLoadCode(const Generator& generator,
             replacements["@VAR_TYPE@"] = mElementType->GetCodeType();
             replacements["@VAR_LOAD_CODE@"] = code;
             replacements["@STREAM@"] = stream;
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mElementType, name);
 
             code = generator.ParseTemplate(0, "VariableListLoad",
                 replacements);
@@ -245,6 +247,8 @@ std::string MetaVariableList::GetLoadRawCode(const Generator& generator,
             replacements["@VAR_TYPE@"] = mElementType->GetCodeType();
             replacements["@VAR_LOAD_CODE@"] = code;
             replacements["@STREAM@"] = stream;
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mElementType, name);
 
             code = generator.ParseTemplate(0, "VariableListLoadRaw",
                 replacements);

--- a/libobjgen/src/MetaVariableMap.cpp
+++ b/libobjgen/src/MetaVariableMap.cpp
@@ -205,6 +205,8 @@ std::string MetaVariableMap::GetLoadCode(const Generator& generator,
             replacements["@VAR_VALUE_TYPE@"] = mValueElementType->GetCodeType();
             replacements["@VAR_VALUE_LOAD_CODE@"] = valueCode;
             replacements["@STREAM@"] = stream;
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mValueElementType, name);
 
             code = generator.ParseTemplate(0, "VariableMapLoad",
                 replacements);
@@ -265,6 +267,8 @@ std::string MetaVariableMap::GetLoadRawCode(const Generator& generator,
             replacements["@VAR_VALUE_TYPE@"] = mValueElementType->GetCodeType();
             replacements["@VAR_VALUE_LOAD_CODE@"] = valueCode;
             replacements["@STREAM@"] = stream;
+            replacements["@PERSIST_COPY@"] =
+                generator.GetPersistentRefCopyCode(mValueElementType, name);
 
             code = generator.ParseTemplate(0, "VariableMapLoadRaw",
                 replacements);

--- a/server/channel/CMakeLists.txt
+++ b/server/channel/CMakeLists.txt
@@ -141,6 +141,7 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/game/DemonBox.cpp               # 0x005C
     src/packets/game/DemonBoxData.cpp           # 0x005E
     src/packets/game/ChannelList.cpp            # 0x0063
+    src/packets/game/ReviveCharacter.cpp        # 0x0067
     src/packets/game/StopMovement.cpp           # 0x006F
     src/packets/game/SpotTriggered.cpp          # 0x0071
     src/packets/game/WorldTime.cpp              # 0x0072
@@ -186,6 +187,7 @@ SET(${PROJECT_NAME}_PACKETS
     src/packets/game/QuestActiveList.cpp        # 0x010B
     src/packets/game/QuestCompletedList.cpp     # 0x010C
     src/packets/game/ClanInfo.cpp               # 0x0150
+    src/packets/game/SyncCharacter.cpp          # 0x017E
     src/packets/game/MapFlag.cpp                # 0x0197
     src/packets/game/DemonCompendium.cpp        # 0x019B
     src/packets/game/DungeonRecords.cpp         # 0x01C4

--- a/server/channel/schema/channelconfig.xml
+++ b/server/channel/schema/channelconfig.xml
@@ -6,6 +6,6 @@
         <member type="u16" name="Port" inherited="true" default="14666"/>
         <member type="string" name="WorldIP" default="127.0.0.1"/>
         <member type="u16" name="WorldPort" default="18666"/>
-        <member type="bool" name="TimeoutEnabled"/>
+        <member type="u16" name="Timeout"/>
     </object>
 </objgen>

--- a/server/channel/schema/clientstate.xml
+++ b/server/channel/schema/clientstate.xml
@@ -4,6 +4,7 @@
         <member type="bool" name="Authenticated"/>
         <member type="bool" name="LoggedIn"/>
         <member type="bool" name="LogoutSave" default="true"/>
+        <member type="bool" name="AcceptRevival"/>
         <member type="AccountLogin*" name="AccountLogin"/>
         <member type="AccountWorldData*" name="AccountWorldData"/>
         <member type="EventState*" name="EventState"/>

--- a/server/channel/schema/entitystate.xml
+++ b/server/channel/schema/entitystate.xml
@@ -46,6 +46,8 @@
         <member type="s16" name="SUPPORT"/>
         <member type="s16" name="PDEF"/>
         <member type="s16" name="MDEF"/>
+        <member type="s16" name="HPRegen"/>
+        <member type="s16" name="MPRegen"/>
         <member type="ActivatedAbility*" name="ActivatedAbility"/>
     </object>
     <object name="ActivatedAbility" scriptenabled="true" persistent="false">

--- a/server/channel/src/ActiveEntityState.cpp
+++ b/server/channel/src/ActiveEntityState.cpp
@@ -28,6 +28,7 @@
 
 // libcomp Includes
 #include <Constants.h>
+#include <DefinitionManager.h>
 #include <ScriptEngine.h>
 
 // objects Includes
@@ -35,39 +36,66 @@
 #include <Demon.h>
 #include <Enemy.h>
 #include <Item.h>
+#include <MiCancelData.h>
 #include <MiCorrectTbl.h>
 #include <MiDevilBattleData.h>
 #include <MiDevilData.h>
+#include <MiDoTDamageData.h>
+#include <MiEffectData.h>
 #include <MiItemData.h>
 #include <MiSkillItemStatusCommonData.h>
+#include <MiStatusBasicData.h>
+#include <MiStatusData.h>
 
 // channel Includes
+#include "ChannelServer.h"
 #include "CharacterManager.h"
-#include "DefinitionManager.h"
+#include "Zone.h"
 
 using namespace channel;
 
+ActiveEntityState::ActiveEntityState() : mCurrentZone(0),
+    mEffectsActive(false), mAlive(true)
+{
+}
+
+ActiveEntityState::ActiveEntityState(const ActiveEntityState& other)
+{
+    (void)other;
+}
+
+const libobjgen::UUID ActiveEntityState::GetEntityUUID()
+{
+    return NULLUUID;
+}
+
 void ActiveEntityState::Move(float xPos, float yPos, uint64_t now)
 {
-    SetOriginX(GetCurrentX());
-    SetOriginY(GetCurrentY());
-    SetOriginRotation(GetCurrentRotation());
-    SetOriginTicks(now);
+    if(IsAlive())
+    {
+        SetOriginX(GetCurrentX());
+        SetOriginY(GetCurrentY());
+        SetOriginRotation(GetCurrentRotation());
+        SetOriginTicks(now);
 
-    SetDestinationX(xPos);
-    SetDestinationY(yPos);
-    SetDestinationTicks(now + 500000);  /// @todo: modify for speed
+        SetDestinationX(xPos);
+        SetDestinationY(yPos);
+        SetDestinationTicks(now + 500000);  /// @todo: modify for speed
+    }
 }
 
 void ActiveEntityState::Rotate(float rot, uint64_t now)
 {
-    SetOriginX(GetCurrentX());
-    SetOriginY(GetCurrentY());
-    SetOriginRotation(GetCurrentRotation());
-    SetOriginTicks(now);
+    if(IsAlive())
+    {
+        SetOriginX(GetCurrentX());
+        SetOriginY(GetCurrentY());
+        SetOriginRotation(GetCurrentRotation());
+        SetOriginTicks(now);
 
-    SetDestinationRotation(CorrectRotation(rot));
-    SetDestinationTicks(now + 500000);  /// @todo: modify for speed
+        SetDestinationRotation(CorrectRotation(rot));
+        SetDestinationTicks(now + 500000);  /// @todo: modify for speed
+    }
 }
 
 void ActiveEntityState::Stop(uint64_t now)
@@ -80,6 +108,11 @@ void ActiveEntityState::Stop(uint64_t now)
     SetOriginY(GetCurrentY());
     SetOriginRotation(GetCurrentRotation());
     SetOriginTicks(now);
+}
+
+bool ActiveEntityState::IsAlive() const
+{
+    return mAlive;
 }
 
 bool ActiveEntityState::IsMoving() const
@@ -160,6 +193,897 @@ void ActiveEntityState::RefreshCurrentPosition(uint64_t now)
     }
 }
 
+Zone* ActiveEntityState::GetZone() const
+{
+    return mCurrentZone;
+}
+
+void ActiveEntityState::SetZone(Zone* zone, bool updatePrevious)
+{
+    if(updatePrevious && mCurrentZone)
+    {
+        mCurrentZone->SetNextStatusEffectTime(0, GetEntityID());
+    }
+
+    mCurrentZone = zone;
+
+    RegisterNextEffectTime();
+}
+
+bool ActiveEntityState::SetHPMP(int16_t hp, int16_t mp, bool adjust,
+    bool canOverflow)
+{
+    int16_t hpAdjusted, mpAdjusted;
+    return SetHPMP(hp, mp, adjust, canOverflow, hpAdjusted, mpAdjusted);
+}
+
+bool ActiveEntityState::SetHPMP(int16_t hp, int16_t mp, bool adjust,
+    bool canOverflow, int16_t& hpAdjusted, int16_t& mpAdjusted)
+{
+    hpAdjusted = mpAdjusted = 0;
+
+    auto cs = GetCoreStats();
+    if(cs == nullptr || (!adjust && hp < 0 && mp < 0))
+    {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(mLock);
+    auto maxHP = GetMaxHP();
+    auto maxMP = GetMaxMP();
+    
+    // If the amount of damage dealt can overflow, do not
+    // use the actual damage dealt, allow it to go
+    // over the actual amount dealt
+    if(canOverflow)
+    {
+        hpAdjusted = hp;
+        mpAdjusted = mp;
+    }
+
+    if(adjust)
+    {
+        hp = (int16_t)(cs->GetHP() + hp);
+        mp = (int16_t)(cs->GetMP() + mp);
+
+        if(!canOverflow)
+        {
+            // If the adjusted damage cannot overflow
+            // stop it from doing so
+            if(cs->GetHP() && hp <= 0)
+            {
+                hp = 1;
+            }
+            else if(!mAlive && hp > 0)
+            {
+                hp = 0;
+            }
+        }
+        
+        // Make sure we don't go under the limit
+        if(hp < 0)
+        {
+            hp = 0;
+        }
+
+        if(mp < 0)
+        {
+            mp = 0;
+        }
+    }
+
+    bool result = false;
+    bool returnDamaged = !adjust || !canOverflow;
+    if(hp >= 0)
+    {
+        auto newHP = hp > maxHP ? maxHP : hp;
+
+        // Update if the entity is alive or not
+        if(cs->GetHP() > 0 && newHP == 0)
+        {
+            mAlive = false;
+            Stop(ChannelServer::GetServerTime());
+            result = !returnDamaged;
+        }
+        else if(cs->GetHP() == 0 && newHP > 0)
+        {
+            mAlive = true;
+            result = !returnDamaged;
+        }
+
+        result |= returnDamaged && newHP != cs->GetHP();
+        
+        if(!canOverflow)
+        {
+            hpAdjusted = (int16_t)(newHP - cs->GetHP());
+        }
+
+        cs->SetHP(newHP);
+    }
+    
+    if(mp >= 0)
+    {
+        auto newMP = mp > maxMP ? maxMP : mp;
+        result |= returnDamaged && newMP != cs->GetMP();
+        
+        if(!canOverflow)
+        {
+            mpAdjusted = (int16_t)(newMP - cs->GetMP());
+        }
+
+        cs->SetMP(newMP);
+    }
+
+    return result;
+}
+
+const std::unordered_map<uint32_t, std::shared_ptr<objects::StatusEffect>>&
+    ActiveEntityState::GetStatusEffects() const
+{
+    return mStatusEffects;
+}
+
+void ActiveEntityState::SetStatusEffects(
+    const std::list<std::shared_ptr<objects::StatusEffect>>& effects)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    mStatusEffects.clear();
+    mTimeDamageEffects.clear();
+    mCancelConditions.clear();
+    mNextEffectTimes.clear();
+
+    RegisterNextEffectTime();
+
+    for(auto effect : effects)
+    {
+        mStatusEffects[effect->GetEffect()] = effect;
+    }
+}
+
+std::set<uint32_t> ActiveEntityState::AddStatusEffects(const AddStatusEffectMap& effects,
+    libcomp::DefinitionManager* definitionManager, uint32_t now, bool queueChanges)
+{
+    std::set<uint32_t> removes;
+
+    if(now == 0)
+    {
+        now = (uint32_t)std::time(0);
+    }
+
+    std::lock_guard<std::mutex> lock(mLock);
+    for(auto ePair : effects)
+    {
+        bool isReplace = ePair.second.second;
+        uint32_t effectType = ePair.first;
+        uint8_t stack = ePair.second.first;
+
+        auto def = definitionManager->GetStatusData(effectType);
+        auto basic = def->GetBasic();
+        auto cancel = def->GetCancel();
+        auto maxStack = basic->GetMaxStack();
+
+        if(stack > maxStack)
+        {
+            stack = maxStack;
+        }
+
+        bool add = true;
+        std::shared_ptr<objects::StatusEffect> effect;
+        std::shared_ptr<objects::StatusEffect> removeEffect;
+        if(mStatusEffects.find(effectType) != mStatusEffects.end())
+        {
+            // Effect exists alreadly, should we modify time/stack or remove?
+            auto existing = mStatusEffects[effectType];
+
+            bool doReplace = isReplace;
+            bool addStack = false;
+            bool resetTime = false;
+            switch(basic->GetApplicationLogic())
+            {
+            case 0:
+                // Add always, replace only if higher/longer or zero (ex: sleep)
+                doReplace = isReplace && ((existing->GetStack() < stack) || !stack);
+                break;
+            case 1:
+                // Always set/add stack, reset time only if stack
+                // represents time (misc)
+                if(isReplace)
+                {
+                    existing->SetStack(stack);
+                    if(basic->GetStackType() == 1)
+                    {
+                        resetTime = true;
+                    }
+                }
+                else
+                {
+                    addStack = true;
+                }
+                break;
+            case 2:
+                // Always reset time, add old stack on add (ex: -kajas)
+                addStack = !isReplace;
+                resetTime = true;
+                break;
+            case 3:
+                // Always reapply time and stack (ex: -karns)
+                doReplace = resetTime = true;
+                break;
+            default:
+                continue;
+                break;
+            }
+
+            if(doReplace)
+            {
+                existing->SetStack(stack);
+            }
+            else if(addStack && existing->GetStack() < maxStack)
+            {
+                stack = (uint8_t)(stack + existing->GetStack());
+                existing->SetStack(maxStack < stack ? maxStack : stack);
+            }
+
+            if(resetTime)
+            {
+                existing->SetExpiration(0);
+            }
+
+            if(existing->GetStack() > 0)
+            {
+                effect = existing;
+            }
+            else
+            {
+                removeEffect = existing;
+            }
+
+            add = false;
+        }
+        else
+        {
+            // Effect does not exist already, determine if it can be added
+            auto common = def->GetCommon();
+
+            // Map out existing effects and info to check for inverse cancellation
+            bool canCancel = common->CorrectTblCount() > 0;
+            libcomp::EnumMap<CorrectTbl, std::unordered_map<bool, uint8_t>> cancelMap;
+            for(auto c : common->GetCorrectTbl())
+            {
+                if(c->GetValue() == 0 ||
+                    c->GetType() == objects::MiCorrectTbl::Type_t::PERCENT)
+                {
+                    canCancel = false;
+                    cancelMap.clear();
+                }
+                else
+                {
+                    bool positive = c->GetValue() > 0;
+                    std::unordered_map<bool, uint8_t>& m = cancelMap[c->GetID()];
+                    m[positive] = (uint8_t)((m.find(positive) != m.end()
+                        ? m[positive] : 0) + 1);
+                }
+            }
+
+            std::set<uint32_t> inverseEffects;
+            for(auto pair : mStatusEffects)
+            {
+                auto exDef = definitionManager->GetStatusData(pair.first);
+                auto exBasic = exDef->GetBasic();
+                if(exBasic->GetGroupID() == basic->GetGroupID())
+                {
+                    if(basic->GetGroupRank() >= exBasic->GetGroupRank())
+                    {
+                        // Replace the lower ranked effect in the same group
+                        removeEffect = pair.second;
+                    }
+                    else
+                    {
+                        // Higher rank exists, do not add or replace
+                        add = false;
+                    }
+
+                    canCancel = false;
+                    break;
+                }
+
+                // Check if the existing effect is an inverse that should be cancelled instead.
+                // For an effect to be inverse, both effects must have correct table entries
+                // which are all numeric, none can have a zero value and the number of positive
+                // values on one for each entry ID must match the number of negative values on
+                // the other and vice-versa. The actual values themselves do NOT need to inversely
+                // match.
+                auto exCommon = exDef->GetCommon();
+                if(canCancel && common->CorrectTblCount() == exCommon->CorrectTblCount())
+                {
+                    bool exCancel = true;
+                    libcomp::EnumMap<CorrectTbl, std::unordered_map<bool, uint8_t>> exCancelMap;
+                    for(auto c : exCommon->GetCorrectTbl())
+                    {
+                        if(c->GetValue() == 0 ||
+                            c->GetType() == objects::MiCorrectTbl::Type_t::PERCENT)
+                        {
+                            exCancel = false;
+                            break;
+                        }
+                        else
+                        {
+                            bool positive = c->GetValue() > 0;
+                            std::unordered_map<bool, uint8_t>& m = exCancelMap[c->GetID()];
+                            m[positive] = (uint8_t)((m.find(positive) != m.end()
+                                ? m[positive] : 0) + 1);
+                        }
+                    }
+
+                    if(exCancel && cancelMap.size() == exCancelMap.size())
+                    {
+                        for(auto cPair : cancelMap)
+                        {
+                            if(exCancelMap.find(cPair.first) == exCancelMap.end())
+                            {
+                                exCancel = false;
+                                break;
+                            }
+
+                            auto otherMap = exCancelMap[cPair.first];
+                            for(auto mPair : cPair.second)
+                            {
+                                if(otherMap.find(!mPair.first) == otherMap.end() ||
+                                    otherMap[!mPair.first] != mPair.second)
+                                {
+                                    exCancel = false;
+                                    break;
+                                }
+                            }
+                        }
+
+                        // Correct table values are inversed, existing effect
+                        // can be cancelled
+                        if(exCancel)
+                        {
+                            inverseEffects.insert(pair.first);
+                        }
+                    }
+                }
+            }
+
+            if(canCancel && inverseEffects.size() > 0)
+            {
+                // Should never be more than one but in case there is, the
+                // lowest ID will be cancelled
+                auto exEffect = mStatusEffects[*inverseEffects.begin()];
+                if(exEffect->GetStack() == stack)
+                {
+                    // Cancel the old one, don't add anything
+                    add = false;
+
+                    removeEffect = exEffect;
+                }
+                else if(exEffect->GetStack() < stack)
+                {
+                    // Cancel the old one, add the new one with a lower stack
+                    stack = (uint8_t)(stack - exEffect->GetStack());
+                    add = true;
+
+                    removeEffect = exEffect;
+                }
+                else
+                {
+                    // Reduce the stack of the existing one;
+                    exEffect->SetStack((uint8_t)(exEffect->GetStack() - stack));
+                    add = false;
+
+                    // Application logic 2 effects have their expirations reset
+                    // any time they are re-applied
+                    auto exDef = definitionManager->GetStatusData(
+                        exEffect->GetEffect());
+                    if(exDef->GetBasic()->GetApplicationLogic() == 2)
+                    {
+                        exEffect->SetExpiration(0);
+                    }
+
+                    effect = exEffect;
+                }
+            }
+        }
+    
+        if(add)
+        {
+            // Effect not set yet, build it now
+            effect = libcomp::PersistentObject::New<objects::StatusEffect>(true);
+            effect->SetEntity(GetEntityUUID());
+            effect->SetEffect(effectType);
+            effect->SetStack(stack);
+        }
+
+        // Perform insert or edit modifications
+        if(effect)
+        {
+            if(effect->GetExpiration() == 0)
+            {
+                //Set the expiration
+                uint32_t expiration = 0;
+                bool absoluteTime = false;
+                switch(cancel->GetDurationType())
+                {
+                case objects::MiCancelData::DurationType_t::MS:
+                case objects::MiCancelData::DurationType_t::MS_SET:
+                    // Milliseconds stored as relative countdown
+                    expiration = cancel->GetDuration();
+                    break;
+                case objects::MiCancelData::DurationType_t::HOUR:
+                    // Convert hours to absolute time in seconds
+                    expiration = (uint32_t)(cancel->GetDuration() * 3600);
+                    absoluteTime = true;
+                    break;
+                case objects::MiCancelData::DurationType_t::DAY:
+                case objects::MiCancelData::DurationType_t::DAY_SET:
+                    // Convert days to absolute time in seconds
+                    expiration = (uint32_t)(cancel->GetDuration() * 24 * 3600);
+                    absoluteTime = true;
+                    break;
+                default:
+                    // None or invalid, nothing to do
+                    break;
+                }
+
+                if(basic->GetStackType() == 1)
+                {
+                    // Stack scales time
+                    expiration = expiration * effect->GetStack();
+                }
+
+                if(absoluteTime)
+                {
+                    expiration = (uint32_t)(now + expiration);
+                }
+
+                effect->SetExpiration(expiration);
+            }
+        }
+    
+        if(removeEffect)
+        {
+            removes.insert(removeEffect->GetEffect());
+            mStatusEffects.erase(removeEffect->GetEffect());
+            mTimeDamageEffects.erase(removeEffect->GetEffect());
+            if(mEffectsActive && queueChanges)
+            {
+                // Non-system time 3 indicates removes
+                mNextEffectTimes[3].insert(removeEffect->GetEffect());
+            }
+        }
+
+        if(effect)
+        {
+            mStatusEffects[effect->GetEffect()] = effect;
+            if(mEffectsActive)
+            {
+                if(add)
+                {
+                    ActivateStatusEffect(effect, definitionManager, now);
+                }
+
+                if(queueChanges)
+                {
+                    // Add non-system time for add or update
+                    mNextEffectTimes[add ? 1 : 2].insert(effect->GetEffect());
+                }
+            }
+        }
+    }
+
+    if(mEffectsActive)
+    {
+        RegisterNextEffectTime();
+    }
+
+    return removes;
+}
+
+void ActiveEntityState::ExpireStatusEffects(const std::set<uint32_t>& effectTypes)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+    for(uint32_t effectType : effectTypes)
+    {
+        auto it = mStatusEffects.find(effectType);
+        if(it != mStatusEffects.end())
+        {
+            mStatusEffects.erase(effectType);
+            mTimeDamageEffects.erase(effectType);
+            for(auto cPair : mCancelConditions)
+            {
+                cPair.second.erase(effectType);
+            }
+
+            if(mEffectsActive)
+            {
+                // Non-system time 3 indicates removes
+                SetNextEffectTime(effectType, 0);
+                mNextEffectTimes[3].insert(effectType);
+            }
+        }
+    }
+}
+
+void ActiveEntityState::CancelStatusEffects(uint8_t cancelFlags)
+{
+    std::set<uint32_t> cancelled;
+    if(mCancelConditions.size() > 0)
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        for(auto cPair : mCancelConditions)
+        {
+            if(cancelFlags & cPair.first)
+            {
+                for(uint32_t effectType : cPair.second)
+                {
+                    cancelled.insert(effectType);
+                }
+            }
+        }
+    }
+
+    if(cancelled.size() > 0)
+    {
+        ExpireStatusEffects(cancelled);
+    }
+}
+
+void ActiveEntityState::SetStatusEffectsActive(bool activate,
+    libcomp::DefinitionManager* definitionManager, uint32_t now)
+{
+    if(now == 0)
+    {
+        now = (uint32_t)std::time(0);
+    }
+
+    // Already set
+    if(mEffectsActive == activate)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mLock);
+    mEffectsActive = activate;
+    if(activate)
+    {
+        // Set regen
+        SetNextEffectTime(0, now + 10);
+
+        // Set status effect expirations
+        for(auto pair : mStatusEffects)
+        {
+            ActivateStatusEffect(pair.second, definitionManager, now);
+        }
+
+        RegisterNextEffectTime();
+    }
+    else
+    {
+        mTimeDamageEffects.clear();
+        mCancelConditions.clear();
+        
+        if(mCurrentZone)
+        {
+            mCurrentZone->SetNextStatusEffectTime(0, GetEntityID());
+        }
+
+        for(auto pair : mNextEffectTimes)
+        {
+            // Skip non-system times
+            if(pair.first <= 3) continue;
+
+            for(auto effectType : pair.second)
+            {
+                auto it = mStatusEffects.find(effectType);
+                if(it == mStatusEffects.end()) continue;
+
+                uint32_t exp = GetCurrentExpiration(it->second, definitionManager,
+                    pair.first, now);
+                it->second->SetExpiration(exp);
+            }
+        }
+    }
+}
+
+bool ActiveEntityState::PopEffectTicks(libcomp::DefinitionManager* definitionManager,
+    uint32_t time, int32_t& hpTDamage, int32_t& mpTDamage, std::set<uint32_t>& added,
+    std::set<uint32_t>& updated, std::set<uint32_t>& removed)
+{
+    hpTDamage = 0;
+    mpTDamage = 0;
+    added.clear();
+    updated.clear();
+    removed.clear();
+
+    std::lock_guard<std::mutex> lock(mLock);
+    bool found = false;
+    bool reregister = false;
+    do
+    {
+        std::set<uint32_t> passed;
+        std::unordered_map<uint32_t, uint32_t> next;
+        for(auto pair : mNextEffectTimes)
+        {
+            if(pair.first > time) break;
+
+            passed.insert(pair.first);
+            
+            // Check hardcoded added, updated, removed first
+            if(pair.first == 1)
+            {
+                added = pair.second;
+                continue;
+            }
+            else if(pair.first == 2)
+            {
+                updated = pair.second;
+                continue;
+            }
+            else if(pair.first == 3)
+            {
+                removed = pair.second;
+                continue;
+            }
+
+            if(pair.second.find(0) != pair.second.end())
+            {
+                // Adjust T-Damage if the entity is not dead
+                if(mAlive)
+                {
+                    hpTDamage = (int32_t)(hpTDamage - GetHPRegen());
+                    mpTDamage = (int32_t)(mpTDamage - GetMPRegen());
+
+                    // Apply T-damage
+                    for(auto effectType : mTimeDamageEffects)
+                    {
+                        auto se = definitionManager->GetStatusData(effectType);
+                        auto damage = se->GetEffect()->GetDamage();
+
+                        hpTDamage = (int32_t)(hpTDamage + damage->GetHPDamage());
+                        mpTDamage = (int32_t)(mpTDamage + damage->GetMPDamage());
+                    }
+                }
+
+                // T-Damage applies is every 10 seconds
+                next[0] = pair.first + 10;
+
+                pair.second.erase(0);
+            }
+
+            for(auto effectType : pair.second)
+            {
+                // Effect has ended
+                auto effect = mStatusEffects[effectType];
+                mStatusEffects.erase(effectType);
+                mTimeDamageEffects.erase(effectType);
+                removed.insert(effectType);
+
+                for(auto cPair : mCancelConditions)
+                {
+                    cPair.second.erase(effectType);
+                }
+            }
+        }
+
+        for(auto t : passed)
+        {
+            mNextEffectTimes.erase(t);
+        }
+
+        for(auto pair : next)
+        {
+            SetNextEffectTime(pair.first, pair.second);
+        }
+
+        found = passed.size() > 0;
+        reregister |= found;
+    } while(found);
+
+    if(reregister)
+    {
+        RegisterNextEffectTime();
+    }
+
+    // If anything was popped off the map, update the entity
+    if(hpTDamage || mpTDamage || added.size() > 0 ||
+        updated.size() > 0 || removed.size() > 0)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+std::list<std::pair<std::shared_ptr<objects::StatusEffect>, uint32_t>>
+    ActiveEntityState::GetCurrentStatusEffectStates(
+    libcomp::DefinitionManager* definitionManager, uint32_t now)
+{
+    if(now == 0)
+    {
+        now = (uint32_t)std::time(0);
+    }
+
+    std::list<std::pair<std::shared_ptr<objects::StatusEffect>, uint32_t>> result;
+    std::lock_guard<std::mutex> lock(mLock);
+
+    if(!mEffectsActive)
+    {
+        // Just pull the stored values
+        for(auto pair : mStatusEffects)
+        {
+            std::pair<std::shared_ptr<objects::StatusEffect>, uint32_t> p(pair.second,
+                pair.second->GetExpiration());
+            result.push_back(p);
+        }
+
+        return result;
+    }
+
+    // Pull the times and transform the stored expiration
+    std::unordered_map<uint32_t, uint32_t> nextTimes;
+    for(auto pair : mNextEffectTimes)
+    {
+        // Skip non-system times
+        if(pair.first <= 3) continue;
+
+        for(auto effectType : pair.second)
+        {
+            nextTimes[effectType] = pair.first;
+        }
+    }
+    
+    for(auto pair : mStatusEffects)
+    {
+        uint32_t exp = pair.second->GetExpiration();
+
+        auto it = nextTimes.find(pair.first);
+        if(it != nextTimes.end())
+        {
+            exp = GetCurrentExpiration(pair.second, definitionManager,
+                it->second, now);
+        }
+
+        std::pair<std::shared_ptr<objects::StatusEffect>, uint32_t> p(pair.second,
+            exp);
+        result.push_back(p);
+    }
+
+    return result;
+}
+
+void ActiveEntityState::SetStatusEffects(
+    const std::list<libcomp::ObjectReference<objects::StatusEffect>>& effects)
+{
+    std::list<std::shared_ptr<objects::StatusEffect>> l;
+    for(auto e : effects)
+    {
+        l.push_back(e.Get());
+    }
+    SetStatusEffects(l);
+}
+
+void ActiveEntityState::ActivateStatusEffect(
+    const std::shared_ptr<objects::StatusEffect>& effect,
+    libcomp::DefinitionManager* definitionManager, uint32_t now)
+{
+    auto effectType = effect->GetEffect();
+
+    auto se = definitionManager->GetStatusData(effectType);
+    auto cancel = se->GetCancel();
+    switch(cancel->GetDurationType())
+    {
+        case objects::MiCancelData::DurationType_t::MS:
+        case objects::MiCancelData::DurationType_t::MS_SET:
+            {
+                // Force next tick time to duration
+                uint32_t time = (uint32_t)(now + (effect->GetExpiration() * 0.001));
+                mNextEffectTimes[time].insert(effectType);
+            }
+            break;
+        default:
+            mNextEffectTimes[effect->GetExpiration()].insert(effectType);
+            break;
+    }
+
+    // Mark the cancel conditions
+    for(uint16_t x = 0x0001; x < 0x00100;)
+    {
+        uint8_t x8 = (uint8_t)x;
+        if(cancel->GetCancelTypes() & x8)
+        {
+            mCancelConditions[x8].insert(effectType);
+        }
+
+        x = (uint16_t)(x << 1);
+    }
+
+    // Add to timed damage effect set if T-Damage is specified
+    auto damage = se->GetEffect()->GetDamage();
+    if(damage->GetHPDamage() || damage->GetMPDamage())
+    {
+        // Ignore if the damage applies as part of the skill only
+        auto basic = se->GetBasic();
+        if(!(basic->GetStackType() == 1 && basic->GetApplicationLogic() == 0))
+        {
+            mTimeDamageEffects.insert(effectType);
+        }
+    }
+}
+
+void ActiveEntityState::SetNextEffectTime(uint32_t effectType, uint32_t time)
+{
+    for(auto pair : mNextEffectTimes)
+    {
+        // Skip non-system times
+        if(pair.first <= 3) continue;
+
+        if(pair.second.find(effectType) != pair.second.end())
+        {
+            if(time == 0)
+            {
+                pair.second.erase(effectType);
+                if(pair.second.size() == 0)
+                {
+                    mNextEffectTimes.erase(pair.first);
+                }
+            }
+
+            return;
+        }
+    }
+
+    if(time != 0)
+    {
+        mNextEffectTimes[time].insert(effectType);
+    }
+}
+
+void ActiveEntityState::RegisterNextEffectTime()
+{
+    if(mCurrentZone && mEffectsActive)
+    {
+        mCurrentZone->SetNextStatusEffectTime(mNextEffectTimes.size() > 0
+            ? mNextEffectTimes.begin()->first : 0, GetEntityID());
+    }
+}
+
+uint32_t ActiveEntityState::GetCurrentExpiration(
+    const std::shared_ptr<objects::StatusEffect>& effect,
+    libcomp::DefinitionManager* definitionManager, uint32_t nextTime,
+    uint32_t now)
+{
+    uint32_t exp = effect->GetExpiration();
+
+    if(exp > 0)
+    {
+        auto se = definitionManager->GetStatusData(effect->GetEffect());
+        auto cancel = se->GetCancel();
+        switch(cancel->GetDurationType())
+        {
+        case objects::MiCancelData::DurationType_t::MS:
+        case objects::MiCancelData::DurationType_t::MS_SET:
+            {
+                // Convert back to milliseconds
+                exp = (uint32_t)((nextTime - now) * 1000);
+                if(effect->GetExpiration() < exp)
+                {
+                    exp = 0;
+                }
+            }
+            break;
+        default:
+            // Time is absolute, nothing to do
+            break;
+        }
+    }
+
+    return exp;
+}
+
 float ActiveEntityState::CorrectRotation(float rot) const
 {
     if(rot > 3.16f)
@@ -196,108 +1120,112 @@ ActiveEntityStateImp<objects::Enemy>::ActiveEntityStateImp()
 }
 
 template<>
-bool ActiveEntityStateImp<objects::Character>::RecalculateStats(
+void ActiveEntityStateImp<objects::Character>::SetEntity(
+    const std::shared_ptr<objects::Character>& entity)
+{
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        mEntity = entity;
+    }
+
+    std::list<libcomp::ObjectReference<objects::StatusEffect>> effects;
+    if(entity)
+    {
+        // Character should always be set but check just in case
+        effects = entity->GetStatusEffects();
+        mAlive = entity->GetCoreStats()->GetHP() > 0;
+    }
+
+    SetStatusEffects(effects);
+}
+
+template<>
+void ActiveEntityStateImp<objects::Demon>::SetEntity(
+    const std::shared_ptr<objects::Demon>& entity)
+{
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        mEntity = entity;
+    }
+
+    std::list<libcomp::ObjectReference<objects::StatusEffect>> effects;
+    if(entity)
+    {
+        effects = entity->GetStatusEffects();
+        mAlive = entity->GetCoreStats()->GetHP() > 0;
+    }
+
+    SetStatusEffects(effects);
+}
+
+template<>
+void ActiveEntityStateImp<objects::Enemy>::SetEntity(
+    const std::shared_ptr<objects::Enemy>& entity)
+{
+    {
+        std::lock_guard<std::mutex> lock(mLock);
+        mEntity = entity;
+    }
+    
+    if(entity)
+    {
+        mAlive = entity->GetCoreStats()->GetHP() > 0;
+    }
+}
+
+template<>
+const libobjgen::UUID ActiveEntityStateImp<objects::Character>::GetEntityUUID()
+{
+    return mEntity->GetUUID();
+}
+
+template<>
+const libobjgen::UUID ActiveEntityStateImp<objects::Demon>::GetEntityUUID()
+{
+    return mEntity->GetUUID();
+}
+
+template<>
+const libobjgen::UUID ActiveEntityStateImp<objects::Enemy>::GetEntityUUID()
+{
+    return NULLUUID;
+}
+
+template<>
+uint8_t ActiveEntityStateImp<objects::Character>::RecalculateStats(
     libcomp::DefinitionManager* definitionManager)
 {
+    std::lock_guard<std::mutex> lock(mLock);
+
     auto c = GetEntity();
     auto cs = c->GetCoreStats().Get();
 
-    std::unordered_map<uint8_t, int16_t> correctMap = CharacterManager::GetCharacterBaseStatMap(cs);
+    auto stats = CharacterManager::GetCharacterBaseStatMap(cs);
 
+    std::list<std::shared_ptr<objects::MiCorrectTbl>> correctTbls;
     for(auto equip : c->GetEquippedItems())
     {
         if(!equip.IsNull())
         {
             auto itemData = definitionManager->GetItemData(equip->GetType());
-            auto itemCommonData = itemData->GetCommon();
-
-            for(auto ct : itemCommonData->GetCorrectTbl())
+            for(auto ct : itemData->GetCommon()->GetCorrectTbl())
             {
-                auto tblID = ct->GetID();
-                switch (ct->GetType())
-                {
-                    case objects::MiCorrectTbl::Type_t::NUMERIC:
-                        correctMap[tblID] = (int16_t)(correctMap[tblID] + ct->GetValue());
-                        break;
-                    case objects::MiCorrectTbl::Type_t::PERCENT:
-                        /// @todo: apply in the right order
-                        break;
-                    default:
-                        break;
-                }
+                correctTbls.push_back(ct);
             }
         }
     }
 
-    /// @todo: apply effects
+    GetStatusEffectCorrectTbls(definitionManager, correctTbls);
 
-    CharacterManager::CalculateDependentStats(correctMap, cs->GetLevel(), false);
+    AdjustStats(correctTbls, stats, true);
+    CharacterManager::CalculateDependentStats(stats, cs->GetLevel(), false);
+    AdjustStats(correctTbls, stats, false);
 
-    SetMaxHP(correctMap[libcomp::CORRECT_MAXHP]);
-    SetMaxMP(correctMap[libcomp::CORRECT_MAXMP]);
-    SetSTR(correctMap[libcomp::CORRECT_STR]);
-    SetMAGIC(correctMap[libcomp::CORRECT_MAGIC]);
-    SetVIT(correctMap[libcomp::CORRECT_VIT]);
-    SetINTEL(correctMap[libcomp::CORRECT_INTEL]);
-    SetSPEED(correctMap[libcomp::CORRECT_SPEED]);
-    SetLUCK(correctMap[libcomp::CORRECT_LUCK]);
-    SetCLSR(correctMap[libcomp::CORRECT_CLSR]);
-    SetLNGR(correctMap[libcomp::CORRECT_LNGR]);
-    SetSPELL(correctMap[libcomp::CORRECT_SPELL]);
-    SetSUPPORT(correctMap[libcomp::CORRECT_SUPPORT]);
-    SetPDEF(correctMap[libcomp::CORRECT_PDEF]);
-    SetMDEF(correctMap[libcomp::CORRECT_MDEF]);
-
-    return true;
-}
-
-bool RecalculateDemonStats(libcomp::DefinitionManager* definitionManager,
-    objects::ActiveEntityStateObject* entity,
-    std::shared_ptr<objects::EntityStats> cs, uint32_t demonID)
-{
-    auto demonData = definitionManager->GetDevilData(demonID);
-    auto battleData = demonData->GetBattleData();
-
-    std::unordered_map<uint8_t, int16_t> correctMap;
-    correctMap[libcomp::CORRECT_STR] = cs->GetSTR();
-    correctMap[libcomp::CORRECT_MAGIC] = cs->GetMAGIC();
-    correctMap[libcomp::CORRECT_VIT] = cs->GetVIT();
-    correctMap[libcomp::CORRECT_INTEL] = cs->GetINTEL();
-    correctMap[libcomp::CORRECT_SPEED] = cs->GetSPEED();
-    correctMap[libcomp::CORRECT_LUCK] = cs->GetLUCK();
-    correctMap[libcomp::CORRECT_MAXHP] = battleData->GetCorrect(libcomp::CORRECT_MAXHP);
-    correctMap[libcomp::CORRECT_MAXMP] = battleData->GetCorrect(libcomp::CORRECT_MAXMP);
-    correctMap[libcomp::CORRECT_CLSR] = battleData->GetCorrect(libcomp::CORRECT_CLSR);
-    correctMap[libcomp::CORRECT_LNGR] = battleData->GetCorrect(libcomp::CORRECT_LNGR);
-    correctMap[libcomp::CORRECT_SPELL] = battleData->GetCorrect(libcomp::CORRECT_SPELL);
-    correctMap[libcomp::CORRECT_SUPPORT] = battleData->GetCorrect(libcomp::CORRECT_SUPPORT);
-    correctMap[libcomp::CORRECT_PDEF] = battleData->GetCorrect(libcomp::CORRECT_PDEF);
-    correctMap[libcomp::CORRECT_MDEF] = battleData->GetCorrect(libcomp::CORRECT_MDEF);
-
-    /// @todo: apply effects
-
-    CharacterManager::CalculateDependentStats(correctMap, cs->GetLevel(), true);
-
-    entity->SetMaxHP(correctMap[libcomp::CORRECT_MAXHP]);
-    entity->SetMaxMP(correctMap[libcomp::CORRECT_MAXMP]);
-    entity->SetSTR(correctMap[libcomp::CORRECT_STR]);
-    entity->SetMAGIC(correctMap[libcomp::CORRECT_MAGIC]);
-    entity->SetVIT(correctMap[libcomp::CORRECT_VIT]);
-    entity->SetINTEL(correctMap[libcomp::CORRECT_INTEL]);
-    entity->SetSPEED(correctMap[libcomp::CORRECT_SPEED]);
-    entity->SetLUCK(correctMap[libcomp::CORRECT_LUCK]);
-    entity->SetCLSR(correctMap[libcomp::CORRECT_CLSR]);
-    entity->SetLNGR(correctMap[libcomp::CORRECT_LNGR]);
-    entity->SetSPELL(correctMap[libcomp::CORRECT_SPELL]);
-    entity->SetSUPPORT(correctMap[libcomp::CORRECT_SUPPORT]);
-    entity->SetPDEF(correctMap[libcomp::CORRECT_PDEF]);
-    entity->SetMDEF(correctMap[libcomp::CORRECT_MDEF]);
-
-    return true;
+    return CompareAndResetStats(stats);
 }
 
 template<>
-bool ActiveEntityStateImp<objects::Demon>::RecalculateStats(
+uint8_t ActiveEntityStateImp<objects::Demon>::RecalculateStats(
     libcomp::DefinitionManager* definitionManager)
 {
     auto d = GetEntity();
@@ -306,11 +1234,11 @@ bool ActiveEntityStateImp<objects::Demon>::RecalculateStats(
         return true;
     }
 
-    return RecalculateDemonStats(definitionManager, this, d->GetCoreStats().Get(), d->GetType());
+    return RecalculateDemonStats(definitionManager, d->GetType());
 }
 
 template<>
-bool ActiveEntityStateImp<objects::Enemy>::RecalculateStats(
+uint8_t ActiveEntityStateImp<objects::Enemy>::RecalculateStats(
     libcomp::DefinitionManager* definitionManager)
 {
     auto e = GetEntity();
@@ -319,7 +1247,182 @@ bool ActiveEntityStateImp<objects::Enemy>::RecalculateStats(
         return true;
     }
 
-    return RecalculateDemonStats(definitionManager, this, e->GetCoreStats().Get(), e->GetType());
+    return RecalculateDemonStats(definitionManager, e->GetType());
 }
 
+}
+
+const std::set<CorrectTbl> BASE_STATS =
+    {
+        CorrectTbl::STR,
+        CorrectTbl::MAGIC,
+        CorrectTbl::VIT,
+        CorrectTbl::INT,
+        CorrectTbl::SPEED,
+        CorrectTbl::LUCK
+    };
+
+void ActiveEntityState::AdjustStats(
+    const std::list<std::shared_ptr<objects::MiCorrectTbl>>& adjustments,
+    libcomp::EnumMap<CorrectTbl, int16_t>& stats, bool baseMode) const
+{
+    std::set<CorrectTbl> removed;
+    for(auto ct : adjustments)
+    {
+        auto tblID = ct->GetID();
+
+        // Only adjust base or calculated stats depending on mode
+        if(baseMode != (BASE_STATS.find(tblID) != BASE_STATS.end())) continue;
+
+        // If a value is reduced to 0%, leave it
+        if(removed.find(tblID) != removed.end()) continue;
+
+        switch(ct->GetType())
+        {
+        case objects::MiCorrectTbl::Type_t::PERCENT:
+            // Percentage sets can either be an immutable set to zero
+            // or an increase/decrease by a set amount
+            if(ct->GetValue() == 0)
+            {
+                removed.insert(tblID);
+                stats[tblID] = 0;
+            }
+            else
+            {
+                stats[tblID] = (int16_t)(stats[tblID] +
+                    (int16_t)(stats[tblID] * (ct->GetValue() * 0.01)));
+            }
+            break;
+        case objects::MiCorrectTbl::Type_t::NUMERIC:
+            stats[tblID] = (int16_t)(stats[tblID] + ct->GetValue());
+            break;
+        default:
+            break;
+        }
+    }
+
+    CharacterManager::AdjustStatBounds(stats);
+}
+
+void ActiveEntityState::GetStatusEffectCorrectTbls(
+    libcomp::DefinitionManager* definitionManager,
+    std::list<std::shared_ptr<objects::MiCorrectTbl>>& adjustments)
+{
+    for(auto ePair : GetStatusEffects())
+    {
+        auto statusData = definitionManager->GetStatusData(ePair.first);
+        for(auto ct : statusData->GetCommon()->GetCorrectTbl())
+        {
+            uint8_t multiplier = (statusData->GetBasic()->GetStackType() == 2)
+                ? ePair.second->GetStack() : 1;
+            for(uint8_t i = 0; i < multiplier; i++)
+            {
+                adjustments.push_back(ct);
+            }
+        }
+    }
+
+    // Sort the adjustments, set to 0% first, non-zero percents next, numeric last
+    adjustments.sort([](const std::shared_ptr<objects::MiCorrectTbl>& a,
+        const std::shared_ptr<objects::MiCorrectTbl>& b)
+    {
+        return a->GetType() == objects::MiCorrectTbl::Type_t::PERCENT &&
+            (a->GetValue() == 0 ||
+            b->GetType() != objects::MiCorrectTbl::Type_t::PERCENT);
+    });
+}
+
+uint8_t ActiveEntityState::RecalculateDemonStats(
+    libcomp::DefinitionManager* definitionManager, uint32_t demonID)
+{
+    std::lock_guard<std::mutex> lock(mLock);
+
+    auto demonData = definitionManager->GetDevilData(demonID);
+    auto battleData = demonData->GetBattleData();
+    auto cs = GetCoreStats();
+
+    libcomp::EnumMap<CorrectTbl, int16_t> stats;
+    stats[CorrectTbl::STR] = cs->GetSTR();
+    stats[CorrectTbl::MAGIC] = cs->GetMAGIC();
+    stats[CorrectTbl::VIT] = cs->GetVIT();
+    stats[CorrectTbl::INT] = cs->GetINTEL();
+    stats[CorrectTbl::SPEED] = cs->GetSPEED();
+    stats[CorrectTbl::LUCK] = cs->GetLUCK();
+
+    for(size_t i = 0; i < 126; i++)
+    {
+        CorrectTbl tblID = (CorrectTbl)i;
+        if(BASE_STATS.find(tblID) == BASE_STATS.end())
+        {
+            stats[tblID] = battleData->GetCorrect((size_t)i);
+        }
+    }
+
+    std::list<std::shared_ptr<objects::MiCorrectTbl>> correctTbls;
+    GetStatusEffectCorrectTbls(definitionManager, correctTbls);
+
+    AdjustStats(correctTbls, stats, true);
+    CharacterManager::CalculateDependentStats(stats, cs->GetLevel(), true);
+    AdjustStats(correctTbls, stats, false);
+
+    return CompareAndResetStats(stats);
+}
+
+uint8_t ActiveEntityState::CompareAndResetStats(libcomp::EnumMap<CorrectTbl, int16_t>& stats)
+{
+    auto cs = GetCoreStats();
+    int16_t hp = cs->GetHP();
+    int16_t mp = cs->GetMP();
+    if(hp > stats[CorrectTbl::HP_MAX])
+    {
+        hp = stats[CorrectTbl::HP_MAX];
+    }
+
+    if(mp > stats[CorrectTbl::MP_MAX])
+    {
+        mp = stats[CorrectTbl::HP_MAX];
+    }
+
+    bool worldChange =
+        hp != cs->GetHP()
+        || mp != cs->GetMP()
+        || GetMaxHP() != stats[CorrectTbl::HP_MAX]
+        || GetMaxMP() != stats[CorrectTbl::MP_MAX];
+
+    bool anyChange = worldChange
+        || GetSTR() != stats[CorrectTbl::STR]
+        || GetMAGIC() != stats[CorrectTbl::MAGIC]
+        || GetVIT() != stats[CorrectTbl::VIT]
+        || GetINTEL() != stats[CorrectTbl::INT]
+        || GetSPEED() != stats[CorrectTbl::SPEED]
+        || GetLUCK() != stats[CorrectTbl::LUCK]
+        || GetCLSR() != stats[CorrectTbl::CLSR]
+        || GetLNGR() != stats[CorrectTbl::LNGR]
+        || GetSPELL() != stats[CorrectTbl::SPELL]
+        || GetSUPPORT() != stats[CorrectTbl::SUPPORT]
+        || GetPDEF() != stats[CorrectTbl::PDEF]
+        || GetMDEF() != stats[CorrectTbl::MDEF]
+        || GetHPRegen() != stats[CorrectTbl::HP_REGEN]
+        || GetMPRegen() != stats[CorrectTbl::MP_REGEN];
+
+    cs->SetHP(hp);
+    cs->SetMP(mp);
+    SetMaxHP(stats[CorrectTbl::HP_MAX]);
+    SetMaxMP(stats[CorrectTbl::MP_MAX]);
+    SetSTR(stats[CorrectTbl::STR]);
+    SetMAGIC(stats[CorrectTbl::MAGIC]);
+    SetVIT(stats[CorrectTbl::VIT]);
+    SetINTEL(stats[CorrectTbl::INT]);
+    SetSPEED(stats[CorrectTbl::SPEED]);
+    SetLUCK(stats[CorrectTbl::LUCK]);
+    SetCLSR(stats[CorrectTbl::CLSR]);
+    SetLNGR(stats[CorrectTbl::LNGR]);
+    SetSPELL(stats[CorrectTbl::SPELL]);
+    SetSUPPORT(stats[CorrectTbl::SUPPORT]);
+    SetPDEF(stats[CorrectTbl::PDEF]);
+    SetMDEF(stats[CorrectTbl::MDEF]);
+    SetHPRegen(stats[CorrectTbl::HP_REGEN]);
+    SetMPRegen(stats[CorrectTbl::MP_REGEN]);
+
+    return worldChange ? 2 : (anyChange ? 1 : 0);
 }

--- a/server/channel/src/ChannelClientConnection.cpp
+++ b/server/channel/src/ChannelClientConnection.cpp
@@ -43,13 +43,24 @@ ClientState* ChannelClientConnection::GetClientState() const
     return mClientState.get();
 }
 
-void ChannelClientConnection::RefreshTimeout(uint64_t now)
+void ChannelClientConnection::RefreshTimeout(uint64_t now, uint16_t aliveUntil)
 {
-    // 30 seconds from now
-    mTimeout = now + 30000000;
+    mTimeout = now + (uint64_t)(aliveUntil * 1000000);
 }
 
 uint64_t ChannelClientConnection::GetTimeout() const
 {
     return mTimeout;
+}
+
+void ChannelClientConnection::BroadcastPacket(const std::list<std::shared_ptr<
+    ChannelClientConnection>>& clients, libcomp::Packet& packet)
+{
+    std::list<std::shared_ptr<libcomp::TcpConnection>> connections;
+    for(auto client : clients)
+    {
+        connections.push_back(client);
+    }
+
+    libcomp::TcpConnection::BroadcastPacket(connections, packet);
 }

--- a/server/channel/src/ChannelClientConnection.h
+++ b/server/channel/src/ChannelClientConnection.h
@@ -63,14 +63,24 @@ public:
     /**
      * Refresh the client timeout.
      * @param now Current server time
+     * @param aliveUntil Time in seconds that needs to pass before the
+     *  refresh time is no longer valid and the timeout countdown starts
      */
-    void RefreshTimeout(uint64_t now);
+    void RefreshTimeout(uint64_t now, uint16_t aliveUntil);
 
     /**
      * Get the next client timeout timestamp.
      * @return Server time representation of the next timeout timestamp
      */
     uint64_t GetTimeout() const;
+
+    /**
+     * Broadcast the supplied packet to each client connection in the list.
+     * @param clients List of client connections to send the packet to
+     * @param packet Packet to send to the supplied clients
+     */
+    static void BroadcastPacket(const std::list<std::shared_ptr<
+        ChannelClientConnection>>& clients, libcomp::Packet& packet);
 
 private:
     /// State of the client

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -145,6 +145,8 @@ bool ChannelServer::Initialize()
         to_underlying(ClientToChannelPacketCode_t::PACKET_DEMON_BOX_DATA));
     clientPacketManager->AddParser<Parsers::ChannelList>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_CHANNEL_LIST));
+    clientPacketManager->AddParser<Parsers::ReviveCharacter>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_REVIVE_CHARACTER));
     clientPacketManager->AddParser<Parsers::StopMovement>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_STOP_MOVEMENT));
     clientPacketManager->AddParser<Parsers::SpotTriggered>(
@@ -237,6 +239,8 @@ bool ChannelServer::Initialize()
         to_underlying(ClientToChannelPacketCode_t::PACKET_QUEST_COMPLETED_LIST));
     clientPacketManager->AddParser<Parsers::ClanInfo>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_CLAN_INFO));
+    clientPacketManager->AddParser<Parsers::SyncCharacter>(
+        to_underlying(ClientToChannelPacketCode_t::PACKET_SYNC_CHARACTER));
     clientPacketManager->AddParser<Parsers::MapFlag>(
         to_underlying(ClientToChannelPacketCode_t::PACKET_MAP_FLAG));
     clientPacketManager->AddParser<Parsers::DemonCompendium>(
@@ -643,7 +647,7 @@ std::shared_ptr<libcomp::TcpConnection> ChannelServer::CreateConnection(
 
         // Kill the connection if the client doesn't send packets
         // shortly after connecting
-        connection->RefreshTimeout(GetServerTime());
+        connection->RefreshTimeout(GetServerTime(), 30);
     }
     else
     {

--- a/server/channel/src/ChannelServer.h
+++ b/server/channel/src/ChannelServer.h
@@ -91,12 +91,6 @@ public:
     static ServerTime GetServerTime();
 
     /**
-     * Get the current time relative to the server in seconds.
-     * @return Current time relative to the server in seconds
-     */
-    static uint32_t GetServerTimeInSeconds();
-
-    /**
      * Get the amount of time left in an expiration relative to the server,
      * in seconds.
      * @return Time until expiration relative to the server, in seconds

--- a/server/channel/src/ChatManager.h
+++ b/server/channel/src/ChatManager.h
@@ -129,6 +129,17 @@ private:
         const std::list<libcomp::String>& args);
 
     /**
+     * GM command to apply a status effect to the client's character or
+     * demon.
+     * @param client Pointer to the client that sent the command
+     * @param args List of arguments for the command
+     * @return true if the command was handled properly, else false
+     */
+    bool GMCommand_Effect(const std::shared_ptr<
+        channel::ChannelClientConnection>& client,
+        const std::list<libcomp::String>& args);
+
+    /**
      * GM command to spawn an entity in the client's zone.
      * @param client Pointer to the client that sent the command
      * @param args List of arguments for the command
@@ -167,6 +178,16 @@ private:
      * @return true if the command was handled properly, else false
      */
     bool GMCommand_Item(const std::shared_ptr<
+        channel::ChannelClientConnection>& client,
+        const std::list<libcomp::String>& args);
+
+    /**
+     * GM command to kill a character in the same zone.
+     * @param client Pointer to the client that sent the command
+     * @param args List of arguments for the command
+     * @return true if the command was handled properly, else false
+     */
+    bool GMCommand_Kill(const std::shared_ptr<
         channel::ChannelClientConnection>& client,
         const std::list<libcomp::String>& args);
 

--- a/server/channel/src/EnemyState.cpp
+++ b/server/channel/src/EnemyState.cpp
@@ -111,7 +111,7 @@ bool EnemyState::Prepare(const std::weak_ptr<EnemyState>& self,
 
 bool EnemyState::UpdateState(uint64_t now)
 {
-    if(!mAIScript)
+    if(!IsAlive() || !mAIScript)
     {
         return false;
     }

--- a/server/channel/src/EventManager.cpp
+++ b/server/channel/src/EventManager.cpp
@@ -474,11 +474,10 @@ bool EventManager::Homepoint(const std::shared_ptr<ChannelClientConnection>& cli
 {
     auto e = std::dynamic_pointer_cast<objects::EventHomepoint>(instance->GetEvent());
 
-    auto server = mServer.lock();
     auto state = client->GetClientState();
     auto cState = state->GetCharacterState();
     auto character = cState->GetEntity();
-    auto zone = server->GetZoneManager()->GetZoneInstance(client);
+    auto zone = cState->GetZone();
 
     /// @todo: check for invalid zone types or positions
 

--- a/server/channel/src/ManagerConnection.h
+++ b/server/channel/src/ManagerConnection.h
@@ -129,17 +129,22 @@ public:
         GetEntityClient(int32_t id, bool worldID = false);
 
     /**
-     * Schedule future server work to execute HandleClientTimeouts.
+     * Schedule future server work to execute HandleClientTimeouts every
+     * 10 seconds.
+     * @param timeout Time in seconds that needs to pass for a client
+     *  connection to time out
      * @return true if the work was scheduled, false if it was not
      */
-    bool ScheduleClientTimeoutHandler();
+    bool ScheduleClientTimeoutHandler(uint16_t timeout);
 
     /**
      * Cycle through the current client connections and disconnect clients
      * that not pinged the server for a while.
-     * @param now The current server time used to check for timeouts 
+     * @param now The current server time used to check for timeouts
+     * @param timeout Time in seconds that needs to pass for a client
+     *  connection to time out
      */
-    void HandleClientTimeouts(uint64_t now);
+    void HandleClientTimeouts(uint64_t now, uint16_t timeout);
 
 private:
     /// Static list of supported message types for the manager.

--- a/server/channel/src/Packets.h
+++ b/server/channel/src/Packets.h
@@ -58,6 +58,7 @@ PACKET_PARSER_DECL(PartnerDemonData);       // 0x005B
 PACKET_PARSER_DECL(DemonBox);               // 0x005C
 PACKET_PARSER_DECL(DemonBoxData);           // 0x005E
 PACKET_PARSER_DECL(ChannelList);            // 0x0063
+PACKET_PARSER_DECL(ReviveCharacter);        // 0x0067
 PACKET_PARSER_DECL(StopMovement);           // 0x006F
 PACKET_PARSER_DECL(SpotTriggered);          // 0x0071
 PACKET_PARSER_DECL(WorldTime);              // 0x0072
@@ -103,6 +104,7 @@ PACKET_PARSER_DECL(DepoRent);               // 0x0104
 PACKET_PARSER_DECL(QuestActiveList);        // 0x010B
 PACKET_PARSER_DECL(QuestCompletedList);     // 0x010C
 PACKET_PARSER_DECL(ClanInfo);               // 0x0150
+PACKET_PARSER_DECL(SyncCharacter);          // 0x017E
 PACKET_PARSER_DECL(MapFlag);                // 0x0197
 PACKET_PARSER_DECL(DemonCompendium);        // 0x019B
 PACKET_PARSER_DECL(DungeonRecords);         // 0x01C4

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -40,6 +40,7 @@
 #include <ActivatedAbility.h>
 #include <Item.h>
 #include <ItemBox.h>
+#include <MiAddStatusTbl.h>
 #include <MiBattleDamageData.h>
 #include <MiCastBasicData.h>
 #include <MiCastData.h>
@@ -48,8 +49,12 @@
 #include <MiDamageData.h>
 #include <MiDevilData.h>
 #include <MiDischargeData.h>
+#include <MiDoTDamageData.h>
+#include <MiEffectData.h>
 #include <MiNPCBasicData.h>
 #include <MiSkillData.h>
+#include <MiStatusData.h>
+#include <MiStatusBasicData.h>
 #include <MiSummonData.h>
 #include <MiTargetData.h>
 #include <ServerZone.h>
@@ -77,6 +82,7 @@ const uint8_t DAMAGE_TYPE_DRAIN = 5;
 const uint16_t FLAG1_LETHAL = 1;
 const uint16_t FLAG1_CRITICAL = 1 << 6;
 const uint16_t FLAG1_WEAKPOINT = 1 << 7;
+const uint16_t FLAG1_REVIVAL = 1 << 9;
 const uint16_t FLAG1_REFLECT = 1 << 11; //Only displayed with DAMAGE_TYPE_NONE
 const uint16_t FLAG1_BLOCK = 1 << 12;   //Only dsiplayed with DAMAGE_TYPE_NONE
 const uint16_t FLAG1_PROTECT = 1 << 15;
@@ -95,15 +101,18 @@ struct SkillTargetResult
     int32_t Damage2 = 0;
     uint8_t Damage2Type = DAMAGE_TYPE_NONE;
     uint16_t DamageFlags1 = 0;
-    bool AilmentDamaged = false;
-    int32_t AilmentDamageAmount = 0;
+    uint8_t AilmentDamageType = 0;
+    int32_t AilmentDamage = 0;
     uint16_t DamageFlags2 = 0;
     int32_t TechnicalDamage = 0;
     int32_t PursuitDamage = 0;
+    bool Knockback = false;
+    AddStatusEffectMap AddedStatuses;
+    std::set<uint32_t> CancelledStatuses;
 };
 
 bool CalculateDamage(const std::shared_ptr<ActiveEntityState>& source,
-    uint32_t hpCost, uint32_t mpCost, SkillTargetResult& target,
+    int16_t hpCost, int16_t mpCost, SkillTargetResult& target,
     std::shared_ptr<objects::MiBattleDamageData> damageData);
 
 int32_t CalculateDamage_Normal(uint16_t mod, uint8_t& damageType,
@@ -230,10 +239,28 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
     auto state = client->GetClientState();
     auto cState = state->GetCharacterState();
     auto character = cState->GetEntity();
+    
+    // Check targets
+    if(skillData->GetTarget()->GetType() == objects::MiTargetData::Type_t::DEAD_ALLY)
+    {
+        auto damageFormula = skillData->GetDamage()->GetBattleDamage()->GetFormula();
+        bool isRevive = damageFormula == objects::MiBattleDamageData::Formula_t::HEAL_NORMAL
+            || damageFormula == objects::MiBattleDamageData::Formula_t::HEAL_STATIC
+            || damageFormula == objects::MiBattleDamageData::Formula_t::HEAL_MAX_PERCENT;
 
-    // Check conditions
-    /// @todo: check more than just costs
-    uint32_t hpCost = 0, mpCost = 0;
+        // If the target is a character and they have not accepted revival, stop here
+        auto targetEntityID = (int32_t)activated->GetTargetObjectID();
+        auto targetClientState = ClientState::GetEntityClientState(targetEntityID);
+        if(isRevive && (!targetClientState ||
+            (!targetClientState->GetAcceptRevival() &&
+            targetClientState->GetCharacterState()->GetEntityID() == targetEntityID)))
+        {
+            return false;
+        }
+    }
+
+    // Check costs
+    int16_t hpCost = 0, mpCost = 0;
     uint16_t hpCostPercent = 0, mpCostPercent = 0;
     std::unordered_map<uint32_t, uint16_t> itemCosts;
     if(skillID == SKILL_SUMMON_DEMON)
@@ -273,7 +300,7 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
                     }
                     else
                     {
-                        hpCost += num;
+                        hpCost = (int16_t)(hpCost + num);
                     }
                     break;
                 case objects::MiCostTbl::Type_t::MP:
@@ -283,7 +310,7 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
                     }
                     else
                     {
-                        mpCost += num;
+                        mpCost = (int16_t)(mpCost + num);
                     }
                     break;
                 case objects::MiCostTbl::Type_t::ITEM:
@@ -310,14 +337,14 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
         }
     }
 
-    hpCost = (uint32_t)(hpCost + ceil(((float)hpCostPercent * 0.01f) *
+    hpCost = (int16_t)(hpCost + ceil(((float)hpCostPercent * 0.01f) *
         (float)sourceState->GetMaxHP()));
-    mpCost = (uint32_t)(mpCost + ceil(((float)mpCostPercent * 0.01f) *
+    mpCost = (int16_t)(mpCost + ceil(((float)mpCostPercent * 0.01f) *
         (float)sourceState->GetMaxMP()));
 
     auto sourceStats = sourceState->GetCoreStats();
-    bool canPay = ((hpCost == 0) || hpCost < (uint32_t)sourceStats->GetHP()) &&
-        ((mpCost == 0) || mpCost < (uint32_t)sourceStats->GetMP());
+    bool canPay = ((hpCost == 0) || hpCost < sourceStats->GetHP()) &&
+        ((mpCost == 0) || mpCost < sourceStats->GetMP());
     auto characterManager = server->GetCharacterManager();
     for(auto itemCost : itemCosts)
     {
@@ -342,8 +369,11 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
     }
 
     // Pay the costs
-    sourceStats->SetHP(static_cast<int16_t>(sourceStats->GetHP() - (uint16_t)hpCost));
-    sourceStats->SetMP(static_cast<int16_t>(sourceStats->GetMP() - (uint16_t)mpCost));
+    if(hpCost > 0 || mpCost > 0)
+    {
+        sourceState->SetHPMP((int16_t)-hpCost, (int16_t)-mpCost, true);
+    }
+
     for(auto itemCost : itemCosts)
     {
         characterManager->AddRemoveItem(client, itemCost.first, itemCost.second,
@@ -371,6 +401,8 @@ bool SkillManager::ExecuteSkill(const std::shared_ptr<ChannelClientConnection> c
             return ExecuteNormalSkill(client, sourceState->GetEntityID(), activated,
                 hpCost, mpCost);
     }
+
+    characterManager->CancelStatusEffects(client, EFFECT_CANCEL_SKILL);
 
     if(success)
     {
@@ -420,12 +452,12 @@ void SkillManager::SendFailure(const std::shared_ptr<ChannelClientConnection> cl
     reply.WriteU8(0);  //Unknown
     reply.WriteS32Little(-1);  //Unknown
 
-    client->SendPacket(reply);
+    mServer.lock()->GetZoneManager()->BroadcastPacket(client, reply);
 }
 
 bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnection> client,
     int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-    uint32_t hpCost, uint32_t mpCost)
+    int16_t hpCost, int16_t mpCost)
 {
     auto state = client->GetClientState();
 
@@ -436,6 +468,7 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
     }
 
     auto server = mServer.lock();
+    auto characterManager = server->GetCharacterManager();
     auto definitionManager = server->GetDefinitionManager();
     auto zoneManager = server->GetZoneManager();
     auto skillID = activated->GetSkillID();
@@ -512,11 +545,15 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
     // Run calculations
     bool hasBattleDamage = false;
     auto battleDamageData = skillData->GetDamage()->GetBattleDamage();
+    auto addStatuses = skillData->GetDamage()->GetAddStatuses();
     for(SkillTargetResult& target : targetResults)
     {
         if(battleDamageData->GetFormula() !=
             objects::MiBattleDamageData::Formula_t::NONE)
         {
+            /// @todo: implement knockback properly
+            target.Knockback = true;
+
             if(!CalculateDamage(source, hpCost, mpCost, target, battleDamageData))
             {
                 LOG_ERROR(libcomp::String("Damage failed to calculate: %1\n")
@@ -525,6 +562,42 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
             }
 
             hasBattleDamage = true;
+        }
+
+        // Determine which status effects to apply
+        for(auto addStatus : addStatuses)
+        {
+            if(addStatus->GetOnKnockback() && !target.Knockback) continue;
+
+            uint16_t successRate = addStatus->GetSuccessRate();
+            if(successRate >= 100 || (rand() % 99) <= successRate)
+            {
+                int8_t minStack = addStatus->GetMinStack();
+                int8_t maxStack = addStatus->GetMaxStack();
+
+                // Sanity check
+                if(minStack > maxStack) continue;
+
+                int8_t stack = (int8_t)(minStack + (rand() % (maxStack - minStack)));
+                if(stack == 0) continue;
+
+                target.AddedStatuses[addStatus->GetStatusID()] =
+                    std::pair<uint8_t, bool>(stack, addStatus->GetIsReplace());
+
+                // Check for status T-Damage to apply at the end of the skill
+                auto statusDef = definitionManager->GetStatusData(
+                    addStatus->GetStatusID());
+                auto basicDef = statusDef->GetBasic();
+                if(basicDef->GetStackType() == 1 && basicDef->GetApplicationLogic() == 0)
+                {
+                    auto tDamage = statusDef->GetEffect()->GetDamage();
+                    if(tDamage->GetHPDamage() > 0)
+                    {
+                        /// @todo: transform properly
+                        target.AilmentDamage += tDamage->GetHPDamage();
+                    }
+                }
+            }
         }
     }
 
@@ -536,12 +609,16 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
 
     // Apply calculation results, keeping track of entities that may
     // need to update the world with their modified state
-    for(auto target : targetResults)
+    std::set<std::shared_ptr<ActiveEntityState>> revived;
+    std::unordered_map<std::shared_ptr<ActiveEntityState>, uint8_t> cancellations;
+    for(SkillTargetResult& target : targetResults)
     {
+        cancellations[target.EntityState] = target.Knockback
+            ? EFFECT_CANCEL_KNOCKBACK : 0;
         if(hasBattleDamage)
         {
-            int32_t hpAdjust = target.TechnicalDamage;
-            int32_t mpAdjust = 0;
+            int32_t hpDamage = target.TechnicalDamage + target.AilmentDamage;
+            int32_t mpDamage = 0;
 
             for(int i = 0; i < 2; i++)
             {
@@ -555,52 +632,54 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
                     case DAMAGE_TYPE_DRAIN:
                         if(hpMode)
                         {
-                            hpAdjust = (int32_t)(hpAdjust + val);
+                            hpDamage = (int32_t)(hpDamage + val);
                         }
                         else
                         {
-                            mpAdjust = (int32_t)(mpAdjust + val);
+                            mpDamage = (int32_t)(mpDamage + val);
                         }
                         break;
                     default:
                         if(hpMode)
                         {
-                            hpAdjust = (int32_t)(hpAdjust + val);
+                            hpDamage = (int32_t)(hpDamage + val);
                         }
                         break;
                 }
             }
 
-            auto targetStats = target.EntityState->GetCoreStats();
-            hpAdjust = static_cast<int32_t>(targetStats->GetHP() - hpAdjust);
-            mpAdjust = static_cast<int32_t>(targetStats->GetMP() - mpAdjust);
+            bool targetAlive = target.EntityState->IsAlive();
 
-            // Adjust for more than max or less than zero
-            if(hpAdjust <= 0)
+            int16_t hpAdjusted, mpAdjusted;
+            if(target.EntityState->SetHPMP((int16_t)-hpDamage, (int16_t)-mpDamage, true,
+                true, hpAdjusted, mpAdjusted))
             {
-                hpAdjust = 0;
+                // Changed from alive to dead or vice versa
+                if(target.EntityState->GetEntityType() ==
+                    objects::EntityStateObject::EntityType_t::CHARACTER)
+                {
+                    // Reset accept revival
+                    auto targetClientState = ClientState::GetEntityClientState(
+                        target.EntityState->GetEntityID());
+                    targetClientState->SetAcceptRevival(false);
+                }
 
-                if(targetStats->GetHP() > 0)
+                if(targetAlive)
                 {
                     target.DamageFlags1 |= FLAG1_LETHAL;
                 }
-            }
-            else if(hpAdjust > target.EntityState->GetMaxHP())
-            {
-                hpAdjust = target.EntityState->GetMaxHP();
+                else
+                {
+                    target.DamageFlags1 |= FLAG1_REVIVAL;
+                    revived.insert(target.EntityState);
+                }
             }
             
-            if(mpAdjust < 0)
+            if(hpAdjusted <= 0)
             {
-                mpAdjust = 0;
+                cancellations[target.EntityState] |= EFFECT_CANCEL_HIT |
+                    EFFECT_CANCEL_DAMAGE;
             }
-            else if(mpAdjust > target.EntityState->GetMaxMP())
-            {
-                mpAdjust = target.EntityState->GetMaxMP();
-            }
-
-            targetStats->SetHP(static_cast<int16_t>(hpAdjust));
-            targetStats->SetMP(static_cast<int16_t>(mpAdjust));
 
             switch(target.EntityState->GetEntityType())
             {
@@ -613,7 +692,32 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
             }
         }
 
-        target.EntityState->RecalculateStats(definitionManager);
+        characterManager->RecalculateStats(client, target.EntityState->GetEntityID());
+    }
+
+    for(auto cancelPair : cancellations)
+    {
+        if(cancelPair.second)
+        {
+            cancelPair.first->CancelStatusEffects(cancelPair.second);
+        }
+    }
+
+    characterManager->CancelStatusEffects(client, EFFECT_CANCEL_SKILL);
+
+    // Now that previous effects have been cancelled, add the new ones
+    uint32_t effectTime = (uint32_t)std::time(0);
+    for(SkillTargetResult& target : targetResults)
+    {
+        if(target.AddedStatuses.size() > 0)
+        {
+            auto removed = target.EntityState->AddStatusEffects(
+                target.AddedStatuses, definitionManager, effectTime, false);
+            for(auto r : removed)
+            {
+                target.CancelledStatuses.insert(r);
+            }
+        }
     }
 
     FinalizeSkillExecution(client, sourceEntityID, activated, skillData, hpCost, mpCost);
@@ -626,7 +730,7 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
     reply.WriteS8((int8_t)activated->GetActivationID());
 
     reply.WriteU32Little((uint32_t)targetResults.size());
-    for(auto target : targetResults)
+    for(SkillTargetResult& target : targetResults)
     {
         reply.WriteS32Little(target.EntityState->GetEntityID());
         reply.WriteS32Little(abs(target.Damage1));
@@ -635,34 +739,58 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
         reply.WriteU8(target.Damage2Type);
         reply.WriteU16Little(target.DamageFlags1);
 
-        reply.WriteU8(static_cast<uint8_t>(target.AilmentDamaged ? 1 : 0));
-        reply.WriteS32Little(abs(target.AilmentDamageAmount));
+        reply.WriteU8(target.AilmentDamageType);
+        reply.WriteS32Little(abs(target.AilmentDamage));
 
         //Knockback location info?
         reply.WriteFloat(0);
         reply.WriteFloat(0);
         reply.WriteFloat(0);
-        reply.WriteFloat(0);
-        reply.WriteFloat(0);
-        reply.WriteFloat(0);
-        reply.WriteU8(0);
 
-        uint32_t effectAddCount = 0;
-        uint32_t effectCancelCount = 0;
-        reply.WriteU32Little(effectAddCount);
-        reply.WriteU32Little(effectCancelCount);
-        for(uint32_t i = 0; i < effectAddCount; i++)
+        /// @todo: Apply hit timing values properly
+        reply.WriteFloat(0);
+        reply.WriteFloat(0);
+        reply.WriteFloat(0);
+
+        reply.WriteU8(0);   // Unknown
+
+        std::list<std::shared_ptr<objects::StatusEffect>> addedStatuses;
+        std::set<uint32_t> cancelledStatuses;
+        if(target.AddedStatuses.size() > 0)
         {
-            /// @todo: Added status effects
-            reply.WriteU32Little(0);
-            reply.WriteS32Little(0);
-            reply.WriteU8(0);
+            // Make sure the added statuses didn't get removed/re-added
+            // already for some reason
+            auto effects = target.EntityState->GetStatusEffects();
+            for(auto added : target.AddedStatuses)
+            {
+                if(effects.find(added.first) != effects.end())
+                {
+                    addedStatuses.push_back(effects[added.first]);
+                }
+            }
+
+            for(auto cancelled : target.CancelledStatuses)
+            {
+                if(effects.find(cancelled) == effects.end())
+                {
+                    cancelledStatuses.insert(cancelled);
+                }
+            }
         }
-        
-        for(uint32_t i = 0; i < effectCancelCount; i++)
+
+        reply.WriteU32Little((uint32_t)addedStatuses.size());
+        reply.WriteU32Little((uint32_t)cancelledStatuses.size());
+
+        for(auto effect : addedStatuses)
         {
-            /// @todo: Cancelled status effects
-            reply.WriteU32Little(0);
+            reply.WriteU32Little(effect->GetEffect());
+            reply.WriteS32Little((int32_t)effect->GetExpiration());
+            reply.WriteU8(effect->GetStack());
+        }
+
+        for(auto cancelled : cancelledStatuses)
+        {
+            reply.WriteU32Little(cancelled);
         }
 
         reply.WriteU16Little(target.DamageFlags2);
@@ -670,41 +798,28 @@ bool SkillManager::ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnect
         reply.WriteS32Little(target.PursuitDamage);
     }
 
-    client->SendPacket(reply);
+    zoneManager->BroadcastPacket(client, reply);
 
-    // Each entity with adjusted HP/MP needs to be communicated to the world
-    // if they belong to a party
+    if(revived.size() > 0)
+    {
+        for(auto entity : revived)
+        {
+            characterManager->SendEntityRevival(client, entity, 6, true);
+        }
+    }
+
+    /// @todo: Transform enemies killed into bodies
+
     if(displayStateModified.size() > 0)
     {
-        auto worldConnection = server->GetManagerConnection()
-            ->GetWorldConnection();
-        for(auto entity : displayStateModified)
-        {
-            auto entityClientState = ClientState::GetEntityClientState(
-                entity->GetEntityID());
-            if(!entityClientState || !entityClientState->GetPartyID()) continue;
-
-            libcomp::Packet packet;
-            if(entity->GetEntityType() ==
-                objects::EntityStateObject::EntityType_t::PARTNER_DEMON)
-            {
-                entityClientState->GetPartyDemonPacket(packet);
-            }
-            else
-            {
-                entityClientState->GetPartyCharacterPacket(packet);
-            }
-            worldConnection->QueuePacket(packet);
-        }
-
-        worldConnection->FlushOutgoing();
+        characterManager->UpdateWorldDisplayState(displayStateModified);
     }
 
     return true;
 }
 
 bool CalculateDamage(const std::shared_ptr<ActiveEntityState>& source,
-    uint32_t hpCost, uint32_t mpCost, SkillTargetResult& target,
+    int16_t hpCost, int16_t mpCost, SkillTargetResult& target,
     std::shared_ptr<objects::MiBattleDamageData> damageData)
 {
     bool isHeal = false;
@@ -782,11 +897,11 @@ bool CalculateDamage(const std::shared_ptr<ActiveEntityState>& source,
                 target.Damage1 = CalculateDamage_Percent(
                     damageData->GetModifier1(), target.Damage1Type,
                     static_cast<int16_t>(source->GetCoreStats()->GetHP() +
-                        (int16_t)hpCost));
+                        hpCost));
                 target.Damage2 = CalculateDamage_Percent(
                     damageData->GetModifier2(), target.Damage2Type,
                     static_cast<int16_t>(source->GetCoreStats()->GetMP() +
-                        (int16_t)mpCost));
+                        mpCost));
             }
             break;
         case objects::MiBattleDamageData::Formula_t::DMG_MAX_PERCENT:
@@ -918,7 +1033,7 @@ int32_t CalculateDamage_MaxPercent(uint16_t mod, uint8_t& damageType,
 
 void SkillManager::FinalizeSkillExecution(const std::shared_ptr<ChannelClientConnection> client,
     int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-    std::shared_ptr<objects::MiSkillData> skillData, uint32_t hpCost, uint32_t mpCost)
+    std::shared_ptr<objects::MiSkillData> skillData, int16_t hpCost, int16_t mpCost)
 {
     SendExecuteSkill(client, sourceEntityID, activated, skillData, hpCost, mpCost);
 
@@ -1017,12 +1132,12 @@ void SkillManager::SendChargeSkill(const std::shared_ptr<ChannelClientConnection
     reply.WriteFloat(300.0f);   //Run speed during charge
     reply.WriteFloat(300.0f);   //Run speed after charge
 
-    client->SendPacket(reply);
+    mServer.lock()->GetZoneManager()->BroadcastPacket(client, reply);
 }
 
 void SkillManager::SendExecuteSkill(const std::shared_ptr<ChannelClientConnection> client,
     int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-    std::shared_ptr<objects::MiSkillData> skillData, uint32_t hpCost, uint32_t mpCost)
+    std::shared_ptr<objects::MiSkillData> skillData, int16_t hpCost, int16_t mpCost)
 {
     auto state = client->GetClientState();
     auto cState = state->GetCharacterState();
@@ -1044,8 +1159,8 @@ void SkillManager::SendExecuteSkill(const std::shared_ptr<ChannelClientConnectio
     reply.WriteS32Little(targetedEntityID);
     reply.WriteFloat(cooldownTime);
     reply.WriteFloat(lockOutTime);
-    reply.WriteU32Little(hpCost);
-    reply.WriteU32Little(mpCost);
+    reply.WriteU32Little((uint32_t)hpCost);
+    reply.WriteU32Little((uint32_t)mpCost);
     reply.WriteU8(0);   //Unknown
     reply.WriteFloat(0);    //Unknown
     reply.WriteFloat(0);    //Unknown
@@ -1055,7 +1170,7 @@ void SkillManager::SendExecuteSkill(const std::shared_ptr<ChannelClientConnectio
     reply.WriteU8(0);   //Unknown
     reply.WriteU8(0xFF);   //Unknown
 
-    client->SendPacket(reply);
+    mServer.lock()->GetZoneManager()->BroadcastPacket(client, reply);
 }
 
 void SkillManager::SendCompleteSkill(const std::shared_ptr<ChannelClientConnection> client,
@@ -1071,5 +1186,5 @@ void SkillManager::SendCompleteSkill(const std::shared_ptr<ChannelClientConnecti
     reply.WriteFloat(300.0f);   //Run speed
     reply.WriteU8(cancelled ? 1 : 0);
 
-    client->SendPacket(reply);
+    mServer.lock()->GetZoneManager()->BroadcastPacket(client, reply);
 }

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -125,7 +125,7 @@ private:
      */
     bool ExecuteNormalSkill(const std::shared_ptr<ChannelClientConnection> client,
         int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-        uint32_t hpCost, uint32_t mpCost);
+        int16_t hpCost, int16_t mpCost);
 
     /**
      * Execute post execution steps like notifying the client that the skill
@@ -139,7 +139,7 @@ private:
      */
     void FinalizeSkillExecution(const std::shared_ptr<ChannelClientConnection> client,
         int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-        std::shared_ptr<objects::MiSkillData> skillData, uint32_t hpCost, uint32_t mpCost);
+        std::shared_ptr<objects::MiSkillData> skillData, int16_t hpCost, int16_t mpCost);
 
     /**
      * Execute the "equip item" ability.
@@ -198,7 +198,7 @@ private:
      */
     void SendExecuteSkill(const std::shared_ptr<ChannelClientConnection> client,
         int32_t sourceEntityID, std::shared_ptr<objects::ActivatedAbility> activated,
-        std::shared_ptr<objects::MiSkillData> skillData, uint32_t hpCost, uint32_t mpCost);
+        std::shared_ptr<objects::MiSkillData> skillData, int16_t hpCost, int16_t mpCost);
 
     /**
      * Notify the client that a skill is complete.

--- a/server/channel/src/Zone.h
+++ b/server/channel/src/Zone.h
@@ -33,6 +33,9 @@
 #include "EnemyState.h"
 #include "EntityState.h"
 
+// Standard C++11 includes
+#include <map>
+
 namespace objects
 {
 class ServerNPC;
@@ -170,6 +173,30 @@ public:
      */
     const std::shared_ptr<objects::ServerZone> GetDefinition();
 
+    /**
+     * Set the next status effect event time associated to an entity
+     * in the zone
+     * @param time Time of the next status effect event time
+     * @param entityID ID of the entity with a status effect event
+     *  at the specified time
+     */
+    void SetNextStatusEffectTime(uint32_t time, int32_t entityID);
+
+    /**
+     * Get the list of entities that have had registered status effect
+     * event times that have passed since the specified time
+     * @param now System time representing the current server time
+     * @return List of entities that have had registered status effect
+     *  event times that have passed
+     */
+    std::list<std::shared_ptr<ActiveEntityState>>
+        GetUpdatedStatusEffectEntities(uint32_t now);
+
+    /**
+     * Perform pre-deletion cleanup actions
+     */
+    void Cleanup();
+
 private:
     /**
      * Register an entity as one that currently exists in the zone
@@ -200,6 +227,10 @@ private:
 
     /// Map of entities in the zone by their ID
     std::unordered_map<int32_t, std::shared_ptr<objects::EntityStateObject>> mAllEntities;
+
+    /// Map of system times to active entities with status effects that need
+    /// handling at that time
+    std::map<uint32_t, std::set<int32_t>> mNextEntityStatusTimes;
 
     /// Unique instance ID of the zone
     uint32_t mID;

--- a/server/channel/src/ZoneManager.h
+++ b/server/channel/src/ZoneManager.h
@@ -94,8 +94,10 @@ public:
     /**
      * Remove a client connection from a zone
      * @param client Client connection to remove from any associated zone
+     * @param logOut If true, special logout actions will be performed
      */
-    void LeaveZone(const std::shared_ptr<ChannelClientConnection>& client);
+    void LeaveZone(const std::shared_ptr<ChannelClientConnection>& client,
+        bool logOut);
 
     /**
      * Send data about entities that exist in a zone to a new connection and
@@ -231,6 +233,17 @@ private:
     void SendEnemyData(const std::shared_ptr<ChannelClientConnection>& client,
         const std::shared_ptr<EnemyState>& enemyState,
         const std::shared_ptr<Zone>& zone, bool sendToAll, bool queue = false);
+
+    /**
+     * Update the state of status effects in the supplied zone, adding
+     * and updating existing effects, expiring old effects and applying
+     * T-damage and regen to entities with applicable affects
+     * @param zone Pointer to the zone to update status effects for
+     * @param now System time representing the current server time to use
+     *  for event checking
+     */
+    void UpdateStatusEffectStates(const std::shared_ptr<Zone>& zone,
+        uint32_t now);
 
     /**
      * Send a packet to every connection in the specified zone

--- a/server/channel/src/packets/game/AllocateSkillPoint.cpp
+++ b/server/channel/src/packets/game/AllocateSkillPoint.cpp
@@ -55,29 +55,29 @@ void AllocatePoint(const std::shared_ptr<ChannelServer> server,
     auto stats = character->GetCoreStats().Get();
 
     int32_t pointCost = 0;
-    switch((libcomp::CorrectData)correctStatOffset)
+    switch((CorrectTbl)correctStatOffset)
     {
-        case libcomp::CorrectData::CORRECT_STR:
+        case CorrectTbl::STR:
             pointCost = GetPointCost(stats->GetSTR());
             stats->SetSTR(static_cast<int16_t>(stats->GetSTR() + 1));
             break;
-        case libcomp::CorrectData::CORRECT_MAGIC:
+        case CorrectTbl::MAGIC:
             pointCost = GetPointCost(stats->GetMAGIC());
             stats->SetMAGIC(static_cast<int16_t>(stats->GetMAGIC() + 1));
             break;
-        case libcomp::CorrectData::CORRECT_VIT:
+        case CorrectTbl::VIT:
             pointCost = GetPointCost(stats->GetVIT());
             stats->SetVIT(static_cast<int16_t>(stats->GetVIT() + 1));
             break;
-        case libcomp::CorrectData::CORRECT_INTEL:
+        case CorrectTbl::INT:
             pointCost = GetPointCost(stats->GetINTEL());
             stats->SetINTEL(static_cast<int16_t>(stats->GetINTEL() + 1));
             break;
-        case libcomp::CorrectData::CORRECT_SPEED:
+        case CorrectTbl::SPEED:
             pointCost = GetPointCost(stats->GetSPEED());
             stats->SetSPEED(static_cast<int16_t>(stats->GetSPEED() + 1));
             break;
-        case libcomp::CorrectData::CORRECT_LUCK:
+        case CorrectTbl::LUCK:
             pointCost = GetPointCost(stats->GetLUCK());
             stats->SetLUCK(static_cast<int16_t>(stats->GetLUCK() + 1));
             break;
@@ -87,12 +87,13 @@ void AllocatePoint(const std::shared_ptr<ChannelServer> server,
 
     character->SetPoints(static_cast<int32_t>(character->GetPoints() - pointCost));
 
-    cState->RecalculateStats(server->GetDefinitionManager());
+    auto characterManager = server->GetCharacterManager();
+    characterManager->RecalculateStats(client, cState->GetEntityID(), false);
 
     libcomp::Packet reply;
     reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_ALLOCATE_SKILL_POINT);
     reply.WriteS32Little(cState->GetEntityID());
-    server->GetCharacterManager()->GetEntityStatsPacketData(reply, stats, cState, true);
+    characterManager->GetEntityStatsPacketData(reply, stats, cState, 1);
     reply.WriteS32Little(pointCost);
 
     client->SendPacket(reply);

--- a/server/channel/src/packets/game/ReviveCharacter.cpp
+++ b/server/channel/src/packets/game/ReviveCharacter.cpp
@@ -1,0 +1,198 @@
+/**
+ * @file server/channel/src/packets/game/ReviveCharacter.cpp
+ * @ingroup channel
+ *
+ * @author HACKfrost
+ *
+ * @brief Request from the client to revive the player character.
+ *
+ * This file is part of the Channel Server (channel).
+ *
+ * Copyright (C) 2012-2016 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Packets.h"
+
+// libcomp Includes
+#include <Constants.h>
+#include <Log.h>
+#include <ManagerPacket.h>
+#include <Packet.h>
+#include <PacketCodes.h>
+
+// Standard C++11 Includes
+#include <math.h>
+
+// object Includes
+#include <ItemBox.h>
+#include <ServerZone.h>
+
+// channel Includes
+#include "ChannelServer.h"
+
+using namespace channel;
+
+bool Parsers::ReviveCharacter::Parse(libcomp::ManagerPacket *pPacketManager,
+    const std::shared_ptr<libcomp::TcpConnection>& connection,
+    libcomp::ReadOnlyPacket& p) const
+{
+    (void)pPacketManager;
+
+    if(p.Size() != 8)
+    {
+        return false;
+    }
+
+    const static int8_t REVIVAL_REVIVE_DONE = -1;
+    const static int8_t REVIVAL_REVIVE_AND_WAIT = 1;    // Waits on -1
+    const static int8_t REVIVAL_REVIVE_NORMAL = 3;
+    const static int8_t REVIVAL_REVIVE_ACCEPT = 4;
+    const static int8_t REVIVAL_REVIVE_DENY = 5;
+    //const static int8_t REVIVAL_REVIVE_UNKNOWN = 7;  // Used by revival mode 596
+
+    int32_t entityID = p.ReadS32Little();
+    int32_t revivalMode = p.ReadS32Little();
+    (void)entityID;
+
+    auto client = std::dynamic_pointer_cast<ChannelClientConnection>(connection);
+    auto server = std::dynamic_pointer_cast<ChannelServer>(pPacketManager->GetServer());
+    auto characterManager = server->GetCharacterManager();
+    auto zoneManager = server->GetZoneManager();
+    auto state = client->GetClientState();
+    auto cState = state->GetCharacterState();
+    auto character = cState->GetEntity();
+    auto cs = cState->GetCoreStats();
+
+    int8_t responseType1 = -1, responseType2 = -1;
+
+    int64_t xpLoss = 0;
+    uint32_t newZoneID = 0;
+    float newX = 0.f, newY = 0.f, newRot = 0.f;
+    float hpRestore = 0;
+    bool xpLossLevel = cs->GetLevel() >= 10 && cs->GetLevel() < 99;
+    switch(revivalMode)
+    {
+    case 104:   // Home point
+        if(character->GetHomepointZone())
+        {
+            responseType1 = REVIVAL_REVIVE_AND_WAIT;
+            responseType2 = REVIVAL_REVIVE_DONE;
+            hpRestore = 1.f;
+
+            // Adjust XP
+            if(xpLossLevel)
+            {
+                xpLoss = (int64_t)floorl(
+                    (double)libcomp::LEVEL_XP_REQUIREMENTS[(size_t)cs->GetLevel()] *
+                    (double)(0.01 - (0.00005 * cs->GetLevel())) - 0.01);
+            }
+
+            // Change zone
+            newZoneID = character->GetHomepointZone();
+            newX = character->GetHomepointX();
+            newY = character->GetHomepointY();
+            newRot = 0.f;
+        }
+        break;
+    case 105:   // Dungeon entrance
+        {
+            responseType1 = REVIVAL_REVIVE_AND_WAIT;
+            responseType2 = REVIVAL_REVIVE_DONE;
+            hpRestore = 0.3f;
+
+            // Adjust XP
+            if(xpLossLevel)
+            {
+                xpLoss = (int64_t)floorl(
+                    (double)libcomp::LEVEL_XP_REQUIREMENTS[(size_t)cs->GetLevel()] *
+                    (double)(0.02 - (0.00005 * cs->GetLevel())));
+            }
+
+            // Move to entrance
+            auto zone = cState->GetZone();
+            auto zoneDef = zone->GetDefinition();
+            newZoneID = zoneDef->GetID();
+            newX = zoneDef->GetStartingX();
+            newX = zoneDef->GetStartingY();
+            newRot = zoneDef->GetStartingRotation();
+        }
+        break;
+    case 107:   // Item revival
+        {
+            /// @todo: replace hardcoded value
+            const static uint32_t itemType = 101;
+
+            auto items = characterManager->GetExistingItems(character,
+                itemType, character->GetItemBoxes(0).Get());
+
+            if(items.size() > 0)
+            {
+                characterManager->AddRemoveItem(client, itemType, 1, false);
+                responseType1 = REVIVAL_REVIVE_NORMAL;
+                hpRestore = 1.f;
+            }
+        }
+        break;
+    case 108:   // Receive revival
+        {
+            responseType1 = REVIVAL_REVIVE_ACCEPT;
+            state->SetAcceptRevival(true);
+        }
+        break;
+    case 109:   // Deny receive revival
+        {
+            responseType1 = REVIVAL_REVIVE_DENY;
+            state->SetAcceptRevival(false);
+        }
+        break;
+    case 596:   /// @todo: Special dungeon entrance revival?
+    case 665:   /// @todo: Followed by a zone change
+    default:
+        LOG_ERROR(libcomp::String("Unknown revival mode requested: %1\n")
+            .Arg(revivalMode));
+        return true;
+        break;
+    }
+
+    if(xpLoss > 0)
+    {
+        if(xpLoss > cs->GetXP())
+        {
+            xpLoss = cs->GetXP();
+        }
+
+        cs->SetXP(cs->GetXP() - xpLoss);
+    }
+
+    if(hpRestore > 0.f)
+    {
+        cState->SetHPMP((int16_t)floorl(cState->GetMaxHP() * hpRestore), -1, false);
+        state->SetAcceptRevival(false);
+    }
+
+    characterManager->SendEntityRevival(client, cState, responseType1,
+        responseType1 == REVIVAL_REVIVE_NORMAL ||
+        responseType1 == REVIVAL_REVIVE_ACCEPT ||
+        responseType1 == REVIVAL_REVIVE_DENY);
+
+    if(newZoneID)
+    {
+        zoneManager->EnterZone(client, newZoneID, newX, newY, newRot, true);
+        characterManager->SendEntityRevival(client, cState, responseType2, true);
+    }
+
+    return true;
+}

--- a/server/channel/src/packets/internal/PartyUpdate.cpp
+++ b/server/channel/src/packets/internal/PartyUpdate.cpp
@@ -125,11 +125,12 @@ void QueuePartyMemberInfo(std::shared_ptr<ChannelClientConnection> client,
         reply.WriteU16Little(member->GetMP());
         reply.WriteU16Little(member->GetMaxMP());
 
-        int8_t unknownCount = 0;
-        reply.WriteS8(unknownCount);
-        for(int8_t i = 0; i < unknownCount; i++)
+        // Seemingly unused, maybe this was previously status effects?
+        int8_t unusedCount = 0;
+        reply.WriteS8(unusedCount);
+        for(int8_t i = 0; i < unusedCount; i++)
         {
-            reply.WriteS32Little(0);    // Unknown
+            reply.WriteS32Little(0);
         }
 
         reply.WriteS32Little(localDemonEntityID);

--- a/server/channel/src/packets/internal/SetWorldInfo.cpp
+++ b/server/channel/src/packets/internal/SetWorldInfo.cpp
@@ -149,9 +149,9 @@ bool SetWorldInfoFromPacket(libcomp::ManagerPacket *pPacketManager,
     // to start the main loop in addition to any recurring scheduled work
     server->Tick();
 
-    if(conf->GetTimeoutEnabled())
+    if(conf->GetTimeout() > 0)
     {
-        server->GetManagerConnection()->ScheduleClientTimeoutHandler();
+        server->GetManagerConnection()->ScheduleClientTimeoutHandler(conf->GetTimeout());
     }
 
     return true;


### PR DESCRIPTION
Includes new GMands:
@effect: Add a status effect and stack size to either the character or partner demon
@kill: Kills the player character or another character in the same zone by name for use in testing revival

ActiveEntityState has been changed quite a bit to support status effects.  This change also involved a large amount of binary data analysis which resulted in some skill manager changes as well that will be useful later.  I also found a caching issue with collections of persistent references being set while loading the parent object from the DB.

Fixes #215 
Fixes #216