### PR TITLE
Maintain parties that are part of Cathedral teams.

### DIFF
--- a/server/world/src/CharacterManager.cpp
+++ b/server/world/src/CharacterManager.cpp
@@ -1791,7 +1791,7 @@ void CharacterManager::TeamKick(std::shared_ptr<objects::CharacterLogin> cLogin,
         // Remove them from their party, as the only way they are in one is if
         // they're part of a Cathedral team
         if (targetLogin->GetPartyID()) {
-          PartyKick(cLogin, targetCID);
+          PartyLeave(targetLogin, nullptr);
         }
       }
     }

--- a/server/world/src/CharacterManager.cpp
+++ b/server/world/src/CharacterManager.cpp
@@ -467,15 +467,15 @@ bool CharacterManager::AddToParty(
     // When joining a party, all non-Cathedral teams must be left, so check
     // for membership in the leader's team (non-Cathedral teams were broken
     // on party creation)
-    auto party = partyID ? GetParty(partyID) : 0;
-    auto leader = party ? GetCharacterLogin(party->GetLeaderCID()) : 0;
-    auto leaderTeamID = leader ? leader->GetTeamID() : 0;
+    auto party = partyID ? GetParty(partyID) : nullptr;
+    auto partyLeader = party ? GetCharacterLogin(party->GetLeaderCID()) : nullptr;
+    auto partyLeaderTeamID = partyLeader ? partyLeader->GetTeamID() : 0;
     auto teamID = login->GetTeamID();
 
-    if ((teamID || leaderTeamID) && (teamID != leaderTeamID)) {
+    if (party && (teamID || partyLeaderTeamID) && (teamID != partyLeaderTeamID)) {
       // New party member is not on the leader's team, revoke all team
       // memberships of the party members
-      for (auto& partyMember : party->GetMemberIDsList()) {
+      for (auto partyMember : party->GetMemberIDs()) {
         TeamLeave(GetCharacterLogin(partyMember));
       }
     }

--- a/server/world/src/packets/TeamUpdate.cpp
+++ b/server/world/src/packets/TeamUpdate.cpp
@@ -302,9 +302,7 @@ bool Parsers::TeamUpdate::Parse(
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEAVE: {
       // Leave current team and party
       characterManager->TeamLeave(cLogin);
-      if (cLogin->GetPartyID()) {
-        characterManager->PartyLeave(cLogin, nullptr);
-      }
+      characterManager->PartyLeave(cLogin, nullptr);
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEADER_UPDATE: {
       // Update team leader

--- a/server/world/src/packets/TeamUpdate.cpp
+++ b/server/world/src/packets/TeamUpdate.cpp
@@ -303,7 +303,7 @@ bool Parsers::TeamUpdate::Parse(
       // Leave current team and party
       characterManager->TeamLeave(cLogin);
       if (cLogin->GetPartyID()) {
-        characterManager->PartyLeave(cLogin, connection);
+        characterManager->PartyLeave(cLogin, nullptr);
       }
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEADER_UPDATE: {

--- a/server/world/src/packets/TeamUpdate.cpp
+++ b/server/world/src/packets/TeamUpdate.cpp
@@ -301,10 +301,10 @@ bool Parsers::TeamUpdate::Parse(
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEAVE: {
       // Leave current team and party
-      if(cLogin->GetPartyID()) {
+      characterManager->TeamLeave(cLogin);
+      if (cLogin->GetPartyID()) {
         characterManager->PartyLeave(cLogin, connection);
       }
-      characterManager->TeamLeave(cLogin);
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEADER_UPDATE: {
       // Update team leader

--- a/server/world/src/packets/TeamUpdate.cpp
+++ b/server/world/src/packets/TeamUpdate.cpp
@@ -300,7 +300,10 @@ bool Parsers::TeamUpdate::Parse(
       connection->SendPacket(reply);
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEAVE: {
-      // Leave current team
+      // Leave current team and party
+      if(cLogin->GetPartyID()) {
+        characterManager->PartyLeave(cLogin, connection);
+      }
       characterManager->TeamLeave(cLogin);
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_LEADER_UPDATE: {
@@ -319,7 +322,7 @@ bool Parsers::TeamUpdate::Parse(
       characterManager->TeamLeaderUpdate(teamID, cid, connection, targetCID);
     } break;
     case InternalPacketAction_t::PACKET_ACTION_GROUP_KICK: {
-      // Kick a member
+      // Kick a member from both team and party
       if (p.Left() < 4) {
         LogTeamError([&]() {
           return libcomp::String(


### PR DESCRIPTION
1) So long as all party members are part of the same Cathedral team, that team will be maintained.
2) If a team member who is part of a party is removed from the team for any reason, they are removed from the party.

Fixes #1267