### PR TITLE
Exploit guardrails, skill/status adjustments and bug fixes

### DIFF
--- a/contrib/testing/constants.xml
+++ b/contrib/testing/constants.xml
@@ -95,6 +95,7 @@
 
     <constant name="STATUS_BIKE">807</constant>
     <constant name="STATUS_CLOAK">903</constant>
+    <constant name="STATUS_COMP_TUNING">816,817</constant>
     <constant name="STATUS_DEATH">32</constant>
     <constant name="STATUS_DEMON_QUEST_ACTIVE">1030</constant>
     <constant name="STATUS_HIDDEN">143</constant>

--- a/docs/guide/setup/config/channel.xml
+++ b/docs/guide/setup/config/channel.xml
@@ -85,6 +85,19 @@
 </section><!-- SystemMessage -->
 
 <section>
+<title>SystemMessageColor</title>
+<para><emphasis role="strong">Type:</emphasis> enum</para>
+<para><emphasis role="strong">Default:</emphasis> <emphasis>BLUE</emphasis></para>
+<para>System ticker message color to use when displaying the configured SystemMessage. Valid options are RED, WHITE, BLUE and PURPLE.</para>
+
+<section>
+<title>Example</title>
+<para><![CDATA[<member name="SystemMessageColor">RED</member>]]></para>
+</section><!-- Example -->
+
+</section><!-- SystemMessageColor -->
+
+<section>
 <title>AutoCompressCurrency</title>
 <para><emphasis role="strong">Type:</emphasis> boolean</para>
 <para><emphasis role="strong">Default:</emphasis> false</para>

--- a/libcomp/src/PacketCodes.h
+++ b/libcomp/src/PacketCodes.h
@@ -352,6 +352,7 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_STOP_MOVEMENT = 0x0070,  //!< Message containing entity or object movement stopping information.
     PACKET_WORLD_TIME = 0x0073,  //!< Response for the server's current world time.
     PACKET_ITEM_BOX = 0x0075,  //!< Response for info about a specific item box.
+    PACKET_ERROR_ITEM = 0x0079, //!< Notification that an item request packet has failed. Causes an item box refresh.
     PACKET_ITEM_UPDATE = 0x007A,  //!< Message containing updated information about an item in a box.
     PACKET_EQUIPMENT_LIST = 0x007C,  //!< Response for equipment information.
     PACKET_TRADE_REQUEST = 0x007E,  //!< Response for starting a trade with another player.
@@ -371,6 +372,7 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_SHOP_BUY = 0x0095,  //!< Response to the request to buy an item from a shop.
     PACKET_SHOP_SELL = 0x0097,  //!< Response to the request to sell an item to a shop.
     PACKET_DEMON_BOX_UPDATE = 0x0098,  //!< Message containing information that one or more demon box has been updated.
+    PACKET_ERROR_COMP = 0x0099, //!< Notification that a demon box request packet has failed. Causes a demon box refresh.
     PACKET_POST_LIST = 0x009D, //!< Response to the request to list items in the player account's Post.
     PACKET_POST_ITEM = 0x009F, //!< Response to the request to move an item from the Post into the current character's inventory.
     PACKET_POST_GIFT = 0x00A1,  //!< Response to the request to open/retrieve post gift information.
@@ -409,6 +411,7 @@ enum class ChannelToClientPacketCode_t : uint16_t
     PACKET_PARTY_MEMBER_ICON = 0x00EA,  //!< Notification that a current party member's icon state has changed.
     PACKET_DEMON_FUSION = 0x00F0,  //!< Response containing the results of a two-way fusion.
     PACKET_LOOT_DEMON_EGG_DATA = 0x00F2,    //!< Response to the request for information about the demon in a demon egg.
+    PACKET_ERROR_FRIEND = 0x00F5,   //!< Notification that a friend request packet has failed.
     PACKET_SHOP_REPAIR = 0x00F7,    //!< Response to the request to repair an item at a shop.
     PACKET_PARTY_KICK = 0x00EC,  //!< Notification that a player has been kicked from the current party.
     PACKET_SYNC = 0x00F4,  //!< Response containing the server time.

--- a/libcomp/src/ServerConstants.cpp
+++ b/libcomp/src/ServerConstants.cpp
@@ -306,6 +306,8 @@ bool ServerConstants::Initialize(const String& filePath)
         sConstants.ZONE_DEFAULT);
 
     String listStr;
+    success &= LoadString(constants["STATUS_COMP_TUNING"], listStr) &&
+        ToIntegerSet(sConstants.STATUS_COMP_TUNING, listStr.Split(","));
     success &= LoadString(constants["SKILL_TRAESTO_ARCADIA"], listStr) &&
         ToIntegerArray(sConstants.SKILL_TRAESTO_ARCADIA, listStr.Split(","));
     success &= LoadString(constants["SKILL_TRAESTO_DSHINJUKU"], listStr) &&
@@ -317,24 +319,35 @@ bool ServerConstants::Initialize(const String& filePath)
     success &= LoadString(constants["SKILL_TRAESTO_SOUHONZAN"], listStr) &&
         ToIntegerArray(sConstants.SKILL_TRAESTO_SOUHONZAN, listStr.Split(","));
 
