### PR TITLE
Fusion mistakes and libcomp implementations

### DIFF
--- a/server/channel/schema/clientstate.xml
+++ b/server/channel/schema/clientstate.xml
@@ -48,9 +48,6 @@
     </object>
     <object name="EventState" persistent="false">
         <member type="EventInstance*" name="Current" nulldefault="true"/>
-        <member type="list" name="Previous">
-            <element type="EventInstance*"/>
-        </member>
         <member type="list" name="Queued">
             <element type="EventInstance*"/>
         </member>

--- a/server/channel/src/CharacterManager.cpp
+++ b/server/channel/src/CharacterManager.cpp
@@ -4275,6 +4275,11 @@ void CharacterManager::UpdateFamiliarity(const std::shared_ptr<
     channel::ChannelClientConnection>& client, int32_t familiarity,
     bool isAdjust, bool sendPacket)
 {
+    if(isAdjust && !familiarity)
+    {
+        return;
+    }
+
     auto state = client->GetClientState();
     auto cState = state->GetCharacterState();
     auto dState = state->GetDemonState();

--- a/server/channel/src/FusionManager.h
+++ b/server/channel/src/FusionManager.h
@@ -66,7 +66,7 @@ public:
      * @param demonID2 ID of the second demon being fused
      * @param costItemType Optional cost item type used to pay for the fusion,
      *  defaults to macca
-     * @return true if the fusion succeeded, false if it did not
+     * @return true if the fusion did not fail, false if it did
      */
     bool HandleFusion(const std::shared_ptr<
         ChannelClientConnection>& client, int64_t demonID1, int64_t demonID2,
@@ -80,7 +80,7 @@ public:
      * @param demonID3 ID of the third demon being fused
      * @param soloFusion true if a solo fusion is being performed, false
      *  if it is a normal party based tri-fusion
-     * @return true if the fusion succeeded, false if it did not
+     * @return true if the fusion did not fail, false if it did
      */
     bool HandleTriFusion(const std::shared_ptr<
         ChannelClientConnection>& client, int64_t demonID1, int64_t demonID2,
@@ -134,6 +134,7 @@ private:
      * @param resultDemon Output parameter to return the resulting demon in
      * @return Error code associated to the reason why any failure may have
      *  ocurred:
+     *  2 = Fusion mistake
      *  1 = Normal failure
      *  0 = No failure
      *  -1 = Generic/criteria error
@@ -145,6 +146,57 @@ private:
         ChannelClientConnection>& client, int64_t demonID1, int64_t demonID2,
         int64_t demonID3, uint32_t costItemType,
         std::shared_ptr<objects::Demon>& resultDemon);
+
+    /**
+     * Calculate the resulting demon based upon the supplied demon IDs
+     * @param client Pointer to the client performing the fusion
+     * @param demonID1 ID of the first demon being fused
+     * @param demonID2 ID of the second demon being fused
+     * @param demonID3 ID of the third demon being fused
+     * @param specialFusion Output parameter designating if the result is from
+     *  a predefined special fusion
+     * @return Type ID of the demon that would be fused
+     */
+    uint32_t GetResultDemon(const std::shared_ptr<
+        ChannelClientConnection>& client, int64_t demonID1, int64_t demonID2,
+        int64_t demonID3, bool& specialFusion);
+
+    /**
+     * Calculate the resulting mistake demon based upon the supplied demon
+     * types and potential outcome already determined. Should be ignored
+     * for mitama fusions.
+     * @param demonType1 Type ID of the first demon being fused
+     * @param demonType2 Type ID of the second demon being fused
+     * @param demonType3 Type ID of the third demon being fused
+     * @param targetType Demon type of normal fusion result
+     * @param success If true, potential outcome would be a success
+     * @param specialFusion Fusion mode is either special two-way or trifusion
+     *  solo
+     * @param specialTarget Normal fusion result is a predefined special fusion
+     * @param successRate Fusion sucess rate checked to determine the result
+     * @return Type ID of a mistake outcome
+     */
+    uint32_t GetMistakeResultType(uint32_t demonType1, uint32_t demonType2,
+        uint32_t demonType3, uint32_t targetType, bool success,
+        bool specialFusion, bool specialTarget, double successRate);
+    
+    /**
+     * Utility function to check if any or all match set entries are present
+     * when checking special fusion criteria. If one of each required type is
+     * found, it checks to make sure there is a valid combination available 
+     * which is vital when fusing two of the same type or a variant and a
+     * specific demon with the same base type.
+     * @param matches Array of distinct "match indexes" compared to the
+     *  criteria for a match determined by the executing code. For example
+     *  index 0 with values 1 and 2 means the first input demon matches
+     *  criteria 1 and 2.
+     * @param triFusion If true, trifusion is being checked, otherwise two-way
+     * @param any If false, all match criteria must be accounted for. If true,
+     *  only one match must exist.
+     * @return true if the types match
+     */
+    static bool TypesMatch(const std::array<std::set<uint8_t>, 3>& matches,
+        bool triFusion, bool any);
 
     /**
      * Sum up and average the demon levels supplied and optionally

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -11371,6 +11371,10 @@ bool SkillManager::FamiliarityUpItem(
             fPoints = (int32_t)ceill(
                 floorl((float)(maxFamiliarity - currentVal) *
                     deltaPercent * 0.01f) - 1);
+            if(fPoints < 0)
+            {
+                fPoints = 0;
+            }
         }
 
         if(minIncrease && fPoints < minIncrease)

--- a/server/channel/src/packets/game/ShopRepair.cpp
+++ b/server/channel/src/packets/game/ShopRepair.cpp
@@ -113,8 +113,8 @@ bool Parsers::ShopRepair::Parse(libcomp::ManagerPacket *pPacketManager,
         LogItemError([item, accountUID]()
         {
             return libcomp::String("Player attempted to repair irreparable"
-                " item type %1: %2\n")
-                .Arg(item->GetType()).Arg(accountUID.ToString());
+                " item type %1: %2\n").Arg(item ? item->GetType() : 0)
+                .Arg(accountUID.ToString());
         });
     }
     else if(shop && item->GetItemBox() == inventory->GetUUID())

--- a/tools/cathedral/src/ActionPlayBGMUI.cpp
+++ b/tools/cathedral/src/ActionPlayBGMUI.cpp
@@ -75,7 +75,7 @@ void ActionPlayBGM::Load(const std::shared_ptr<objects::Action>& act)
     prop->isStop->setChecked(mAction->GetIsStop());
     prop->music->SetValueSigned(mAction->GetMusicID());
     prop->fadeInDelay->setValue(mAction->GetFadeInDelay());
-    prop->unknown->setValue(mAction->GetUnknown());
+    prop->fadeOutDelay->setValue(mAction->GetFadeOutDelay());
 }
 
 std::shared_ptr<objects::Action> ActionPlayBGM::Save() const
@@ -90,7 +90,7 @@ std::shared_ptr<objects::Action> ActionPlayBGM::Save() const
     mAction->SetIsStop(prop->isStop->isChecked());
     mAction->SetMusicID(prop->music->GetValueSigned());
     mAction->SetFadeInDelay(prop->fadeInDelay->value());
-    mAction->SetUnknown(prop->unknown->value());
+    mAction->SetFadeOutDelay(prop->fadeOutDelay->value());
 
     return mAction;
 }

--- a/tools/cathedral/src/ActionStartEventUI.cpp
+++ b/tools/cathedral/src/ActionStartEventUI.cpp
@@ -47,6 +47,10 @@ ActionStartEvent::ActionStartEvent(ActionList *pList, MainWindow *pMainWindow,
     prop = new Ui::ActionStartEvent;
     prop->setupUi(pWidget);
 
+    prop->eventTransformScriptParams->Setup(
+        DynamicItemType_t::PRIMITIVE_STRING, nullptr);
+    prop->eventTransformScriptParams->SetAddText("Add Param");
+
     ui->actionTitle->setText(tr("<b>Start Event</b>"));
     ui->layoutMain->addWidget(pWidget);
 
@@ -73,6 +77,11 @@ void ActionStartEvent::Load(const std::shared_ptr<objects::Action>& act)
     prop->allowInterrupt->setCurrentIndex(to_underlying(
         mAction->GetAllowInterrupt()));
     prop->autoOnly->setChecked(mAction->GetAutoOnly());
+
+    for(auto param : mAction->GetEventTransformScriptParams())
+    {
+        prop->eventTransformScriptParams->AddString(param);
+    }
 }
 
 std::shared_ptr<objects::Action> ActionStartEvent::Save() const
@@ -88,6 +97,9 @@ std::shared_ptr<objects::Action> ActionStartEvent::Save() const
     mAction->SetAllowInterrupt((objects::ActionStartEvent::AllowInterrupt_t)
         prop->allowInterrupt->currentIndex());
     mAction->SetAutoOnly(prop->autoOnly->isChecked());
+
+    mAction->SetEventTransformScriptParams(
+        prop->eventTransformScriptParams->GetStringList());
 
     return mAction;
 }

--- a/tools/cathedral/src/EventBaseUI.cpp
+++ b/tools/cathedral/src/EventBaseUI.cpp
@@ -74,8 +74,6 @@ void EventBase::Load(const std::shared_ptr<objects::EventBase>& e)
 
     ui->next->SetEvent(e->GetNext());
     ui->queueNext->SetEvent(e->GetQueueNext());
-    ui->pop->setChecked(e->GetPop());
-    ui->popNext->setChecked(e->GetPopNext());
 
     for(auto condition : e->GetConditions())
     {
@@ -86,8 +84,6 @@ void EventBase::Load(const std::shared_ptr<objects::EventBase>& e)
     // (skip invalid is assumed to have already been set)
     if(!ui->layoutBaseBody->isVisible() &&
         (!e->GetQueueNext().IsEmpty() ||
-            e->GetPop() ||
-            e->GetPopNext() ||
             ui->skipInvalid->isChecked()))
     {
         ToggleBaseDisplay();
@@ -103,8 +99,6 @@ std::shared_ptr<objects::EventBase> EventBase::Save() const
 
     mEventBase->SetNext(ui->next->GetEvent());
     mEventBase->SetQueueNext(ui->queueNext->GetEvent());
-    mEventBase->SetPop(ui->pop->isChecked());
-    mEventBase->SetPopNext(ui->popNext->isChecked());
 
     auto conditions = ui->conditions->GetObjectList<objects::EventCondition>();
     mEventBase->SetConditions(conditions);

--- a/tools/cathedral/src/EventPlaySceneUI.cpp
+++ b/tools/cathedral/src/EventPlaySceneUI.cpp
@@ -67,7 +67,7 @@ void EventPlayScene::Load(const std::shared_ptr<objects::Event>& e)
     }
 
     prop->scene->setValue(mEvent->GetSceneID());
-    prop->unknown->setValue(mEvent->GetUnknown());
+    prop->eventLock->setChecked(mEvent->GetEventLock());
 }
 
 std::shared_ptr<objects::Event> EventPlayScene::Save() const
@@ -80,7 +80,7 @@ std::shared_ptr<objects::Event> EventPlayScene::Save() const
     Event::Save();
 
     mEvent->SetSceneID(prop->scene->value());
-    mEvent->SetUnknown((int8_t)prop->unknown->value());
+    mEvent->SetEventLock(prop->eventLock->isChecked());
 
     return mEvent;
 }

--- a/tools/cathedral/src/EventUI.cpp
+++ b/tools/cathedral/src/EventUI.cpp
@@ -83,8 +83,6 @@ void Event::Load(const std::shared_ptr<objects::Event>& e)
     ui->eventID->setText(qs(e->GetID()));
     ui->next->SetEvent(e->GetNext());
     ui->queueNext->SetEvent(e->GetQueueNext());
-    ui->pop->setChecked(e->GetPop());
-    ui->popNext->setChecked(e->GetPopNext());
     ui->skipInvalid->setChecked(e->GetSkipInvalid());
     ui->branchScript->SetScriptID(e->GetBranchScriptID());
     ui->transformScript->SetScriptID(e->GetTransformScriptID());
@@ -108,8 +106,6 @@ void Event::Load(const std::shared_ptr<objects::Event>& e)
     // If any non-base values are set, display the base values section
     if(!ui->layoutBaseBody->isVisible() &&
         (!e->GetQueueNext().IsEmpty() ||
-            e->GetPop() ||
-            e->GetPopNext() ||
             e->GetSkipInvalid() ||
             !e->GetTransformScriptID().IsEmpty()))
     {
@@ -127,8 +123,6 @@ std::shared_ptr<objects::Event> Event::Save() const
     mEventBase->SetID(cs(ui->eventID->text()));
     mEventBase->SetNext(ui->next->GetEvent());
     mEventBase->SetQueueNext(ui->queueNext->GetEvent());
-    mEventBase->SetPop(ui->pop->isChecked());
-    mEventBase->SetPopNext(ui->popNext->isChecked());
     mEventBase->SetSkipInvalid(ui->skipInvalid->isChecked());
 
     mEventBase->SetBranchScriptID(ui->branchScript->GetScriptID());

--- a/tools/cathedral/src/XmlHandler.cpp
+++ b/tools/cathedral/src/XmlHandler.cpp
@@ -315,7 +315,6 @@ std::shared_ptr<XmlTemplateObject> XmlHandler::GetTemplateObject(
     if(objType == "EventBase")
     {
         obj = std::make_shared<objects::EventBase>();
-        lesserMember = "popNext";
         dropObjectIdentifier = true;
     }
     else if(objType == "EventChoice")

--- a/tools/cathedral/ui/ActionPlayBGM.ui
+++ b/tools/cathedral/ui/ActionPlayBGM.ui
@@ -63,14 +63,14 @@
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="lblUnknown">
+      <widget class="QLabel" name="lblFadeOutDelay">
        <property name="text">
-        <string>Unknown:</string>
+        <string>Fade Out Delay:</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QSpinBox" name="unknown">
+      <widget class="QSpinBox" name="fadeOutDelay">
        <property name="minimum">
         <number>-2147483647</number>
        </property>

--- a/tools/cathedral/ui/ActionStartEvent.ui
+++ b/tools/cathedral/ui/ActionStartEvent.ui
@@ -32,14 +32,14 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="lblAllowInterrupt">
        <property name="text">
         <string>Allow Interrupt:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QComboBox" name="allowInterrupt">
        <item>
         <property name="text">
@@ -61,25 +61,41 @@
      <item row="0" column="1">
       <widget class="EventRef" name="event" native="true"/>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="lblAutoOnly">
        <property name="text">
         <string>Auto Only:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="autoOnly">
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lblEventTransformScriptParams">
+       <property name="text">
+        <string>Params:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="DynamicList" name="eventTransformScriptParams" native="true"/>
+     </item>
     </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
+  <customwidget>
+   <class>DynamicList</class>
+   <extends>QWidget</extends>
+   <header>DynamicList.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>EventRef</class>
    <extends>QWidget</extends>

--- a/tools/cathedral/ui/Event.ui
+++ b/tools/cathedral/ui/Event.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>360</height>
+    <height>362</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="actionLayout">
@@ -176,66 +176,38 @@
            <widget class="EventRef" name="queueNext" native="true"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="lblPop">
-            <property name="text">
-             <string>Pop:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="pop">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblPopNext">
-            <property name="text">
-             <string>Pop Next:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="popNext">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="lblTransformScript">
-            <property name="text">
-             <string>Transform Script:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="ServerScript" name="transformScript" native="true"/>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="lblComments">
-            <property name="text">
-             <string>Comments:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="DynamicList" name="comments" native="true"/>
-          </item>
-          <item row="3" column="0">
            <widget class="QLabel" name="lblSkipInvalid">
             <property name="text">
              <string>Skip Invalid:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="1" column="1">
            <widget class="QCheckBox" name="skipInvalid">
             <property name="text">
              <string/>
             </property>
            </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblTransformScript">
+            <property name="text">
+             <string>Transform Script:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="ServerScript" name="transformScript" native="true"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lblComments">
+            <property name="text">
+             <string>Comments:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="DynamicList" name="comments" native="true"/>
           </item>
          </layout>
         </item>

--- a/tools/cathedral/ui/EventBase.ui
+++ b/tools/cathedral/ui/EventBase.ui
@@ -117,41 +117,13 @@
            <widget class="EventRef" name="queueNext" native="true"/>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="lblPop">
-            <property name="text">
-             <string>Pop:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="pop">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblPopNext">
-            <property name="text">
-             <string>Pop Next:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="popNext">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
            <widget class="QLabel" name="lblSkipInvalid">
             <property name="text">
              <string>Skip Invalid:</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="1" column="1">
            <widget class="QCheckBox" name="skipInvalid">
             <property name="text">
              <string/>

--- a/tools/cathedral/ui/EventPlayScene.ui
+++ b/tools/cathedral/ui/EventPlayScene.ui
@@ -46,19 +46,16 @@
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="lblUnknown">
+      <widget class="QLabel" name="lblEventLock">
        <property name="text">
-        <string>Unknown:</string>
+        <string>Event Lock:</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QSpinBox" name="unknown">
-       <property name="minimum">
-        <number>-128</number>
-       </property>
-       <property name="maximum">
-        <number>127</number>
+      <widget class="QCheckBox" name="eventLock">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Deletion of unused "pop" and "popNext" event fields removed the need for a "Previous" collection on the client EventState object.

Fixes #1204 
