### PR TITLE
Add optional parameter for added skills to ActionUpdateCOMP.

### DIFF
--- a/libhack/schema/action_updatecomp.xml
+++ b/libhack/schema/action_updatecomp.xml
@@ -12,6 +12,10 @@
             <key type="u32"/>
             <value type="u8"/>
         </member>
+        <member type="map" name="addedSkills">
+            <key type="u32"/>
+            <value type="s16"/>
+        </member>
         <member type="bool" name="unsummon"/>
     </object>
 </objgen>

--- a/server/channel/src/ActionManager.cpp
+++ b/server/channel/src/ActionManager.cpp
@@ -1521,7 +1521,8 @@ bool ActionManager::UpdateCOMP(ActionContext& ctx) {
   if (add.size() > 0) {
     for (auto pair : add) {
       for (uint8_t i = 0; i < pair.second; i++) {
-        if (!characterManager->ContractDemon(ctx.Client, pair.first, 0, 3000, addedSkills)) {
+        if (!characterManager->ContractDemon(ctx.Client, pair.first, 0, 3000,
+                                             addedSkills)) {
           // Not really a good way to recover from this
           LogActionManagerErrorMsg(
               "Failed to contract one or more demons for COMP add request\n");

--- a/server/channel/src/ActionManager.cpp
+++ b/server/channel/src/ActionManager.cpp
@@ -1430,6 +1430,7 @@ bool ActionManager::UpdateCOMP(ActionContext& ctx) {
 
   // Last add demons
   std::unordered_map<std::shared_ptr<objects::MiDevilData>, uint8_t> add;
+  std::unordered_map<uint32_t, int16_t> addedSkills;
   if (act->AddDemonsCount() > 0) {
     auto definitionManager = server->GetDefinitionManager();
     for (auto pair : act->GetAddDemons()) {
@@ -1453,6 +1454,28 @@ bool ActionManager::UpdateCOMP(ActionContext& ctx) {
       freeCount = (uint8_t)(freeCount - pair.second);
 
       add[demonData] = pair.second;
+    }
+
+    // Now construct the added skill map
+    if (act->AddedSkillsCount() > 0) {
+      for (auto pair : act->GetAddedSkills()) {
+        auto skillData = definitionManager->GetSkillData(pair.first);
+        if (skillData == nullptr) {
+          LogActionManagerError([&]() {
+            return libcomp::String("Invalid skill ID encountered: %1\n")
+                .Arg(pair.first);
+          });
+
+          return false;
+        }
+
+        auto progress = pair.second;
+        if (progress > MAX_INHERIT_SKILL) {
+          progress = MAX_INHERIT_SKILL;
+        }
+
+        addedSkills[pair.first] = progress;
+      }
     }
   }
 
@@ -1498,7 +1521,7 @@ bool ActionManager::UpdateCOMP(ActionContext& ctx) {
   if (add.size() > 0) {
     for (auto pair : add) {
       for (uint8_t i = 0; i < pair.second; i++) {
-        if (!characterManager->ContractDemon(ctx.Client, pair.first, 0, 3000)) {
+        if (!characterManager->ContractDemon(ctx.Client, pair.first, 0, 3000, addedSkills)) {
           // Not really a good way to recover from this
           LogActionManagerErrorMsg(
               "Failed to contract one or more demons for COMP add request\n");

--- a/server/channel/src/ActionManager.cpp
+++ b/server/channel/src/ActionManager.cpp
@@ -1469,12 +1469,12 @@ bool ActionManager::UpdateCOMP(ActionContext& ctx) {
           return false;
         }
 
-        auto progress = pair.second;
-        if (progress > MAX_INHERIT_SKILL) {
-          progress = MAX_INHERIT_SKILL;
+        auto inheritance_progress = pair.second;
+        if (inheritance_progress > MAX_INHERIT_SKILL) {
+          inheritance_progress = MAX_INHERIT_SKILL;
         }
 
-        addedSkills[pair.first] = progress;
+        addedSkills[pair.first] = inheritance_progress;
       }
     }
   }

--- a/server/channel/src/CharacterManager.h
+++ b/server/channel/src/CharacterManager.h
@@ -674,12 +674,16 @@ class CharacterManager {
    *  the demon
    * @param familiarity Optional familiarity level on the contracted
    *  demon, defaults to 0
+   * @param addedSkills Optional unordered map of skills to be added to the
+   * demon at defined mastery levels
    * @return Pointer to the newly created demon
    */
   std::shared_ptr<objects::Demon> ContractDemon(
       const std::shared_ptr<channel::ChannelClientConnection>& client,
       const std::shared_ptr<objects::MiDevilData>& demonData,
-      int32_t sourceEntityID, uint16_t familiarity = 0);
+      int32_t sourceEntityID, uint16_t familiarity = 0,
+      const std::unordered_map<uint32_t, int16_t>& addedSkills =
+          std::unordered_map<uint32_t, int16_t>());
 
   /**
    * Create a demon and add it to a character's COMP.
@@ -688,12 +692,16 @@ class CharacterManager {
    *  the demon to create
    * @param familiarity Optional familiarity level on the contracted
    *  demon, defaults to 0
+   * @param addedSkills Optional unordered map of skills to be added to the
+   * demon at defined mastery levels
    * @return Pointer to the newly created demon
    */
   std::shared_ptr<objects::Demon> ContractDemon(
       const std::shared_ptr<objects::Character>& character,
       const std::shared_ptr<objects::MiDevilData>& demonData,
-      uint16_t familiarity = 0);
+      uint16_t familiarity = 0,
+      const std::unordered_map<uint32_t, int16_t>& addedSkills =
+          std::unordered_map<uint32_t, int16_t>());
 
   /**
    * Create a demon.


### PR DESCRIPTION
Closes #1327 

ActionUpdateCOMP now has optional member addedSkills. It takes key-value pairs where key is the skill ID and value is the mastery.