+    if(!success)
+    {
+        LOG_ERROR("Failed to load one or more primitive constant values\n");
+        return false;
+    }
+
     auto complexIter = complexConstants.find("CAMEO_MAP");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load CAMEO_MAP\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint16_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load CAMEO_MAP key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.CAMEO_MAP.find(key) !=
                 sConstants.CAMEO_MAP.end())
             {
                 LOG_ERROR("Duplicate CAMEO_MAP key encountered\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -349,44 +362,43 @@ bool ServerConstants::Initialize(const String& filePath)
                     if(!success)
                     {
                         LOG_ERROR("Failed to load an element in CAMEO_MAP\n");
-                        break;
+                        return false;
                     }
                 }
-            }
-
-            if(!success)
-            {
-                break;
             }
         }
     }
     else
     {
         LOG_ERROR("CAMEO_MAP not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("CLAN_FORM_MAP");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map) &&
-            LoadIntegerMap(map, sConstants.CLAN_FORM_MAP);
+        if(!LoadKeyValueStrings(complexIter->second, map) ||
+            !LoadIntegerMap(map, sConstants.CLAN_FORM_MAP))
+        {
+            LOG_ERROR("Failed to load CLAN_FORM_MAP\n");
+            return false;
+        }
     }
     else
     {
         LOG_ERROR("CLAN_FORM_MAP not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("CLAN_LEVEL_SKILLS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load CLAN_LEVEL_SKILLS\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -394,7 +406,7 @@ bool ServerConstants::Initialize(const String& filePath)
             {
                 LOG_ERROR("CLAN_LEVEL_SKILLS must specify skills for all"
                     " 10 levels\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -413,7 +425,7 @@ bool ServerConstants::Initialize(const String& filePath)
                         {
                             LOG_ERROR("Failed to load an element in"
                                 " CLAN_LEVEL_SKILLS\n");
-                            break;
+                            return false;
                         }
                     }
 
@@ -425,27 +437,32 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("CLAN_LEVEL_SKILLS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEMON_BOOK_BONUS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load DEMON_BOOK_BONUS\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint16_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load DEMON_BOOK_BONUS key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.DEMON_BOOK_BONUS.find(key) !=
                 sConstants.DEMON_BOOK_BONUS.end())
             {
                 LOG_ERROR("Duplicate DEMON_BOOK_BONUS key encountered\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -461,41 +478,41 @@ bool ServerConstants::Initialize(const String& filePath)
                     {
                         LOG_ERROR("Failed to load an element in"
                             " DEMON_BOOK_BONUS\n");
-                        break;
+                        return false;
                     }
                 }
-            }
-
-            if(!success)
-            {
-                break;
             }
         }
     }
     else
     {
         LOG_ERROR("DEMON_BOOK_BONUS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEMON_CRYSTALS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load DEMON_CRYSTALS\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint32_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load DEMON_CRYSTALS key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.DEMON_CRYSTALS.find(key) !=
                 sConstants.DEMON_CRYSTALS.end())
             {
                 LOG_ERROR("Duplicate DEMON_CRYSTALS key encountered\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -511,31 +528,26 @@ bool ServerConstants::Initialize(const String& filePath)
                     {
                         LOG_ERROR("Failed to load an element in"
                             " DEMON_CRYSTALS\n");
-                        break;
+                        return false;
                     }
                 }
-            }
-
-            if(!success)
-            {
-                break;
             }
         }
     }
     else
     {
         LOG_ERROR("DEMON_CRYSTALS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEMON_FUSION_SKILLS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load DEMON_FUSION_SKILLS\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -543,7 +555,7 @@ bool ServerConstants::Initialize(const String& filePath)
             {
                 LOG_ERROR("DEMON_FUSION_SKILLS must specify all 21"
                     " inheritance type skill mappings\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -555,8 +567,7 @@ bool ServerConstants::Initialize(const String& filePath)
                     {
                         LOG_ERROR("DEMON_FUSION_SKILLS element encountered"
                             " with level count other than 3\n");
-                        success = false;
-                        break;
+                        return false;
                     }
 
                     size_t subIdx = 0;
@@ -573,17 +584,17 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("DEMON_FUSION_SKILLS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEMON_QUEST_XP");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load DEMON_QUEST_XP\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -598,8 +609,7 @@ bool ServerConstants::Initialize(const String& filePath)
                 {
                     LOG_ERROR("Failed to load an entry in"
                         " DEMON_QUEST_XP\n");
-                    success = false;
-                    break;
+                    return false;
                 }
             }
         }
@@ -607,143 +617,161 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("DEMON_QUEST_XP not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEPO_MAP_DEMON");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map) &&
-            LoadIntegerMap(map, sConstants.DEPO_MAP_DEMON);
+        if(!LoadKeyValueStrings(complexIter->second, map) ||
+            !LoadIntegerMap(map, sConstants.DEPO_MAP_DEMON))
+        {
+            LOG_ERROR("Failed to load DEPO_MAP_DEMON\n");
+            return false;
+        }
     }
     else
     {
         LOG_ERROR("DEPO_MAP_DEMON not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("DEPO_MAP_ITEM");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map) &&
-            LoadIntegerMap(map, sConstants.DEPO_MAP_ITEM);
+        if(!LoadKeyValueStrings(complexIter->second, map) ||
+            !LoadIntegerMap(map, sConstants.DEPO_MAP_ITEM))
+        {
+            LOG_ERROR("Failed to load DEPO_MAP_ITEM\n");
+            return false;
+        }
     }
     else
     {
         LOG_ERROR("DEPO_MAP_ITEM not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("EQUIP_MOD_EDIT_ITEMS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load EQUIP_MOD_EDIT_ITEMS\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint32_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load EQUIP_MOD_EDIT_ITEMS key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.EQUIP_MOD_EDIT_ITEMS.find(key) !=
                 sConstants.EQUIP_MOD_EDIT_ITEMS.end())
             {
                 LOG_ERROR("Duplicate EQUIP_MOD_EDIT_ITEMS key encountered\n");
-                success = false;
+                return false;
             }
-            else
+            else if(!ToIntegerArray(sConstants.EQUIP_MOD_EDIT_ITEMS[key],
+                    libcomp::String(pair.second).Split(",")))
             {
-                success &= ToIntegerArray(sConstants.EQUIP_MOD_EDIT_ITEMS[key],
-                    libcomp::String(pair.second).Split(","));
-            }
-
-            if(!success)
-            {
-                break;
+                LOG_ERROR("Failed to load an element in EQUIP_MOD_EDIT_ITEMS\n");
+                return false;
             }
         }
     }
     else
     {
         LOG_ERROR("EQUIP_MOD_EDIT_ITEMS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("FUSION_BOOST_SKILLS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load FUSION_BOOST_SKILLS\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint32_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load FUSION_BOOST_SKILLS key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.FUSION_BOOST_SKILLS.find(key) !=
                 sConstants.FUSION_BOOST_SKILLS.end())
             {
                 LOG_ERROR("Duplicate FUSION_BOOST_SKILLS key encountered\n");
-                success = false;
+                return false;
             }
-            else
+            else if(!ToIntegerArray(sConstants.FUSION_BOOST_SKILLS[key],
+                    libcomp::String(pair.second).Split(",")))
             {
-                success &= ToIntegerArray(sConstants.FUSION_BOOST_SKILLS[key],
-                    libcomp::String(pair.second).Split(","));
-            }
-
-            if(!success)
-            {
-                break;
+                LOG_ERROR("Failed to load an element in FUSION_BOOST_SKILLS\n");
+                return false;
             }
         }
     }
     else
     {
         LOG_ERROR("FUSION_BOOST_SKILLS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("FUSION_BOOST_STATUSES");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map) &&
-            LoadIntegerMap(map, sConstants.FUSION_BOOST_STATUSES);
+        if(!LoadKeyValueStrings(complexIter->second, map) ||
+            !LoadIntegerMap(map, sConstants.FUSION_BOOST_STATUSES))
+        {
+            LOG_ERROR("Failed to load FUSION_BOOST_STATUSES\n");
+            return false;
+        }
     }
     else
     {
         LOG_ERROR("FUSION_BOOST_STATUSES not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("QUEST_BONUS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map) &&
-            LoadIntegerMap(map, sConstants.QUEST_BONUS);
+        if(!LoadKeyValueStrings(complexIter->second, map) ||
+            !LoadIntegerMap(map, sConstants.QUEST_BONUS))
+        {
+            LOG_ERROR("Failed to load QUEST_BONUS\n");
+            return false;
+        }
     }
     else
     {
         LOG_ERROR("QUEST_BONUS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("RATE_SCALING_ITEMS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load RATE_SCALING_ITEMS\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -751,7 +779,7 @@ bool ServerConstants::Initialize(const String& filePath)
             {
                 LOG_ERROR("RATE_SCALING_ITEMS must specify items for each"
                     " of the 4 types\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -770,7 +798,7 @@ bool ServerConstants::Initialize(const String& filePath)
                         {
                             LOG_ERROR("Failed to load an element in"
                                 " RATE_SCALING_ITEMS\n");
-                            break;
+                            return false;
                         }
                     }
 
@@ -782,98 +810,100 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("RATE_SCALING_ITEMS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("SPIRIT_FUSION_BOOST");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load SPIRIT_FUSION_BOOST\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint32_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load SPIRIT_FUSION_BOOST key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.SPIRIT_FUSION_BOOST.find(key) !=
                 sConstants.SPIRIT_FUSION_BOOST.end())
             {
                 LOG_ERROR("Duplicate SPIRIT_FUSION_BOOST key encountered\n");
-                success = false;
+                return false;
             }
-            else
+            else if(!ToIntegerArray(sConstants.SPIRIT_FUSION_BOOST[key],
+                    libcomp::String(pair.second).Split(",")))
             {
-                success &= ToIntegerArray(sConstants.SPIRIT_FUSION_BOOST[key],
-                    libcomp::String(pair.second).Split(","));
-            }
-
-            if(!success)
-            {
-                break;
+                LOG_ERROR("Failed to load an element in SPIRIT_FUSION_BOOST\n");
+                return false;
             }
         }
     }
     else
     {
         LOG_ERROR("SPIRIT_FUSION_BOOST not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("SYNTH_ADJUSTMENTS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load SYNTH_ADJUSTMENTS\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint32_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load SYNTH_ADJUSTMENTS key\n");
-                success = false;
+                return false;
             }
             else if(sConstants.SYNTH_ADJUSTMENTS.find(key) !=
                 sConstants.SYNTH_ADJUSTMENTS.end())
             {
                 LOG_ERROR("Duplicate SYNTH_ADJUSTMENTS key encountered\n");
-                success = false;
+                return false;
             }
-            else
+            else if(!ToIntegerArray(sConstants.SYNTH_ADJUSTMENTS[key],
+                    libcomp::String(pair.second).Split(",")))
             {
-                success &= ToIntegerArray(sConstants.SYNTH_ADJUSTMENTS[key],
-                    libcomp::String(pair.second).Split(","));
-            }
-
-            if(!success)
-            {
-                break;
+                LOG_ERROR("Failed to load an element in SYNTH_ADJUSTMENTS\n");
+                return false;
             }
         }
     }
     else
     {
         LOG_ERROR("SYNTH_ADJUSTMENTS not found\n");
-        success = false;
+        return false;
     }
     
     complexIter = complexConstants.find("SYNTH_SKILLS");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load SYNTH_SKILLS\n");
-            success = false;
+            return false;
         }
         else
         {
             if(strList.size() != 5)
             {
                 LOG_ERROR("SYNTH_SKILLS must specify all five skill IDs\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -889,8 +919,7 @@ bool ServerConstants::Initialize(const String& filePath)
                     {
                         LOG_ERROR("Failed to load a skill ID in"
                             " SLOT_MOD_ITEMS\n");
-                        success = false;
-                        break;
+                        return false;
                     }
 
                     idx++;
@@ -901,21 +930,26 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("SYNTH_SKILLS not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("TRIFUSION_SPECIAL_DARK");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::unordered_map<std::string, std::string> map;
-        success = LoadKeyValueStrings(complexIter->second, map);
+        if(!LoadKeyValueStrings(complexIter->second, map))
+        {
+            LOG_ERROR("Failed to load TRIFUSION_SPECIAL_DARK\n");
+            return false;
+        }
+
         for(auto pair : map)
         {
             uint8_t key;
             if(!LoadInteger(pair.first, key))
             {
                 LOG_ERROR("Failed to load TRIFUSION_SPECIAL_DARK key\n");
-                success = false;
+                return false;
             }
             else
             {
@@ -929,14 +963,8 @@ bool ServerConstants::Initialize(const String& filePath)
                 {
                     LOG_ERROR("Failed to load an element in"
                         " TRIFUSION_SPECIAL_DARK\n");
-                    success = false;
-                    break;
+                    return false;
                 }
-            }
-
-            if(!success)
-            {
-                break;
             }
         }
 
@@ -950,17 +978,17 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("TRIFUSION_SPECIAL_DARK not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("TRIFUSION_SPECIAL_ELEMENTAL");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load TRIFUSION_SPECIAL_ELEMENTAL\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -968,16 +996,21 @@ bool ServerConstants::Initialize(const String& filePath)
             {
                 LOG_ERROR("TRIFUSION_SPECIAL_ELEMENTAL must specify all 6"
                     " two elemental combinations\n");
-                success = false;
+                return false;
             }
             else
             {
                 size_t idx = 0;
                 for(auto elem : strList)
                 {
-                    success &= ToIntegerArray(
+                    if(!ToIntegerArray(
                         sConstants.TRIFUSION_SPECIAL_ELEMENTAL[idx++],
-                        elem.Split(","));
+                        elem.Split(",")))
+                    {
+                        LOG_ERROR("Failed to load an element in"
+                            " TRIFUSION_SPECIAL_ELEMENTAL\n");
+                        return false;
+                    }
                 }
             }
         }
@@ -985,17 +1018,17 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("TRIFUSION_SPECIAL_ELEMENTAL not found\n");
-        success = false;
+        return false;
     }
 
     complexIter = complexConstants.find("VA_ADD_ITEM");
-    if(success && complexIter != complexConstants.end())
+    if(complexIter != complexConstants.end())
     {
         std::list<String> strList;
         if(!LoadStringList(complexIter->second, strList))
         {
             LOG_ERROR("Failed to load VA_ADD_ITEM\n");
-            success = false;
+            return false;
         }
         else
         {
@@ -1010,8 +1043,7 @@ bool ServerConstants::Initialize(const String& filePath)
                 {
                     LOG_ERROR("Failed to load an element in"
                         " VA_ADD_ITEM\n");
-                    success = false;
-                    break;
+                    return false;
                 }
             }
         }
@@ -1019,7 +1051,7 @@ bool ServerConstants::Initialize(const String& filePath)
     else
     {
         LOG_ERROR("VA_ADD_ITEM not found\n");
-        success = false;
+        return false;
     }
 
     return success;

--- a/libcomp/src/ServerConstants.h
+++ b/libcomp/src/ServerConstants.h
@@ -347,6 +347,9 @@ struct Data
     /// Status effect ID of a cloaked entity
     uint32_t STATUS_CLOAK;
 
+    /// Status effect IDs that remove the summoned demon level cap
+    std::set<uint32_t> STATUS_COMP_TUNING;
+
     /// Status effect ID of instant death
     uint32_t STATUS_DEATH;
 
@@ -531,6 +534,31 @@ private:
             }
 
             prop[idx++] = val;
+        }
+
+        return true;
+    }
+
+    /**
+     * Utility function to load a list of strings into a set
+     * @param prop Set of integers to assign the value to
+     * @param values List of strings reference to pull the values from
+     * @return true on success, false on failure
+     */
+    template<typename T>
+    static bool ToIntegerSet(std::set<T>& prop,
+        std::list<String> values)
+    {
+        bool success;
+        for(auto str : values)
+        {
+            T val = str.ToInteger<T>(&success);
+            if(!success)
+            {
+                return false;
+            }
+
+            prop.insert(val);
         }
 
         return true;

--- a/server/channel/src/AccountManager.cpp
+++ b/server/channel/src/AccountManager.cpp
@@ -601,7 +601,7 @@ bool AccountManager::InitializeCharacter(libcomp::ObjectReference<
         if(equip.IsNull()) continue;
 
         //If we already have an object ID, it's already loaded
-        if(!state->GetObjectID(equip.GetUUID()))
+        if(state->GetObjectID(equip.GetUUID()) <= 0)
         {
             if(!equip.Get(db))
             {

--- a/server/channel/src/ChannelClientConnection.cpp
+++ b/server/channel/src/ChannelClientConnection.cpp
@@ -55,6 +55,12 @@ uint64_t ChannelClientConnection::GetTimeout() const
     return mTimeout;
 }
 
+void ChannelClientConnection::Kill()
+{
+    mClientState->SetLogoutSave(false);
+    Close();
+}
+
 void ChannelClientConnection::BroadcastPacket(const std::list<std::shared_ptr<
     ChannelClientConnection>>& clients, libcomp::Packet& packet, bool queue)
 {

--- a/server/channel/src/ChannelClientConnection.h
+++ b/server/channel/src/ChannelClientConnection.h
@@ -77,6 +77,13 @@ public:
     uint64_t GetTimeout() const;
 
     /**
+     * Close the connection after marking it to not save any logout data.
+     * This is useful for if the client gets into a state that is too complex
+     * to recover from to avoid data corruption.
+     */
+    void Kill();
+
+    /**
      * Broadcast the supplied packet to each client connection in the list.
      * @param clients List of client connections to send the packet to
      * @param packet Packet to send to the supplied clients

--- a/server/channel/src/ChatManager.cpp
+++ b/server/channel/src/ChatManager.cpp
@@ -158,7 +158,7 @@ bool ChatManager::SendChatMessage(const std::shared_ptr<
     {
         case ChatType_t::CHAT_PARTY:
             visibility = ChatVis_t::CHAT_VIS_PARTY;
-            LOG_INFO(libcomp::String("[Party]:  %1: %2\n.").Arg(sentFrom)
+            LOG_INFO(libcomp::String("[Party]:  %1: %2\n").Arg(sentFrom)
                 .Arg(message));
             if(state->GetPartyID())
             {
@@ -168,13 +168,13 @@ bool ChatManager::SendChatMessage(const std::shared_ptr<
             else
             {
                 LOG_ERROR(libcomp::String("Party chat attempted by"
-                    " character not in a party: %1\n.").Arg(sentFrom));
+                    " character not in a party: %1\n").Arg(sentFrom));
                 return false;
             }
             break;
         case ChatType_t::CHAT_CLAN:
             visibility = ChatVis_t::CHAT_VIS_CLAN;
-            LOG_INFO(libcomp::String("[Clan]:  %1: %2\n.").Arg(sentFrom)
+            LOG_INFO(libcomp::String("[Clan]:  %1: %2\n").Arg(sentFrom)
                 .Arg(message));
             if(state->GetClanID())
             {
@@ -184,23 +184,23 @@ bool ChatManager::SendChatMessage(const std::shared_ptr<
             else
             {
                 LOG_ERROR(libcomp::String("Clan chat attempted by"
-                    " character not in a clan: %1\n.").Arg(sentFrom));
+                    " character not in a clan: %1\n").Arg(sentFrom));
                 return false;
             }
             break;
         case ChatType_t::CHAT_SHOUT:
             visibility = ChatVis_t::CHAT_VIS_ZONE;
-            LOG_INFO(libcomp::String("[Shout]:  %1: %2\n.").Arg(sentFrom)
+            LOG_INFO(libcomp::String("[Shout]:  %1: %2\n").Arg(sentFrom)
                 .Arg(message));
             break;
         case ChatType_t::CHAT_SAY:
             visibility = ChatVis_t::CHAT_VIS_RANGE;
-            LOG_INFO(libcomp::String("[Say]:  %1: %2\n.").Arg(sentFrom)
+            LOG_INFO(libcomp::String("[Say]:  %1: %2\n").Arg(sentFrom)
                 .Arg(message));
             break;
         case ChatType_t::CHAT_SELF:
             visibility = ChatVis_t::CHAT_VIS_SELF;
-            LOG_INFO(libcomp::String("[Self]:  %1: %2\n.").Arg(sentFrom)
+            LOG_INFO(libcomp::String("[Self]:  %1: %2\n").Arg(sentFrom)
                 .Arg(message));
             break;
         default:

--- a/server/channel/src/ClientState.cpp
+++ b/server/channel/src/ClientState.cpp
@@ -162,7 +162,7 @@ int64_t ClientState::GetObjectID(const libobjgen::UUID& uuid)
         return iter->second;
     }
 
-    return 0;
+    return -1;
 }
 
 const libobjgen::UUID ClientState::GetObjectUUID(int64_t objectID)

--- a/server/channel/src/FusionManager.cpp
+++ b/server/channel/src/FusionManager.cpp
@@ -306,8 +306,7 @@ bool FusionManager::HandleTriFusion(
                         " additional errors.\n").Arg(state->GetAccountUID().ToString()));
                     for(auto pClient : pClients)
                     {
-                        pClient->GetClientState()->SetLogoutSave(false);
-                        pClient->Close();
+                        pClient->Kill();
                     }
 
                     return false;
@@ -391,7 +390,7 @@ bool FusionManager::HandleTriFusion(
                     auto d = dPair.second;
 
                     int64_t objID = pState->GetObjectID(d->GetUUID());
-                    if(objID == 0)
+                    if(objID <= 0)
                     {
                         objID = server->GetNextObjectID();
                         pState->SetObjectID(d->GetUUID(), objID);

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -148,10 +148,11 @@ public:
      * Cancel the activated skill of an active entity.
      * @param source Pointer of the entity that is cancelling the skill
      * @param activationID ID of the activated ability instance
+     * @param cancelType Cancellation type to send to the client
      * @return true if the skill was cancelled successfully, false otherwise
      */
     bool CancelSkill(const std::shared_ptr<ActiveEntityState> source,
-        int8_t activationID);
+        int8_t activationID, uint8_t cancelType = 1);
 
     /**
      * Notify the client that a skill failed activation or execution.

--- a/server/channel/src/ZoneInstance.cpp
+++ b/server/channel/src/ZoneInstance.cpp
@@ -55,8 +55,7 @@ namespace libcomp
                 objects::ZoneInstanceObject> binding(mVM, "ZoneInstance");
             binding
                 .Func("GetDefinitionID", &ZoneInstance::GetDefinitionID)
-                .Func("GetFlagState", &ZoneInstance::GetFlagStateValue)
-                .Func("GetTimerID", &ZoneInstance::GetTimerID);
+                .Func("GetFlagState", &ZoneInstance::GetFlagStateValue);
 
             Bind<ZoneInstance>("ZoneInstance", binding);
         }
@@ -275,10 +274,4 @@ void ZoneInstance::SetFlagState(int32_t key, int32_t value, int32_t worldCID)
 {
     std::lock_guard<std::mutex> lock(mLock);
     mFlagStates[worldCID][key] = value;
-}
-
-uint32_t ZoneInstance::GetTimerID()
-{
-    auto timeLimitData = GetTimeLimitData();
-    return timeLimitData ? timeLimitData->GetID() : 0;
 }

--- a/server/channel/src/ZoneInstance.h
+++ b/server/channel/src/ZoneInstance.h
@@ -156,12 +156,6 @@ public:
      */
     void SetFlagState(int32_t key, int32_t value, int32_t worldCID);
 
-    /**
-     * Get the timer ID of assigned MiTimeLimitData record if one exists
-     * @return Timer ID or 0 if one is not set
-     */
-    uint32_t GetTimerID();
-
 private:
     /// General use flags and associated values used for event sequences etc
     /// keyed on 0 for all characters or world CID if for a specific one

--- a/server/channel/src/packets/game/AllocateSkillPoint.cpp
+++ b/server/channel/src/packets/game/AllocateSkillPoint.cpp
@@ -85,7 +85,6 @@ void AllocatePoint(const std::shared_ptr<ChannelServer> server,
         LOG_ERROR(libcomp::String("AllocateSkillPoint attempted with an"
             " insufficient amount of stat points available: %1\n")
             .Arg(state->GetAccountUID().ToString()));
-        state->SetLogoutSave(false);
         client->Close();
         return;
     }

--- a/server/channel/src/packets/game/BazaarItemAdd.cpp
+++ b/server/channel/src/packets/game/BazaarItemAdd.cpp
@@ -83,8 +83,7 @@ bool Parsers::BazaarItemAdd::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR(libcomp::String("BazaarItemAdd failed to save: %1\n")
                 .Arg(state->GetAccountUID().ToString()));
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
             return true;
         }
 

--- a/server/channel/src/packets/game/BazaarItemBuy.cpp
+++ b/server/channel/src/packets/game/BazaarItemBuy.cpp
@@ -142,8 +142,7 @@ bool Parsers::BazaarItemBuy::Parse(libcomp::ManagerPacket *pPacketManager,
                 {
                     LOG_ERROR(libcomp::String("BazaarItemBuy failed to save: %1\n")
                         .Arg(state->GetAccountUID().ToString()));
-                    state->SetLogoutSave(false);
-                    client->Close();
+                    client->Kill();
                     return true;
                 }
 

--- a/server/channel/src/packets/game/BazaarItemDrop.cpp
+++ b/server/channel/src/packets/game/BazaarItemDrop.cpp
@@ -76,8 +76,7 @@ bool Parsers::BazaarItemDrop::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR(libcomp::String("BazaarItemDrop failed to save: %1\n")
                 .Arg(state->GetAccountUID().ToString()));
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
             return true;
         }
 

--- a/server/channel/src/packets/game/BazaarItemUpdate.cpp
+++ b/server/channel/src/packets/game/BazaarItemUpdate.cpp
@@ -82,8 +82,7 @@ bool Parsers::BazaarItemUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR(libcomp::String("BazaarItemUpdate failed to save: %1\n")
                 .Arg(state->GetAccountUID().ToString()));
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
             return true;
         }
     }

