### PR TITLE
Remaining functional parts of search lists and several bug fixes

### DIFF
--- a/libcomp/schema/item.xml
+++ b/libcomp/schema/item.xml
@@ -2,7 +2,7 @@
 <objgen>
     <object name="Item" location="world" scriptenabled="true">
         <member type="u32" name="Type"/>
-        <member type="ItemBox*" name="ItemBox"/>
+        <member type="ItemBox*" name="ItemBox" key="true" unique="false"/>
         <member type="s8" name="BoxSlot" default="-1"/>
         <member type="u16" name="StackSize" default="1"/>
         <member type="u16" name="Durability"/>

--- a/libcomp/src/Constants.h
+++ b/libcomp/src/Constants.h
@@ -139,6 +139,11 @@ namespace libcomp
 /// ID of the "Gun knowledge" expertise.
 #define EXPERTISE_GUN_KNOWLEDGE (34)
 
+/// Default movement speed (as binary data representation) to check
+/// against any player entity to signify if a differing speed needs
+/// to be communicated to the client.
+#define STAT_DEFAULT_SPEED (30)
+
 /// Time until the client is expected to timeout and disconnect (in seconds).
 #define TIMEOUT_CLIENT (15)
 
@@ -228,30 +233,6 @@ namespace libcomp
 /// Maximum cost number representation value.
 #define COST_NUMREP_MAX     (2)
 
-/// Client has not attempted to login yet.
-#define LOGIN_STATE_WAIT (0)
-
-/// Client has sent a valid account name.
-#define LOGIN_STATE_VALID_ACCT (1)
-
-/// Client has authenticated.
-#define LOGIN_STATE_AUTHENTICATED (2)
-
-/// Client has sent a P0004_sendData packet.
-#define LOGIN_STATE_GOT_SEND_DATA (3)
-
-/// Character data has been loaded by the database thread.
-#define LOGIN_STATE_HAVE_PCDATA (4)
-
-/// Client sent a P0004_sendData packet and the character data has been loaded.
-#define LOGIN_STATE_PENDING_REPLY (5)
-
-/// Client has been notified of a successful login.
-#define LOGIN_STATE_LOGGED_IN (6)
-
-/// Client is attempting to log out.
-#define LOGIN_STATE_PENDING_LOGOUT (7)
-
 /// Macca note value
 #define ITEM_MACCA_NOTE_AMOUNT (50000)
 
@@ -321,8 +302,23 @@ namespace libcomp
 /// Search data index for an item's durability
 #define SEARCH_IDX_DURABILITY (15)
 
+/// Search data index for an item's max durability
+#define SEARCH_IDX_MAX_DURABILITY (16)
+
 /// Search data index for an item's slot count
-#define SEARCH_IDX_SLOT_COUNT (16)
+#define SEARCH_IDX_SLOT_COUNT (17)
+
+/// Search data index for an item's tarot effect
+#define SEARCH_IDX_TAROT (18)
+
+/// Search data index for an item's soul effect
+#define SEARCH_IDX_SOUL (19)
+
+/// Search data index for an item's basic effect
+#define SEARCH_IDX_BASIC_EFFECT (20)
+
+/// Search data index for an item's special effect
+#define SEARCH_IDX_SPECIAL_EFFECT (21)
 
 /// Search data index for the first item mod slot
 #define SEARCH_BASE_MOD_SLOT (100)

