### PR TITLE
Lilim SP1 changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,13 @@ SET(VERSION_YEAR  2018)
 SET(VERSION_MAJOR 3)
 
 # Minor release (1 = SP1).
-SET(VERSION_MINOR 0)
+SET(VERSION_MINOR 1)
 
 # Patch version (a hotfix).
 SET(VERSION_PATCH 0)
 
 # Codename for the version.
-SET(VERSION_CODENAME "Lilim")
+SET(VERSION_CODENAME "Lilim (SP1)")
 
 #
 # END OF VERSION CONSTANTS

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+comphack (3.1.0) xenial; urgency=low
+
+  * Lilim SP1 server release.
+
+ -- COMP Omega <compomega@tutanota.com>  Thu, 05 Jul 2018 15:00:00 -0600
+
 comphack (3.0.0) xenial; urgency=low
 
   * Lilim server release.

--- a/server/channel/src/ActiveEntityState.cpp
+++ b/server/channel/src/ActiveEntityState.cpp
@@ -1633,7 +1633,7 @@ void ActiveEntityState::RemoveStatusEffects(const std::set<uint32_t>& effectType
                 effectType == SVR_CONST.STATUS_MOUNT_SUPER) &&
                 GetDisplayState() == ActiveDisplayState_t::MOUNT)
             {
-                SetDisplayState(ActiveDisplayState_t::MOUNT);
+                SetDisplayState(ActiveDisplayState_t::ACTIVE);
             }
         }
     }
@@ -2637,6 +2637,77 @@ const std::set<CorrectTbl> BASE_STATS =
         CorrectTbl::LUCK
     };
 
