### PR TITLE
Simplify Windows config files. Make the wix installer create folders …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,10 @@ IF(WIN32)
             "${CMAKE_SOURCE_DIR}/contrib/webroot"
             DESTINATION /
             COMPONENT webroot)
+
+        INSTALL(DIRECTORY DESTINATION datastore)
+        INSTALL(DIRECTORY DESTINATION database)
+        INSTALL(DIRECTORY DESTINATION logs)
     ENDIF(NOT CHANNEL_ONLY)
 ELSE()
     SET(COMP_INSTALL_DIR "bin")

--- a/contrib/winconfig/channel.xml
+++ b/contrib/winconfig/channel.xml
@@ -5,10 +5,11 @@
         <member name="DatabaseType">SQLITE3</member>
         <member name="DiffieHellmanKeyPair">940134C09FB9BABE187BCE1030E6364530F0966E951F358CE581139FF8189D65E4C24C75FA21D2DCB58280146F435ECB8857D9CF8F0147099A40D2089107647232E82606CBBF767BD202A50A00F080F242C7FFC7B2D4F6D0CCAD33CF2B5FBCDBC0F5B9189D5BD937AA94DD7E238312F3EFF5D6247CEB5C2CAE1D8F5357FA6F8B</member>
         <member name="DataStore">
-            <element>C:/COMP_hack/DataStore</element>
+            <element>datastore</element>
+            <element>C:/path/to/client/files</element>
         </member>
         <member name="DataStoreSync">false</member>
-        <member name="LogFile">C:/COMP_hack/Logs/channel.log</member>
+        <member name="LogFile">logs/channel.log</member>
         <member name="Timeout">30</member>
     </object>
 </objgen>

--- a/contrib/winconfig/lobby.xml
+++ b/contrib/winconfig/lobby.xml
@@ -4,16 +4,17 @@
         <member name="DatabaseType">SQLITE3</member>
         <member name="SQLite3Config">
             <object>
-                <member name="FileDirectory">C:/COMP_hack/Database/</member>
+                <member name="FileDirectory">database</member>
                 <member name="AutoSchemaUpdate">false</member>
             </object>
         </member>
         <member name="DiffieHellmanKeyPair">940134C09FB9BABE187BCE1030E6364530F0966E951F358CE581139FF8189D65E4C24C75FA21D2DCB58280146F435ECB8857D9CF8F0147099A40D2089107647232E82606CBBF767BD202A50A00F080F242C7FFC7B2D4F6D0CCAD33CF2B5FBCDBC0F5B9189D5BD937AA94DD7E238312F3EFF5D6247CEB5C2CAE1D8F5357FA6F8B</member>
         <member name="DataStore">
-            <element>C:/COMP_hack/DataStore</element>
+            <element>datastore</element>
+            <element>C:/path/to/client/files</element>
         </member>
         <member name="DataStoreSync">false</member>
-        <member name="LogFile">C:/COMP_hack/Logs/lobby.log</member>
-        <member name="WebRoot">C:/COMP_hack/Website</member>
+        <member name="LogFile">logs/lobby.log</member>
+        <member name="WebRoot">webroot</member>
     </object>
 </objgen>

--- a/contrib/winconfig/world.xml
+++ b/contrib/winconfig/world.xml
@@ -5,15 +5,16 @@
         <member name="DatabaseType">SQLITE3</member>
         <member name="SQLite3Config">
             <object>
-                <member name="FileDirectory">C:/COMP_hack/Database/</member>
+                <member name="FileDirectory">database</member>
                 <member name="AutoSchemaUpdate">false</member>
             </object>
         </member>
         <member name="DiffieHellmanKeyPair">940134C09FB9BABE187BCE1030E6364530F0966E951F358CE581139FF8189D65E4C24C75FA21D2DCB58280146F435ECB8857D9CF8F0147099A40D2089107647232E82606CBBF767BD202A50A00F080F242C7FFC7B2D4F6D0CCAD33CF2B5FBCDBC0F5B9189D5BD937AA94DD7E238312F3EFF5D6247CEB5C2CAE1D8F5357FA6F8B</member>
         <member name="DataStore">
-            <element>C:/COMP_hack/DataStore</element>
+            <element>datastore</element>
+            <element>C:/path/to/client/files</element>
         </member>
         <member name="DataStoreSync">false</member>
-        <member name="LogFile">C:/COMP_hack/Logs/world.log</member>
+        <member name="LogFile">logs/world.log</member>
     </object>
 </objgen>


### PR DESCRIPTION
…for datastore, logs and sqlite database to match updated default config.