### PR TITLE
[FIX] Include the username in all API requests and store the session by username.

### DIFF
--- a/contrib/webroot/accountmanager/index.html
+++ b/contrib/webroot/accountmanager/index.html
@@ -139,7 +139,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         var apiThis = this;
 
         var request = {
-            challenge: this.challenge
+            challenge: this.challenge,
+            username: this.username
         };
 
         if(userRequest) {


### PR DESCRIPTION
This fixes problems with the website API only working for one account at a time.