--- a/server/channel/src/packets/game/BazaarMarketClose.cpp
+++ b/server/channel/src/packets/game/BazaarMarketClose.cpp
@@ -76,8 +76,7 @@ bool Parsers::BazaarMarketClose::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR(libcomp::String("BazaarMarketClose failed to save: %1\n")
                 .Arg(state->GetAccountUID().ToString()));
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
             return true;
         }
 

--- a/server/channel/src/packets/game/BazaarMarketOpen.cpp
+++ b/server/channel/src/packets/game/BazaarMarketOpen.cpp
@@ -125,8 +125,7 @@ bool Parsers::BazaarMarketOpen::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR(libcomp::String("BazaarData failed to save: %1\n")
                 .Arg(state->GetAccountUID().ToString()));
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
             return true;
         }
 

--- a/server/channel/src/packets/game/BazaarMarketSales.cpp
+++ b/server/channel/src/packets/game/BazaarMarketSales.cpp
@@ -119,8 +119,7 @@ bool Parsers::BazaarMarketSales::Parse(libcomp::ManagerPacket *pPacketManager,
             {
                 LOG_ERROR(libcomp::String("BazaarMarketSales failed to save: %1\n")
                     .Arg(state->GetAccountUID().ToString()));
-                state->SetLogoutSave(false);
-                client->Close();
+                client->Kill();
                 return true;
             }
         }

