### PR TITLE
Fixing incorrect (rarely requested) SyncCharacter response format

### DIFF
--- a/server/channel/src/packets/game/SyncCharacter.cpp
+++ b/server/channel/src/packets/game/SyncCharacter.cpp
@@ -70,9 +70,9 @@ bool Parsers::SyncCharacter::Parse(libcomp::ManagerPacket *pPacketManager,
     libcomp::Packet reply;
     reply.WritePacketCode(ChannelToClientPacketCode_t::PACKET_SYNC_CHARACTER);
     reply.WriteS32Little(entityID);
-    reply.WriteS16Little((int16_t)cs->GetHP());
-    reply.WriteS16Little((int16_t)cs->GetMP());
-    reply.WriteU32Little(static_cast<uint32_t>(statusEffects.size()));
+    reply.WriteU32Little((uint32_t)cs->GetHP());
+    reply.WriteU32Little((uint32_t)cs->GetMP());
+    reply.WriteU8((uint8_t)statusEffects.size());
     for (auto ePair : statusEffects)
     {
         reply.WriteU32Little(ePair.first->GetEffect());


### PR DESCRIPTION
Fixes #626 
I must have just dodged this with my max HP/MP at the time of writing it, how odd