### PR TITLE
Corrected critical hits not occuring if target Critical Defense turne…

### DIFF
--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -8322,7 +8322,7 @@ uint8_t SkillManager::GetCritLevel(
 
     critRate = (float)((floor((float)critValue * 0.2f) *
                         (1.f + ((float)critValue * 0.01f)) /
-                        (float)(critDef1 * critDef2)) *
+                        (float)(std::max((critDef1 * critDef2), 1))) *
                            100.f +
                        (float)critFinal);
   } else {


### PR DESCRIPTION
Corrected critical hits not occuring if target Critical Defense turned negative. They should now occur in this instance.

How to test:

Step 1) Find an enemy Pixie in Suginami.

Step 2) Summon a demon.

Step 3) Apply:

@ tokusei 130116 50 demon

Step 4) Cast Sukunda 4x on the Pixie.

Step 5) Use your player character to hit them in the jaw. If fixed, the strike with critical. If not fixed, strike will not critical.