--- a/server/channel/src/packets/game/CommonSwitchUpdate.cpp
+++ b/server/channel/src/packets/game/CommonSwitchUpdate.cpp
@@ -42,7 +42,7 @@ bool Parsers::CommonSwitchUpdate::Parse(libcomp::ManagerPacket *pPacketManager,
 {
     (void)pPacketManager;
 
-    if(p.Size() < 1)
+    if(p.Size() < 2)
     {
         return false;
     }

--- a/server/channel/src/packets/game/Enchant.cpp
+++ b/server/channel/src/packets/game/Enchant.cpp
@@ -370,13 +370,11 @@ bool Parsers::Enchant::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             LOG_ERROR("Enchant result failed to save, disconnecting"
                 " player(s)\n");
-            state->SetLogoutSave(false);
-            client->Close();
+            client->Kill();
 
             if(targetClient)
             {
-                targetState->SetLogoutSave(false);
-                targetClient->Close();
+                targetClient->Kill();
             }
 
             return true;

--- a/server/channel/src/packets/game/EquipmentModEdit.cpp
+++ b/server/channel/src/packets/game/EquipmentModEdit.cpp
@@ -92,7 +92,7 @@ bool Parsers::EquipmentModEdit::Parse(libcomp::ManagerPacket *pPacketManager,
     int32_t mode = 0;
     uint32_t subMode = 0;
 
-    if(valid)
+    if(valid && item)
     {
         int32_t successRate = defIter->second[2];
 
@@ -261,7 +261,7 @@ bool Parsers::EquipmentModEdit::Parse(libcomp::ManagerPacket *pPacketManager,
     reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_EQUIPMENT_MOD_EDIT);
     reply.WriteS32Little(entityID);
     reply.WriteS64Little(itemID);
-    reply.WriteU32Little(item->GetType());
+    reply.WriteU32Little(item ? item->GetType() : 0);
     reply.WriteU32Little(modItemType);
     reply.WriteS32Little(mode);
     reply.WriteU32Little(subMode);

--- a/server/channel/src/packets/game/ExpertiseDown.cpp
+++ b/server/channel/src/packets/game/ExpertiseDown.cpp
@@ -71,9 +71,9 @@ bool Parsers::ExpertiseDown::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(sourceState == nullptr)
     {
-        LOG_ERROR("Player attempted to lower expertise from an entity that does"
-            " not belong to the client\n");
-        state->SetLogoutSave(true);
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a"
+            " ExpertiseDown request: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
         client->Close();
         return true;
     }

--- a/server/channel/src/packets/game/FixObjectPosition.cpp
+++ b/server/channel/src/packets/game/FixObjectPosition.cpp
@@ -59,9 +59,11 @@ bool Parsers::FixObjectPosition::Parse(libcomp::ManagerPacket *pPacketManager,
     auto eState = state->GetEntityState(entityID);
     if(nullptr == eState)
     {
-        LOG_ERROR(libcomp::String("Invalid entity ID received from a fix object position"
-            " request: %1\n").Arg(entityID));
-        return false;
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a fix"
+            " object position request: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     float destX = p.ReadFloat();

--- a/server/channel/src/packets/game/HotbarData.cpp
+++ b/server/channel/src/packets/game/HotbarData.cpp
@@ -68,7 +68,7 @@ void SendHotbarData(const std::shared_ptr<ChannelClientConnection> client,
             itemID = state->GetObjectID(itemUID);
         }
 
-        reply.WriteS8(itemID != 0 ? type : 0);
+        reply.WriteS8(itemID > 0 ? type : 0);
         reply.WriteS64(itemID);
     }
 

--- a/server/channel/src/packets/game/ItemRepairMax.cpp
+++ b/server/channel/src/packets/game/ItemRepairMax.cpp
@@ -68,9 +68,9 @@ bool Parsers::ItemRepairMax::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(sourceState == nullptr)
     {
-        LOG_ERROR("Player attempted to repair the item of an entity that does"
-            " not belong to the client\n");
-        state->SetLogoutSave(true);
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a"
+            " ItemRepairMax request: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
         client->Close();
         return true;
     }

--- a/server/channel/src/packets/game/MaterialExtract.cpp
+++ b/server/channel/src/packets/game/MaterialExtract.cpp
@@ -74,7 +74,8 @@ bool Parsers::MaterialExtract::Parse(libcomp::ManagerPacket *pPacketManager,
 
     int32_t stacksAdded = 0;
     bool success = false;
-    if((int32_t)character->GetMaterials(itemType) >= stackCount && itemDef)
+    int32_t existingCount = (int32_t)character->GetMaterials(itemType);
+    if(existingCount >= stackCount && itemDef)
     {
         auto inventory = character->GetItemBoxes(0).Get();
         int32_t maxStack = (int32_t)itemDef->GetPossession()->GetStackSize();
@@ -117,7 +118,7 @@ bool Parsers::MaterialExtract::Parse(libcomp::ManagerPacket *pPacketManager,
             if(characterManager->AddRemoveItems(client, items, true))
             {
                 character->SetMaterials(itemType, (uint16_t)(
-                    character->GetMaterials(itemType) - addStacks));
+                    existingCount - addStacks));
                 success = true;
                 stacksAdded = addStacks;
 

--- a/server/channel/src/packets/game/Move.cpp
+++ b/server/channel/src/packets/game/Move.cpp
@@ -61,9 +61,10 @@ bool Parsers::Move::Parse(libcomp::ManagerPacket *pPacketManager,
     auto eState = state->GetEntityState(entityID, false);
     if(nullptr == eState)
     {
-        LOG_ERROR(libcomp::String("Invalid entity ID received from a move request: %1\n")
-            .Arg(entityID));
-        return false;
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a move"
+            " request: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
     else if(!eState->Ready(true))
     {

--- a/server/channel/src/packets/game/Pivot.cpp
+++ b/server/channel/src/packets/game/Pivot.cpp
@@ -60,9 +60,8 @@ bool Parsers::Pivot::Parse(libcomp::ManagerPacket *pPacketManager,
     auto entity = state->GetEntityState(entityID);
     if(!entity)
     {
-        LOG_ERROR("Player attempted to pivot an entity that does not belong"
-            " to the client\n");
-        state->SetLogoutSave(true);
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a pivot"
+            " request: %1\n").Arg(state->GetAccountUID().ToString()));
         client->Close();
         return true;
     }

--- a/server/channel/src/packets/game/PopulateZone.cpp
+++ b/server/channel/src/packets/game/PopulateZone.cpp
@@ -58,9 +58,11 @@ bool Parsers::PopulateZone::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(entityID != cEntityID)
     {
-        LOG_ERROR(libcomp::String("PopulateZone request sent with a character"
-            " entity ID matching the client connection: %1\n")
+        LOG_ERROR(libcomp::String("PopulateZone request sent with an"
+            " entity ID not matching the client connection: %1\n")
             .Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     auto server = std::dynamic_pointer_cast<ChannelServer>(

--- a/server/channel/src/packets/game/PostItem.cpp
+++ b/server/channel/src/packets/game/PostItem.cpp
@@ -93,7 +93,6 @@ bool Parsers::PostItem::Parse(libcomp::ManagerPacket *pPacketManager,
                 // If this fails we don't have a good way to recover, disconnect
                 // the player so they don't get into an invalid state
                 LOG_ERROR("Post item retrieval failed to save.\n");
-                state->SetLogoutSave(true);
                 client->Close();
             }
         }

--- a/server/channel/src/packets/game/Rotate.cpp
+++ b/server/channel/src/packets/game/Rotate.cpp
@@ -61,9 +61,10 @@ bool Parsers::Rotate::Parse(libcomp::ManagerPacket *pPacketManager,
     auto eState = state->GetEntityState(entityID, false);
     if(nullptr == eState)
     {
-        LOG_ERROR(libcomp::String("Invalid entity ID received from a rotate request: %1\n")
-            .Arg(entityID));
-        return false;
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a rotate"
+            " request: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
     else if(!eState->Ready(true))
     {

--- a/server/channel/src/packets/game/SkillActivate.cpp
+++ b/server/channel/src/packets/game/SkillActivate.cpp
@@ -61,15 +61,18 @@ bool Parsers::SkillActivate::Parse(libcomp::ManagerPacket *pPacketManager,
     uint32_t targetType = p.ReadU32Little();
     if(targetType != ACTIVATION_NOTARGET && p.Left() == 0)
     {
-        LOG_ERROR("Invalid skill target type sent from client\n");
+        LOG_ERROR(libcomp::String("Invalid skill target type sent from"
+            " client: %1\n").Arg(state->GetAccountUID().ToString()));
         return false;
     }
 
     auto source = state->GetEntityState(sourceEntityID);
     if(!source)
     {
-        LOG_ERROR("Invalid skill source sent from client for skill activation\n");
-        return false;
+        LOG_ERROR(libcomp::String("Invalid skill source sent from client for"
+            " skill activation: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     int64_t activationObjectID = -1;

--- a/server/channel/src/packets/game/SkillCancel.cpp
+++ b/server/channel/src/packets/game/SkillCancel.cpp
@@ -56,8 +56,10 @@ bool Parsers::SkillCancel::Parse(libcomp::ManagerPacket *pPacketManager,
     auto source = state->GetEntityState(sourceEntityID);
     if(!source)
     {
-        LOG_ERROR("Invalid skill source sent from client for skill cancellation\n");
-        return false;
+        LOG_ERROR(libcomp::String("Invalid skill source sent from client for"
+            " skill cancellation: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     server->QueueWork([](SkillManager* pSkillManager, const std::shared_ptr<

--- a/server/channel/src/packets/game/SkillExecute.cpp
+++ b/server/channel/src/packets/game/SkillExecute.cpp
@@ -57,8 +57,10 @@ bool Parsers::SkillExecute::Parse(libcomp::ManagerPacket *pPacketManager,
     auto source = state->GetEntityState(sourceEntityID);
     if(!source)
     {
-        LOG_ERROR("Invalid skill source sent from client for skill execution\n");
-        return false;
+        LOG_ERROR(libcomp::String("Invalid skill source sent from client for"
+            " skill execution: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     server->QueueWork([](SkillManager* pSkillManager, const std::shared_ptr<

--- a/server/channel/src/packets/game/SkillExecuteInstant.cpp
+++ b/server/channel/src/packets/game/SkillExecuteInstant.cpp
@@ -65,17 +65,20 @@ bool Parsers::SkillExecuteInstant::Parse(libcomp::ManagerPacket *pPacketManager,
     uint32_t targetType = p.ReadU32Little();
     if(targetType != ACTIVATION_NOTARGET && p.Left() == 0)
     {
-        LOG_ERROR("Invalid skill target type sent from client for instant"
-            " execution request.\n");
+        LOG_ERROR(libcomp::String("Invalid skill target type sent from client"
+            " for instant execution request: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
         return false;
     }
 
     auto source = state->GetEntityState(sourceEntityID);
     if(!source)
     {
-        LOG_ERROR("Invalid skill source sent from client for instant"
-            " execution request.\n");
-        return false;
+        LOG_ERROR(libcomp::String("Invalid skill source sent from client for"
+            " instant execution request: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
 
     int64_t targetObjectID = -1;

--- a/server/channel/src/packets/game/SkillForget.cpp
+++ b/server/channel/src/packets/game/SkillForget.cpp
@@ -64,9 +64,9 @@ bool Parsers::SkillForget::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(cState->GetEntityID() != entityID)
     {
-        LOG_ERROR("Player attempted to forget a skill for a character that does"
-            " not belong to the client\n");
-        state->SetLogoutSave(true);
+        LOG_ERROR(libcomp::String("Player attempted to forget a skill for a"
+            " character that does not belong to the client: %1\n")
+            .Arg(state->GetAccountUID().ToString()));
         client->Close();
         return true;
     }

--- a/server/channel/src/packets/game/StopMovement.cpp
+++ b/server/channel/src/packets/game/StopMovement.cpp
@@ -57,9 +57,10 @@ bool Parsers::StopMovement::Parse(libcomp::ManagerPacket *pPacketManager,
     auto eState = state->GetEntityState(entityID, false);
     if(nullptr == eState)
     {
-        LOG_ERROR(libcomp::String("Invalid entity ID received from a stop movement"
-            " request: %1\n").Arg(entityID));
-        return false;
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a stop"
+            " movement request: %1\n").Arg(state->GetAccountUID().ToString()));
+        client->Close();
+        return true;
     }
     else if(!eState->Ready(true))
     {

--- a/server/channel/src/packets/game/TradeAddItem.cpp
+++ b/server/channel/src/packets/game/TradeAddItem.cpp
@@ -120,7 +120,7 @@ bool Parsers::TradeAddItem::Parse(libcomp::ManagerPacket *pPacketManager,
 
     auto otherState = otherClient->GetClientState();
     auto otherObjectID = otherState->GetObjectID(item->GetUUID());
-    if(otherObjectID == 0)
+    if(otherObjectID <= 0)
     {
         otherObjectID = server->GetNextObjectID();
         otherState->SetObjectID(item->GetUUID(), otherObjectID);

--- a/server/channel/src/packets/game/TradeFinish.cpp
+++ b/server/channel/src/packets/game/TradeFinish.cpp
@@ -210,8 +210,6 @@ bool Parsers::TradeFinish::Parse(libcomp::ManagerPacket *pPacketManager,
     if(!db->ProcessChangeSet(changes))
     {
         LOG_ERROR("Trade failed to save.\n");
-        state->SetLogoutSave(true);
-        otherState->SetLogoutSave(true);
         client->Close();
         otherClient->Close();
     }

--- a/server/channel/src/packets/game/TriFusionAccept.cpp
+++ b/server/channel/src/packets/game/TriFusionAccept.cpp
@@ -69,7 +69,7 @@ bool Parsers::TriFusionAccept::Parse(libcomp::ManagerPacket *pPacketManager,
         exchangeSession);
 
     bool doFusion = false;
-    std::array<int64_t, 3> demonIDs = { { 0, 0, 0 } };
+    std::array<int64_t, 3> demonIDs = { { -1, -1, -1 } };
 
     bool success = false;
     if(exchangeSession)

--- a/server/channel/src/packets/game/TriFusionDemonUpdate.cpp
+++ b/server/channel/src/packets/game/TriFusionDemonUpdate.cpp
@@ -186,7 +186,7 @@ bool Parsers::TriFusionDemonUpdate::Parse(libcomp::ManagerPacket *pPacketManager
                     auto d = dPair.second;
 
                     int64_t objID = pState->GetObjectID(d->GetUUID());
-                    if(objID == 0)
+                    if(objID <= 0)
                     {
                         objID = server->GetNextObjectID();
                         pState->SetObjectID(d->GetUUID(), objID);

--- a/server/channel/src/packets/game/TriFusionJoin.cpp
+++ b/server/channel/src/packets/game/TriFusionJoin.cpp
@@ -136,7 +136,7 @@ bool Parsers::TriFusionJoin::Parse(libcomp::ManagerPacket *pPacketManager,
                 auto cs = d->GetCoreStats().Get();
 
                 int64_t objID = state->GetObjectID(d->GetUUID());
-                if(objID == 0)
+                if(objID <= 0)
                 {
                     objID = server->GetNextObjectID();
                     state->SetObjectID(d->GetUUID(), objID);
@@ -181,7 +181,7 @@ bool Parsers::TriFusionJoin::Parse(libcomp::ManagerPacket *pPacketManager,
                 auto cs = d->GetCoreStats().Get();
 
                 int64_t objID = pState->GetObjectID(d->GetUUID());
-                if(objID == 0)
+                if(objID <= 0)
                 {
                     objID = server->GetNextObjectID();
                     pState->SetObjectID(d->GetUUID(), objID);

--- a/server/channel/src/packets/game/TriFusionRewardUpdate.cpp
+++ b/server/channel/src/packets/game/TriFusionRewardUpdate.cpp
@@ -196,7 +196,7 @@ bool Parsers::TriFusionRewardUpdate::Parse(libcomp::ManagerPacket *pPacketManage
                 libcomp::Packet nCopy(notify);
 
                 int64_t objID = pState->GetObjectID(item->GetUUID());
-                if(objID == 0)
+                if(objID <= 0)
                 {
                     objID = server->GetNextObjectID();
                     pState->SetObjectID(item->GetUUID(), objID);

--- a/server/channel/src/packets/game/Warp.cpp
+++ b/server/channel/src/packets/game/Warp.cpp
@@ -67,9 +67,8 @@ bool Parsers::Warp::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(sourceState == nullptr)
     {
-        LOG_ERROR("Player attempted to warp an entity that does not belong"
-            " to the client\n");
-        state->SetLogoutSave(true);
+        LOG_ERROR(libcomp::String("Invalid entity ID received from a warp"
+            " request: %1\n").Arg(state->GetAccountUID().ToString()));
         client->Close();
         return true;
     }

--- a/server/lobby/src/packets/game/StartGame.cpp
+++ b/server/lobby/src/packets/game/StartGame.cpp
@@ -100,12 +100,12 @@ bool Parsers::StartGame::Parse(libcomp::ManagerPacket *pPacketManager,
 
     if(!login)
     {
-
         return false;
     }
 
-    /*LOG_DEBUG(libcomp::String("StartGame is sending the following login "
-        "object to the world:\n%1\n").Arg(login->GetXml()));*/
+    LOG_DEBUG(libcomp::String("Start game request received for character"
+        " '%1' from %2\n").Arg(character->GetName())
+        .Arg(client->GetRemoteAddress()));
 
     // Let the world know what we want to do.
     libcomp::Packet request;


### PR DESCRIPTION
Status effect time reset was initially misunderstood so it has been converted. General changes include:
- Adding control error packets
- Removing SetLogoutSave(false) and converting to Kill function
- Converting object ID default to -1 within server logic
- Better ServerConstants error handling
- Adding previous zone login zone logic from instance
- Extended event condition INSTANCE_ACCESS functionality for variants