--- a/libcomp/src/DataSyncManager.cpp
+++ b/libcomp/src/DataSyncManager.cpp
@@ -226,8 +226,9 @@ bool DataSyncManager::SyncIncoming(libcomp::ReadOnlyPacket& p,
     {
         for(auto obj : records)
         {
-            if(configIter->second->UpdateHandler(*this, lType,
-                obj, false, source))
+            int8_t result = configIter->second->UpdateHandler(*this, lType,
+                obj, false, source);
+            if(result == SYNC_UPDATED)
             {
                 if(configIter->second->ServerOwned)
                 {

--- a/server/channel/src/CharacterManager.h
+++ b/server/channel/src/CharacterManager.h
@@ -190,6 +190,20 @@ public:
         channel::ChannelClientConnection>& client, int8_t icon = 0);
 
     /**
+     * Sends the specified entity's non-battle movement speed to the client
+     * @param client Pointer to the client connection
+     * @param eState Pointer to the entity
+     * @param diffOnly true if the packet should only be sent if the speed
+     *  is not equal to the entity's normal speed
+     * @param queue true if the packet should be queued, false if it
+     *  should be sent right away
+     */
+    void SendMovementSpeed(const std::shared_ptr<
+        channel::ChannelClientConnection>& client,
+        const std::shared_ptr<ActiveEntityState>& eState, bool diffOnly,
+        bool queue = false);
+
+    /**
      * Summon the demon matching the supplied ID on the client's character.
      * @param client Pointer to the client connection containing
      *  the character

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -60,7 +60,7 @@ ClientState::~ClientState()
 {
     auto cEntityID = mCharacterState->GetEntityID();
     auto dEntityID = mDemonState->GetEntityID();
-    auto worldCID = GetAccountLogin()->GetCharacterLogin()->GetWorldCID();
+    auto worldCID = GetWorldCID();
     if(cEntityID != 0 || dEntityID != 0)
     {
         std::lock_guard<std::mutex> lock(sLock);
@@ -221,14 +221,13 @@ bool ClientState::SetObjectID(const libobjgen::UUID& uuid, int64_t objectID)
 
 const libobjgen::UUID ClientState::GetAccountUID() const
 {
-    return mCharacterState->Ready() ?
-        mCharacterState->GetEntity()->GetAccount().GetUUID() : NULLUUID;
+    return GetAccountLogin()->GetAccount().GetUUID();
 }
 
 int32_t ClientState::GetUserLevel() const
 {
-    return mCharacterState->Ready() ?
-        mCharacterState->GetEntity()->GetAccount()->GetUserLevel() : 0;
+    auto account = GetAccountLogin()->GetAccount();
+    return !account.IsNull() ? account->GetUserLevel() : 0;
 }
 
 int32_t ClientState::GetWorldCID() const
@@ -259,7 +258,7 @@ std::shared_ptr<objects::PartyCharacter> ClientState::GetPartyCharacter(
     auto cStats = character->GetCoreStats();
 
     auto member = std::make_shared<objects::PartyCharacter>();
-    member->SetWorldCID(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    member->SetWorldCID(GetWorldCID());
     member->SetName(character->GetName());
     member->SetLevel((uint8_t)cStats->GetLevel());
     member->SetHP((uint16_t)cStats->GetHP());
@@ -298,7 +297,7 @@ std::shared_ptr<objects::PartyMember> ClientState::GetPartyDemon() const
 void ClientState::GetPartyCharacterPacket(libcomp::Packet& p) const
 {
     p.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
-    p.WriteS32Little(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    p.WriteS32Little(GetWorldCID());
     p.WriteU8((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_INFO);
     GetPartyCharacter(false)->SavePacket(p, true);
 }
@@ -306,7 +305,7 @@ void ClientState::GetPartyCharacterPacket(libcomp::Packet& p) const
 void ClientState::GetPartyDemonPacket(libcomp::Packet& p) const
 {
     p.WritePacketCode(InternalPacketCode_t::PACKET_CHARACTER_LOGIN);
-    p.WriteS32Little(GetAccountLogin()->GetCharacterLogin()->GetWorldCID());
+    p.WriteS32Little(GetWorldCID());
     p.WriteU8((uint8_t)CharacterLoginStateFlag_t::CHARLOGIN_PARTY_DEMON_INFO);
     GetPartyDemon()->SavePacket(p, true);
 }

--- a/server/channel/src/FusionManager.cpp
+++ b/server/channel/src/FusionManager.cpp
@@ -1398,7 +1398,8 @@ int8_t FusionManager::ProcessFusion(
                 auto dState = dClient->GetClientState()->GetDemonState();
                 if(dState->GetEntity() == demon)
                 {
-                    characterManager->StoreDemon(dClient, true, 12);
+                    characterManager->StoreDemon(dClient, true,
+                        demonID3 > 0 ? 16 : 12);
                 }
             }
         }

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -346,6 +346,19 @@ private:
         const std::shared_ptr<Zone>& zone);
 
     /**
+     * Handle all logic related to defeating an enemy encounter through combat
+     * or talk skill outcome. Enemy despawn does not count as a defeat and should
+     * be handled separately. If the encounter is not actually defeated, nothing
+     * will be done.
+     * @param source Pointer to the source of the skill
+     * @param zone Pointer to the zone where the skill was executed
+     * @param encounterGroups Map of encounter IDs to spawn group ID
+     */
+    void HandleEncounterDefeat(const std::shared_ptr<ActiveEntityState> source,
+        const std::shared_ptr<Zone>& zone,
+        const std::unordered_map<uint32_t, uint32_t>& encounterGroups);
+
+    /**
      * Handle the outcome of a negotation ending from a skill's execution
      * including things like creating demon eggs and gift boxes or running away.
      * @param source Pointer to the source of the skill

--- a/server/channel/src/Zone.cpp
+++ b/server/channel/src/Zone.cpp
@@ -973,16 +973,16 @@ bool Zone::TimeRestrictionActive(const WorldClock& clock,
         uint16_t dateSum = (uint16_t)(clock.Month * 100 + clock.Day);
         for(auto pair : restriction->GetDateRestriction())
         {
-            if(pair.first > pair.second)
+            if(pair.first < pair.second)
             {
                 // Normal compare
-                dateActive = pair.first >= dateSum &&
+                dateActive = pair.first <= dateSum &&
                     dateSum <= pair.second;
             }
             else
             {
                 // Rollover compare
-                dateActive = pair.first >= dateSum ||
+                dateActive = pair.first <= dateSum ||
                     dateSum <= pair.second;
             }
 
@@ -1010,16 +1010,16 @@ bool Zone::TimeRestrictionActive(const WorldClock& clock,
         uint16_t timeSum = (uint16_t)(clock.SystemHour * 100 + clock.SystemMin);
         for(auto pair : restriction->GetSystemTimeRestriction())
         {
-            if(pair.first > pair.second)
+            if(pair.first < pair.second)
             {
                 // Normal compare
-                timeActive = pair.first >= timeSum &&
+                timeActive = pair.first <= timeSum &&
                     timeSum <= pair.second;
             }
             else
             {
                 // Rollover compare
-                timeActive = pair.first >= timeSum ||
+                timeActive = pair.first <= timeSum ||
                     timeSum <= pair.second;
             }
 
@@ -1048,16 +1048,16 @@ bool Zone::TimeRestrictionActive(const WorldClock& clock,
         uint16_t timeSum = (uint16_t)(clock.Hour * 100 + clock.Min);
         for(auto pair : restriction->GetTimeRestriction())
         {
-            if(pair.first > pair.second)
+            if(pair.first < pair.second)
             {
                 // Normal compare
-                timeActive = pair.first >= timeSum &&
+                timeActive = pair.first <= timeSum &&
                     timeSum <= pair.second;
             }
             else
             {
                 // Rollover compare
-                timeActive = pair.first >= timeSum ||
+                timeActive = pair.first <= timeSum ||
                     timeSum <= pair.second;
             }
 

--- a/server/channel/src/ZoneManager.cpp
+++ b/server/channel/src/ZoneManager.cpp
@@ -769,6 +769,7 @@ void ZoneManager::SendPopulateZoneData(const std::shared_ptr<ChannelClientConnec
 
     PopEntityForZoneProduction(zone, cState->GetEntityID(), 0);
     ShowEntityToZone(zone, cState->GetEntityID());
+    characterManager->SendMovementSpeed(client, cState, true);
 
     // Activate status effects
     cState->SetStatusEffectsActive(true, definitionManager);

--- a/server/channel/src/packets/game/ClanForm.cpp
+++ b/server/channel/src/packets/game/ClanForm.cpp
@@ -98,16 +98,13 @@ bool Parsers::ClanForm::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             auto item = std::dynamic_pointer_cast<objects::Item>(
                 libcomp::PersistentObject::GetObjectByUUID(
-                state->GetObjectUUID(activatedAbility->GetTargetObjectID())));
+                state->GetObjectUUID(activatedAbility->GetActivationObjectID())));
 
             uint32_t itemID = item ? item->GetType() : 0;
             auto baseZoneIter = SVR_CONST.CLAN_FORM_MAP.find(itemID);
 
             if(baseZoneIter != SVR_CONST.CLAN_FORM_MAP.end())
             {
-                server->GetSkillManager()->ExecuteSkill(sourceState, activationID,
-                    activatedAbility->GetTargetObjectID());
-
                 libcomp::Packet request;
                 request.WritePacketCode(InternalPacketCode_t::PACKET_CLAN_UPDATE);
                 request.WriteU8((uint8_t)InternalPacketAction_t::PACKET_ACTION_ADD);

--- a/server/channel/src/packets/game/FixObjectPosition.cpp
+++ b/server/channel/src/packets/game/FixObjectPosition.cpp
@@ -94,11 +94,12 @@ bool Parsers::FixObjectPosition::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         // If a demon is being placed, it will have already been described to the
         // the client by this point so create and show it now.
-        auto zone = zoneManager->GetCurrentZone(client);
+        auto zone = dState->GetZone();
         if(zone)
         {
             zoneManager->PopEntityForZoneProduction(zone, dState->GetEntityID(), 2);
             zoneManager->ShowEntityToZone(zone, dState->GetEntityID());
+            server->GetCharacterManager()->SendMovementSpeed(client, dState, true);
         }
     }
 

--- a/server/channel/src/packets/game/ItemPrice.cpp
+++ b/server/channel/src/packets/game/ItemPrice.cpp
@@ -47,8 +47,6 @@ bool Parsers::ItemPrice::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    LOG_WARNING("In ItemPrice\n");
-
     if(p.Size() != 42)
     {
         return false;

--- a/server/channel/src/packets/game/PlasmaEnd.cpp
+++ b/server/channel/src/packets/game/PlasmaEnd.cpp
@@ -43,9 +43,6 @@ bool Parsers::PlasmaEnd::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-
-    LOG_WARNING("In PlasmaEnd\n");
-
     if(p.Size() != 5)
     {
         return false;

--- a/server/channel/src/packets/game/SearchEntryData.cpp
+++ b/server/channel/src/packets/game/SearchEntryData.cpp
@@ -223,10 +223,10 @@ bool Parsers::SearchEntryData::Parse(libcomp::ManagerPacket *pPacketManager,
 
                 reply.WriteS32Little((int32_t)entry->GetPostTime());
 
-                reply.WriteS16Little(0);    // Tarot?
-                reply.WriteS16Little(0);    // Soul?
-                reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_DURABILITY));
-                reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_DURABILITY) * 1000));
+                reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_TAROT)));
+                reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_SOUL)));
+                reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_MAX_DURABILITY));
+                reply.WriteS16Little((int16_t)entry->GetData(SEARCH_IDX_DURABILITY));
                 reply.WriteS32Little(entry->GetData(SEARCH_IDX_PRICE));
                 reply.WriteS16Little(0);    // Unknown
 
@@ -236,8 +236,8 @@ bool Parsers::SearchEntryData::Parse(libcomp::ManagerPacket *pPacketManager,
                 reply.WriteS16Little((int16_t)entry->GetData(SEARCH_BASE_MOD_SLOT + 3));
                 reply.WriteS16Little((int16_t)entry->GetData(SEARCH_BASE_MOD_SLOT + 4));
 
-                reply.WriteS32Little(-1);   // Unknown
-                reply.WriteS32Little(-1);   // Unknown
+                reply.WriteS32Little(entry->GetData(SEARCH_IDX_BASIC_EFFECT));
+                reply.WriteS32Little(entry->GetData(SEARCH_IDX_SPECIAL_EFFECT));
             }
             break;
         case objects::SearchEntry::Type_t::TRADE_BUYING:

--- a/server/channel/src/packets/game/SearchEntryRegister.cpp
+++ b/server/channel/src/packets/game/SearchEntryRegister.cpp
@@ -266,10 +266,10 @@ bool Parsers::SearchEntryRegister::Parse(libcomp::ManagerPacket *pPacketManager,
             {
                 int8_t unknown1 = p.ReadS8();
                 int8_t subCategory = p.ReadS8();
-                int16_t unknown2 = p.ReadS16Little();
-                int16_t unknown3 = p.ReadS16Little();
+                int16_t tarot = p.ReadS16Little();
+                int16_t soul = p.ReadS16Little();
                 int32_t itemType = p.ReadS32Little();
-                int8_t durability = p.ReadS8();
+                int8_t maxDurability = p.ReadS8();
                 int32_t price = p.ReadS32Little();
                 int32_t unknown4 = p.ReadS32Little();
                 int32_t location = p.ReadS32Little();
@@ -282,7 +282,7 @@ bool Parsers::SearchEntryRegister::Parse(libcomp::ManagerPacket *pPacketManager,
                 libcomp::String comment = p.ReadString16Little(
                     libcomp::Convert::Encoding_t::ENCODING_CP932, true);
 
-                int16_t unknown5 = p.ReadS16Little();
+                int16_t durability = p.ReadS16Little();
 
                 uint16_t modSlots[5];
                 modSlots[0] = p.ReadU16Little();
@@ -292,16 +292,11 @@ bool Parsers::SearchEntryRegister::Parse(libcomp::ManagerPacket *pPacketManager,
                 modSlots[4] = p.ReadU16Little();
 
                 int8_t mainCategory = p.ReadS8();
-                int32_t unknown6 = p.ReadS32Little();
-                int32_t unknown7 = p.ReadS32Little();
+                int32_t basicEffect = p.ReadS32Little();
+                int32_t specialEffect = p.ReadS32Little();
 
                 (void)unknown1;
-                (void)unknown2;
-                (void)unknown3;
                 (void)unknown4;
-                (void)unknown5;
-                (void)unknown6;
-                (void)unknown7;
 
                 entry->SetData(SEARCH_IDX_ITEM_TYPE, itemType);
                 entry->SetData(SEARCH_IDX_MAIN_CATEGORY, mainCategory);
@@ -309,11 +304,18 @@ bool Parsers::SearchEntryRegister::Parse(libcomp::ManagerPacket *pPacketManager,
                 entry->SetData(SEARCH_IDX_PRICE, price);
                 entry->SetData(SEARCH_IDX_LOCATION, location);
                 entry->SetData(SEARCH_IDX_DURABILITY, durability);
+                entry->SetData(SEARCH_IDX_MAX_DURABILITY, maxDurability);
+                entry->SetData(SEARCH_IDX_TAROT, tarot);
+                entry->SetData(SEARCH_IDX_SOUL, soul);
                 entry->SetData(SEARCH_BASE_MOD_SLOT, (int32_t)modSlots[0]);
                 entry->SetData(SEARCH_BASE_MOD_SLOT + 1, (int32_t)modSlots[1]);
                 entry->SetData(SEARCH_BASE_MOD_SLOT + 2, (int32_t)modSlots[2]);
                 entry->SetData(SEARCH_BASE_MOD_SLOT + 3, (int32_t)modSlots[3]);
                 entry->SetData(SEARCH_BASE_MOD_SLOT + 4, (int32_t)modSlots[4]);
+                entry->SetData(SEARCH_IDX_BASIC_EFFECT,
+                    basicEffect > 0 ? basicEffect : -1);
+                entry->SetData(SEARCH_IDX_SPECIAL_EFFECT,
+                    specialEffect > 0 ? specialEffect : -1);
                 entry->SetTextData(SEARCH_IDX_COMMENT, comment);
 
                 success = true;

--- a/server/channel/src/packets/game/SearchEntrySelf.cpp
+++ b/server/channel/src/packets/game/SearchEntrySelf.cpp
@@ -155,11 +155,11 @@ bool Parsers::SearchEntrySelf::Parse(libcomp::ManagerPacket *pPacketManager,
             reply.WriteS8(0);   // Unknown
             reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_SUB_CATEGORY));
 
-            reply.WriteS16Little(0);   // Unknown
-            reply.WriteS16Little(0);   // Unknown
+            reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_TAROT)));
+            reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_SOUL)));
 
             reply.WriteS32Little(entry->GetData(SEARCH_IDX_ITEM_TYPE));
-            reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_DURABILITY));
+            reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_MAX_DURABILITY));
             reply.WriteS32Little(entry->GetData(SEARCH_IDX_PRICE));
             reply.WriteS32Little(0);    // Unknown
             reply.WriteS32Little(entry->GetData(SEARCH_IDX_LOCATION));
@@ -167,7 +167,7 @@ bool Parsers::SearchEntrySelf::Parse(libcomp::ManagerPacket *pPacketManager,
             reply.WriteString16Little(libcomp::Convert::ENCODING_CP932,
                 entry->GetTextData(SEARCH_IDX_COMMENT), true);
 
-            reply.WriteS16Little((int16_t)(entry->GetData(SEARCH_IDX_DURABILITY) * 1000));
+            reply.WriteS16Little((int16_t)entry->GetData(SEARCH_IDX_DURABILITY));
 
             reply.WriteS16Little((int16_t)entry->GetData(SEARCH_BASE_MOD_SLOT));
             reply.WriteS16Little((int16_t)entry->GetData(SEARCH_BASE_MOD_SLOT + 1));
@@ -178,8 +178,8 @@ bool Parsers::SearchEntrySelf::Parse(libcomp::ManagerPacket *pPacketManager,
             reply.WriteS32Little((int32_t)entry->GetPostTime());
             reply.WriteS8((int8_t)entry->GetData(SEARCH_IDX_MAIN_CATEGORY));
 
-            reply.WriteS32Little(-1);    // Unknown
-            reply.WriteS32Little(-1);    // Unknown
+            reply.WriteS32Little(entry->GetData(SEARCH_IDX_BASIC_EFFECT));
+            reply.WriteS32Little(entry->GetData(SEARCH_IDX_SPECIAL_EFFECT));
         }
         break;
     case objects::SearchEntry::Type_t::TRADE_BUYING:

--- a/server/channel/src/packets/game/TriFusionJoin.cpp
+++ b/server/channel/src/packets/game/TriFusionJoin.cpp
@@ -115,7 +115,7 @@ bool Parsers::TriFusionJoin::Parse(libcomp::ManagerPacket *pPacketManager,
             std::list<std::shared_ptr<objects::Demon>> demons;
             for(auto d : pCState->GetEntity()->GetCOMP()->GetDemons())
             {
-                if(!d.IsNull())
+                if(!d.IsNull() && !d->GetLocked())
                 {
                     demons.push_back(d.Get());
                 }

--- a/server/channel/src/packets/game/Warp.cpp
+++ b/server/channel/src/packets/game/Warp.cpp
@@ -84,7 +84,7 @@ bool Parsers::Warp::Parse(libcomp::ManagerPacket *pPacketManager,
     {
         auto item = std::dynamic_pointer_cast<objects::Item>(
             libcomp::PersistentObject::GetObjectByUUID(
-            state->GetObjectUUID(activatedAbility->GetTargetObjectID())));
+            state->GetObjectUUID(activatedAbility->GetActivationObjectID())));
 
         auto warpDef = definitionManager->GetWarpPointData(warpPointID);
         auto skillData = definitionManager->GetSkillData(activatedAbility->GetSkillID());
@@ -97,7 +97,7 @@ bool Parsers::Warp::Parse(libcomp::ManagerPacket *pPacketManager,
             float rot = warpDef->GetRotation();
 
             skillManager->ExecuteSkill(sourceState, activationID,
-                activatedAbility->GetTargetObjectID());
+                activatedAbility->GetActivationObjectID());
 
             // Some of the warp items without expirations need to be consumed
             // but are not skill costs

--- a/server/channel/src/packets/internal/ClanUpdate.cpp
+++ b/server/channel/src/packets/internal/ClanUpdate.cpp
@@ -112,16 +112,16 @@ bool Parsers::ClanUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
                     // Remove the item if its still there (too late if its not :P)
                     auto item = std::dynamic_pointer_cast<objects::Item>(
                         libcomp::PersistentObject::GetObjectByUUID(
-                        state->GetObjectUUID(activatedAbility->GetTargetObjectID())));
+                        state->GetObjectUUID(activatedAbility->GetActivationObjectID())));
 
                     std::unordered_map<uint32_t, uint32_t> itemMap;
                     itemMap[item ? item->GetType() : 0] = 1;
 
                     server->GetCharacterManager()->AddRemoveItems(client, itemMap, false,
-                        activatedAbility->GetTargetObjectID());
+                        activatedAbility->GetActivationObjectID());
 
                     server->GetSkillManager()->ExecuteSkill(cState,
-                        activationID, activatedAbility->GetTargetObjectID());
+                        activationID, activatedAbility->GetActivationObjectID());
                 }
                 else
                 {

--- a/server/world/src/AccountManager.cpp
+++ b/server/world/src/AccountManager.cpp
@@ -241,8 +241,10 @@ std::shared_ptr<objects::AccountLogin> AccountManager::LogoutUser(
         {
             auto server = mServer.lock();
             auto characterManager = server->GetCharacterManager();
+            auto syncManager = server->GetWorldSyncManager();
 
             characterManager->PartyLeave(cLogin, nullptr, true);
+            syncManager->CleanUpCharacterLogin(cLogin->GetWorldCID());
 
             // Notify existing players
             std::list<std::shared_ptr<objects::CharacterLogin>> cLogOuts;

--- a/server/world/src/WorldSyncManager.h
+++ b/server/world/src/WorldSyncManager.h
@@ -82,6 +82,14 @@ public:
         const libcomp::String& type);
 
     /**
+     * Expire the existing record with a matching entry ID and expiration time
+     * of the templated type. If either does not match, nothing will be expired.
+     * @param entryID Entry ID of the record
+     * @param expirationTime Expiration time of the record
+     */
+    template<class T> void Expire(int32_t entryID, uint32_t expirationTime);
+
+    /**
      * Perform cleanup operations based upon a character logging off (or
      * logging on) based upon world level data being synchronized.
      * @param worldCID CID of the character logging off


### PR DESCRIPTION
Fixes #354 
Fixes #355 
Fixes #356 
Fixes #419 
Fixes #420 
Fixes #421 
Fixes #422 

Includes improvements to the login process for characters with more logging, proper failure cleanup and the ability to recover from certain corrupt states.

Also fixes untracked bugs:
-TriFusion with locked demon
-Summoning demon that has leveled past character
-Demon movement speed weirdness after re-log
-Demon skill learning de-pop (should have been inherited skills all along)
-Timespan spawn issues
as well as some issues found during regression testing.