+// The following are all percentage representations that always apply values
+// as a numeric increase or decrease
+const std::set<CorrectTbl> FORCE_NUMERIC =
+    {
+        CorrectTbl::RES_DEFAULT,
+        CorrectTbl::RES_WEAPON,
+        CorrectTbl::RES_SLASH,
+        CorrectTbl::RES_THRUST,
+        CorrectTbl::RES_STRIKE,
+        CorrectTbl::RES_LNGR,
+        CorrectTbl::RES_PIERCE,
+        CorrectTbl::RES_SPREAD,
+        CorrectTbl::RES_FIRE,
+        CorrectTbl::RES_ICE,
+        CorrectTbl::RES_ELEC,
+        CorrectTbl::RES_ALMIGHTY,
+        CorrectTbl::RES_FORCE,
+        CorrectTbl::RES_EXPEL,
+        CorrectTbl::RES_CURSE,
+        CorrectTbl::RES_HEAL,
+        CorrectTbl::RES_SUPPORT,
+        CorrectTbl::RES_MAGICFORCE,
+        CorrectTbl::RES_NERVE,
+        CorrectTbl::RES_MIND,
+        CorrectTbl::RES_WORD,
+        CorrectTbl::RES_SPECIAL,
+        CorrectTbl::RES_SUICIDE,
+        CorrectTbl::RATE_XP,
+        CorrectTbl::RATE_MAG,
+        CorrectTbl::RATE_MACCA,
+        CorrectTbl::RATE_EXPERTISE,
+        CorrectTbl::RATE_CLSR,
+        CorrectTbl::RATE_LNGR,
+        CorrectTbl::RATE_SPELL,
+        CorrectTbl::RATE_SUPPORT,
+        CorrectTbl::RATE_HEAL,
+        CorrectTbl::RATE_CLSR_TAKEN,
+        CorrectTbl::RATE_LNGR_TAKEN,
+        CorrectTbl::RATE_SPELL_TAKEN,
+        CorrectTbl::RATE_SUPPORT_TAKEN,
+        CorrectTbl::RATE_HEAL_TAKEN,
+        CorrectTbl::BOOST_DEFAULT,
+        CorrectTbl::BOOST_WEAPON,
+        CorrectTbl::BOOST_SLASH,
+        CorrectTbl::BOOST_THRUST,
+        CorrectTbl::BOOST_STRIKE,
+        CorrectTbl::BOOST_LNGR,
+        CorrectTbl::BOOST_PIERCE,
+        CorrectTbl::BOOST_SPREAD,
+        CorrectTbl::BOOST_FIRE,
+        CorrectTbl::BOOST_ICE,
+        CorrectTbl::BOOST_ELEC,
+        CorrectTbl::BOOST_ALMIGHTY,
+        CorrectTbl::BOOST_FORCE,
+        CorrectTbl::BOOST_EXPEL,
+        CorrectTbl::BOOST_CURSE,
+        CorrectTbl::BOOST_HEAL,
+        CorrectTbl::BOOST_SUPPORT,
+        CorrectTbl::BOOST_MAGICFORCE,
+        CorrectTbl::BOOST_NERVE,
+        CorrectTbl::BOOST_MIND,
+        CorrectTbl::BOOST_WORD,
+        CorrectTbl::BOOST_SPECIAL,
+        CorrectTbl::BOOST_SUICIDE,
+        CorrectTbl::LB_CHANCE,
+        CorrectTbl::RATE_PC,
+        CorrectTbl::RATE_DEMON,
+        CorrectTbl::RATE_PC_TAKEN,
+        CorrectTbl::RATE_DEMON_TAKEN
+    };
+
 void ActiveEntityState::AdjustStats(
     const std::list<std::shared_ptr<objects::MiCorrectTbl>>& adjustments,
     libcomp::EnumMap<CorrectTbl, int16_t>& stats,
@@ -2672,6 +2743,11 @@ void ActiveEntityState::AdjustStats(
                 effectiveValue = (int32_t)TokuseiManager::CalculateAttributeValue(
                     this, tct->GetValue(), effectiveValue, tct->GetAttributes());
             }
+        }
+
+        if(effectiveType && FORCE_NUMERIC.find(tblID) != FORCE_NUMERIC.end())
+        {
+            effectiveType = 0;
         }
 
         if((uint8_t)tblID >= (uint8_t)CorrectTbl::NRA_WEAPON &&

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -188,16 +188,12 @@ public:
      *  before charging starts.
      * @param mainDemonID Object ID of the demon that is currently summoned
      * @param compDemonID Object ID of the demon that is in the COMP
-     * @param xPos X coordinate where the summoned demon should be moved when
-     *  the skill starts charging
-     * @param yPos Y coordinate where the summoned demon should be moved when
-     *  the skill starts charging
      * @return false if the fusion skill cannot be used for any reason
      */
     bool PrepareFusionSkill(
         const std::shared_ptr<ChannelClientConnection> client,
         uint32_t& skillID, int32_t targetEntityID, int64_t mainDemonID,
-        int64_t compDemonID, float xPos, float yPos);
+        int64_t compDemonID);
 
 private:
     /**
@@ -546,7 +542,6 @@ private:
      * @param pSkill Pointer to the current skill processing state
      * @param mod Base modifier damage value
      * @param damageType Type of damage being dealt
-     * @param affinity Target specific affinity type for the skill
      * @param resist Resistence to the skill affinity
      * @param critLevel Critical level adjustment. Valid values are:
      *  0) No critical adjustment
@@ -558,7 +553,7 @@ private:
     int32_t CalculateDamage_Normal(const std::shared_ptr<ActiveEntityState>& source,
         SkillTargetResult& target, const std::shared_ptr<
         channel::ProcessingSkill>& pSkill, uint16_t mod, uint8_t& damageType,
-        uint8_t affinity, float resist, uint8_t critLevel, bool isHeal);
+        float resist, uint8_t critLevel, bool isHeal);
 
     /**
      * Calculate skill damage or healing based on a static value

--- a/server/channel/src/ZoneGeometry.cpp
+++ b/server/channel/src/ZoneGeometry.cpp
@@ -115,10 +115,10 @@ bool ZoneShape::Collides(const Line& path, Point& point, Line& surface) const
 {
     // If the path is outside of the boundary rectangle and doesn't cross
     // through the max/min boundary points, no collision can exist
-    if((path.first.x < Boundaries[0].x && path.second.x < Boundaries[0].x) ||
-        (path.first.x > Boundaries[1].x && path.second.x > Boundaries[1].x) ||
-        (path.first.y < Boundaries[0].y && path.second.y < Boundaries[0].y) ||
-        (path.first.y > Boundaries[1].y && path.second.y > Boundaries[1].y))
+    if(((path.first.x < Boundaries[0].x && path.second.x < Boundaries[0].x) ||
+        (path.first.x > Boundaries[1].x && path.second.x > Boundaries[1].x)) &&
+        ((path.first.y < Boundaries[0].y && path.second.y < Boundaries[0].y) ||
+        (path.first.y > Boundaries[1].y && path.second.y > Boundaries[1].y)))
     {
         return false;
     }

--- a/server/channel/src/ZoneManager.h
+++ b/server/channel/src/ZoneManager.h
@@ -824,6 +824,14 @@ private:
     bool RemoveInstance(uint32_t instanceID);
 
     /**
+     * Determine if the server object supplied is in a state that would
+     * disabled geometry collision.
+     * @param obj Pointer to a server object
+     * @return true if the object is in a collision disabled state
+     */
+    bool IsGeometryDisabled(const std::shared_ptr<objects::ServerObject>& obj);
+
+    /**
      * Register time restricted actions for a zone with the manager
      * such as time conditional spawn groups or plasma. Times registered
      * with the manager are also registered with the server.

--- a/server/channel/src/packets/game/DemonForce.cpp
+++ b/server/channel/src/packets/game/DemonForce.cpp
@@ -290,7 +290,33 @@ bool Parsers::DemonForce::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             reply.WriteS8(bPair.first);
             reply.WriteS32Little(bPair.second);
-            reply.WriteS16(0);  // New stat value (not actually used)
+
+            // If base stat is not sent, the value will drop to 0. Oddly
+            // enough, this doesn't happen if multiple stats update at once.
+            switch((CorrectTbl)libcomp::DEMON_FORCE_CONVERSION[bPair.first])
+            {
+            case CorrectTbl::STR:
+                reply.WriteS16(demon->GetCoreStats()->GetSTR());
+                break;
+            case CorrectTbl::MAGIC:
+                reply.WriteS16(demon->GetCoreStats()->GetMAGIC());
+                break;
+            case CorrectTbl::VIT:
+                reply.WriteS16(demon->GetCoreStats()->GetVIT());
+                break;
+            case CorrectTbl::INT:
+                reply.WriteS16(demon->GetCoreStats()->GetINTEL());
+                break;
+            case CorrectTbl::SPEED:
+                reply.WriteS16(demon->GetCoreStats()->GetSPEED());
+                break;
+            case CorrectTbl::LUCK:
+                reply.WriteS16(demon->GetCoreStats()->GetLUCK());
+                break;
+            default:
+                reply.WriteS16(0);  // Not necessary
+                break;
+            }
         }
 
         reply.WriteS8(stackSlot);

--- a/server/channel/src/packets/game/EquipmentSpiritDefuse.cpp
+++ b/server/channel/src/packets/game/EquipmentSpiritDefuse.cpp
@@ -157,8 +157,8 @@ bool Parsers::EquipmentSpiritDefuse::Parse(libcomp::ManagerPacket *pPacketManage
         {
             switch(devilData->GetCategory()->GetRace())
             {
-            case objects::MiDCategoryData::Race_t::YOMA:
             case objects::MiDCategoryData::Race_t::EARTH_ELEMENT:
+            case objects::MiDCategoryData::Race_t::NOCTURNE:
             case objects::MiDCategoryData::Race_t::EARTH_MOTHER:
                 demonBoost = 1.2;
                 break;

--- a/server/channel/src/packets/game/EquipmentSpiritFuse.cpp
+++ b/server/channel/src/packets/game/EquipmentSpiritFuse.cpp
@@ -257,8 +257,8 @@ bool Parsers::EquipmentSpiritFuse::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             switch(devilData->GetCategory()->GetRace())
             {
-            case objects::MiDCategoryData::Race_t::YOMA:
             case objects::MiDCategoryData::Race_t::EARTH_ELEMENT:
+            case objects::MiDCategoryData::Race_t::NOCTURNE:
             case objects::MiDCategoryData::Race_t::EARTH_MOTHER:
                 demonBoost = 1.2;
                 break;
@@ -343,9 +343,20 @@ bool Parsers::EquipmentSpiritFuse::Parse(libcomp::ManagerPacket *pPacketManager,
         auto fuseBonusesCurrent = mainItem->GetFuseBonuses();
         auto modSlotsCurrent = mainItem->GetModSlots();
 
-        mainItem->SetBasicEffect(basicItem->GetType());
-        mainItem->SetSpecialEffect(specialItem->GetType());
-        mainItem->SetModSlots(basicItem->GetModSlots());
+        if(basicItem != mainItem)
+        {
+            uint32_t effect = basicItem->GetBasicEffect();
+            mainItem->SetBasicEffect(effect ? effect
+                : basicItem->GetType());
+            mainItem->SetModSlots(basicItem->GetModSlots());
+        }
+
+        if(specialItem != mainItem)
+        {
+            uint32_t effect = specialItem->GetSpecialEffect();
+            mainItem->SetSpecialEffect(effect ? effect
+                : specialItem->GetType());
+        }
 
         std::set<std::shared_ptr<objects::Item>> fusionItems;
         fusionItems.insert(mainItem);

--- a/server/channel/src/packets/game/Move.cpp
+++ b/server/channel/src/packets/game/Move.cpp
@@ -127,7 +127,7 @@ bool Parsers::Move::Parse(libcomp::ManagerPacket *pPacketManager,
 
                 // Monitor for ne'er-do-wells
                 LOG_DEBUG(libcomp::String("Player movement corrected: %1"
-                    " (%2, %2)\n").Arg(state->GetAccountUID().ToString())
+                    " (%2, %3)\n").Arg(state->GetAccountUID().ToString())
                     .Arg(destX).Arg(destY));
             }
         }
@@ -144,7 +144,7 @@ bool Parsers::Move::Parse(libcomp::ManagerPacket *pPacketManager,
 
     // Calculate rotation from origin and destination
     float originRot = eState->GetCurrentRotation();
-    float destRot = (float)atan2(originY - destY, originX - destX);
+    float destRot = (float)atan2(destY - originY, destX - originX);
     eState->SetOriginRotation(originRot);
     eState->SetDestinationRotation(destRot);
 

--- a/server/channel/src/packets/game/SkillActivate.cpp
+++ b/server/channel/src/packets/game/SkillActivate.cpp
@@ -126,11 +126,17 @@ bool Parsers::SkillActivate::Parse(libcomp::ManagerPacket *pPacketManager,
                 float xPos = p.ReadFloat();
                 float yPos = p.ReadFloat();
 
+                // The supplied x/y positions appear to be nonsense based on
+                // certain zones and positions. The proper position will be
+                // calculated in the prepare function.
+                (void)xPos;
+                (void)yPos;
+
                 // Demon fusion skills are always sent from the client as an
                 // "execution skill" that the server needs to convert based
                 // on the demons involved
                 if(!skillManager->PrepareFusionSkill(client, skillID,
-                    targetEntityID, summonedDemonID, compDemonID, xPos, yPos))
+                    targetEntityID, summonedDemonID, compDemonID))
                 {
                     return true;
                 }

--- a/server/lobby/src/packets/game/CharacterList.cpp
+++ b/server/lobby/src/packets/game/CharacterList.cpp
@@ -87,16 +87,22 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
                     loaded &= equip.IsNull() || equip.Get(worldDB) != nullptr;
                     if(!loaded) break;
                 }
-            }
 
-            if(!loaded)
-            {
-                LOG_ERROR(libcomp::String("Character could not be loaded"
-                    " fully: %1\n").Arg(character->GetUUID().ToString()));
+                if(!loaded)
+                {
+                    // This is not a hard failure, let the channel correct
+                    LOG_ERROR(libcomp::String("One or more equipped items"
+                        " failed to load: %1\n")
+                        .Arg(character->GetUUID().ToString()));
+                }
+
+                characters.insert(character);
             }
             else
             {
-                characters.insert(character);
+                // If stats can't load, we need to exclude the character
+                LOG_ERROR(libcomp::String("Character stats coul not be"
+                    " loaded: %1\n").Arg(character->GetUUID().ToString()));
             }
         }
     }
@@ -204,9 +210,9 @@ bool Parsers::CharacterList::Parse(libcomp::ManagerPacket *pPacketManager,
         // Equipment
         for(size_t i = 0; i < 15; i++)
         {
-            auto equip = character->GetEquippedItems(i);
+            auto equip = character->GetEquippedItems(i).Get();
 
-            if(!equip.IsNull())
+            if(equip)
             {
                 reply.WriteU32Little(equip->GetType());
             }

--- a/server/lobby/src/packets/internal/AccountLogin.cpp
+++ b/server/lobby/src/packets/internal/AccountLogin.cpp
@@ -156,8 +156,6 @@ bool Parsers::AccountLogin::Parse(libcomp::ManagerPacket *pPacketManager,
     const std::shared_ptr<libcomp::TcpConnection>& connection,
     libcomp::ReadOnlyPacket& p) const
 {
-    (void)connection;
-
     if(p.Size() < 1)
     {
         LOG_ERROR("Invalid response received for AccountLogin.\n");
@@ -207,6 +205,12 @@ bool Parsers::AccountLogin::Parse(libcomp::ManagerPacket *pPacketManager,
         {
             client->Close();
         }
+    }
+    else
+    {
+        LOG_ERROR("World server sent a malformed AccountLogin message!"
+            " Killing the connection...\n");
+        connection->Close();
     }
 
     return true;

--- a/server/world/src/packets/AccountLogin.cpp
+++ b/server/world/src/packets/AccountLogin.cpp
@@ -273,6 +273,7 @@ void ChannelLogin(std::shared_ptr<WorldServer> server,
             lobbyMessage.WritePacketCode(
                 InternalPacketCode_t::PACKET_ACCOUNT_LOGIN);
 
+            lobbyMessage.WriteS8(1);    // Success
             login->SavePacket(lobbyMessage, false);
             lobbyConnection->SendPacket(lobbyMessage);
 


### PR DESCRIPTION
Fixes include
-Mount cancel skills locked
-XP rate multiplication
-Reunion XP not cleared and reunion switching to non-default rank
-Familiarity down scaling
-Soul point scaling for demon dungeons not enabled
-Expertise calculation wrong at higher ranks
-Demon only instance item usage (and some guardrails for characters)
-Fusion skill demon warp position
-Mooch/care "Miss" due to different status target
-Durability/inheritance do not update when not skill source
-Pursuit damage adjustments
-Demons not included in tokusei party effects
-PARTY_DEMON_TYPE base demon included
-Collision bypass error
-Despawn doesn't stop combat state
-Collision on default open/hidden objects not set properly
-Demon force core stat display issue
-Spirit fuse Nocturne mistaken for Yoma and effect persistence
-Move rotation wrong
-Lobby packet issues