### PR TITLE
Add cooldown status upon successful completion of Mitama allocation reset.

### DIFF
--- a/contrib/testing/config/constants.xml
+++ b/contrib/testing/config/constants.xml
@@ -117,7 +117,7 @@
     <constant name="STATUS_DEMON_QUEST_ACTIVE">1030</constant>
     <constant name="STATUS_DIGITALIZE">905,907</constant>
     <constant name="STATUS_DIGITALIZE_COOLDOWN">906</constant>
-	<constant name="STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN">865</constant>
+    <constant name="STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN">865</constant>
     <constant name="STATUS_MOUNT">801</constant>
     <constant name="STATUS_MOUNT_SUPER">1183</constant>
     <constant name="STATUS_REUNION_XP_SAVE">908</constant>

--- a/contrib/testing/config/constants.xml
+++ b/contrib/testing/config/constants.xml
@@ -117,7 +117,7 @@
     <constant name="STATUS_DEMON_QUEST_ACTIVE">1030</constant>
     <constant name="STATUS_DIGITALIZE">905,907</constant>
     <constant name="STATUS_DIGITALIZE_COOLDOWN">906</constant>
-	<constant name="STATUS_MITAMA_ALLOCATION_COOLDOWN">865</constant>
+	<constant name="STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN">865</constant>
     <constant name="STATUS_MOUNT">801</constant>
     <constant name="STATUS_MOUNT_SUPER">1183</constant>
     <constant name="STATUS_REUNION_XP_SAVE">908</constant>

--- a/contrib/testing/config/constants.xml
+++ b/contrib/testing/config/constants.xml
@@ -117,6 +117,7 @@
     <constant name="STATUS_DEMON_QUEST_ACTIVE">1030</constant>
     <constant name="STATUS_DIGITALIZE">905,907</constant>
     <constant name="STATUS_DIGITALIZE_COOLDOWN">906</constant>
+	<constant name="STATUS_MITAMA_ALLOCATION_COOLDOWN">865</constant>
     <constant name="STATUS_MOUNT">801</constant>
     <constant name="STATUS_MOUNT_SUPER">1183</constant>
     <constant name="STATUS_REUNION_XP_SAVE">908</constant>

--- a/libhack/src/ServerConstants.cpp
+++ b/libhack/src/ServerConstants.cpp
@@ -265,8 +265,8 @@ bool ServerConstants::Initialize(const String& filePath) {
                          sConstants.STATUS_DEMON_QUEST_ACTIVE);
   success &= LoadInteger(constants["STATUS_DIGITALIZE_COOLDOWN"],
                          sConstants.STATUS_DIGITALIZE_COOLDOWN);
-  success &= LoadInteger(constants["STATUS_MITAMA_ALLOCATION_COOLDOWN"],
-                         sConstants.STATUS_MITAMA_ALLOCATION_COOLDOWN);
+  success &= LoadInteger(constants["STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN"],
+                         sConstants.STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN);
   success &= LoadInteger(constants["STATUS_MOUNT"], sConstants.STATUS_MOUNT);
   success &= LoadInteger(constants["STATUS_MOUNT_SUPER"],
                          sConstants.STATUS_MOUNT_SUPER);

--- a/libhack/src/ServerConstants.cpp
+++ b/libhack/src/ServerConstants.cpp
@@ -265,6 +265,8 @@ bool ServerConstants::Initialize(const String& filePath) {
                          sConstants.STATUS_DEMON_QUEST_ACTIVE);
   success &= LoadInteger(constants["STATUS_DIGITALIZE_COOLDOWN"],
                          sConstants.STATUS_DIGITALIZE_COOLDOWN);
+  success &= LoadInteger(constants["STATUS_MITAMA_ALLOCATION_COOLDOWN"],
+                         sConstants.STATUS_MITAMA_ALLOCATION_COOLDOWN);
   success &= LoadInteger(constants["STATUS_MOUNT"], sConstants.STATUS_MOUNT);
   success &= LoadInteger(constants["STATUS_MOUNT_SUPER"],
                          sConstants.STATUS_MOUNT_SUPER);

--- a/libhack/src/ServerConstants.h
+++ b/libhack/src/ServerConstants.h
@@ -408,6 +408,9 @@ class ServerConstants {
     /// Status effect ID of the post digitalize cooldown state
     uint32_t STATUS_DIGITALIZE_COOLDOWN;
 
+    /// Status effect ID of Mitama allocation cooldown effect
+    uint32_t STATUS_MITAMA_ALLOCATION_COOLDOWN;
+
     /// Status effect ID of the demon riding mounted state
     uint32_t STATUS_MOUNT;
 

--- a/libhack/src/ServerConstants.h
+++ b/libhack/src/ServerConstants.h
@@ -409,7 +409,7 @@ class ServerConstants {
     uint32_t STATUS_DIGITALIZE_COOLDOWN;
 
     /// Status effect ID of Mitama allocation cooldown effect
-    uint32_t STATUS_MITAMA_ALLOCATION_COOLDOWN;
+    uint32_t STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN;
 
     /// Status effect ID of the demon riding mounted state
     uint32_t STATUS_MOUNT;

--- a/server/channel/src/packets/game/MitamaReset.cpp
+++ b/server/channel/src/packets/game/MitamaReset.cpp
@@ -29,13 +29,19 @@
 // libcomp Includes
 #include <ManagerPacket.h>
 #include <Packet.h>
+
+// libhack Includes
 #include <PacketCodes.h>
+#include <ServerConstants.h>
 
 // channel Includes
 #include "ChannelServer.h"
 #include "CharacterManager.h"
 #include "EventManager.h"
 #include "TokuseiManager.h"
+
+// object Includes
+#include <StatusEffect.h>
 
 using namespace channel;
 
@@ -103,6 +109,14 @@ void HandleMitamaReset(const std::shared_ptr<ChannelServer> server,
   }
 
   client->SendPacket(reply);
+
+  // Set the cooldown status on the client if successful
+  if (success) {
+    StatusEffectChanges effects;
+    effects[SVR_CONST.STATUS_MITAMA_ALLOCATION_COOLDOWN] = StatusEffectChange(
+        SVR_CONST.STATUS_MITAMA_ALLOCATION_COOLDOWN, 1, true);
+    cState->AddStatusEffects(effects, definitionManager);
+  }
 }
 
 bool Parsers::MitamaReset::Parse(

--- a/server/channel/src/packets/game/MitamaReset.cpp
+++ b/server/channel/src/packets/game/MitamaReset.cpp
@@ -113,8 +113,9 @@ void HandleMitamaReset(const std::shared_ptr<ChannelServer> server,
   // Set the cooldown status on the client if successful
   if (success) {
     StatusEffectChanges effects;
-    effects[SVR_CONST.STATUS_MITAMA_ALLOCATION_COOLDOWN] = StatusEffectChange(
-        SVR_CONST.STATUS_MITAMA_ALLOCATION_COOLDOWN, 1, true);
+    effects[SVR_CONST.STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN] =
+        StatusEffectChange(SVR_CONST.STATUS_MITAMA_ALLOCATION_RESET_COOLDOWN, 1,
+                           true);
     cState->AddStatusEffects(effects, definitionManager);
   }
 }


### PR DESCRIPTION
Fixes #1341 