### PR TITLE
Feature to save and reactivate activated Switch Skills on login.

### DIFF
--- a/docs/guide/chapters/config.rst
+++ b/docs/guide/chapters/config.rst
@@ -1165,23 +1165,25 @@ Example
 SaveSwitchSkills
 ^^^^^^^^^^^^^^^^
 
-**Type:** integer
+**Type:** enumeration
 
-**Default:** 0
+**Default:** NO_REACTIVATION
 
-If above 0, switch skills that have been activated in a previous
-session will be reactivated when the character next logs in. A
-setting of 2 results in all normal switch skill costs being
-paid in the process, in the numerical order of skill IDs
-ascending. Any switches whose costs could not be paid
-will not be activated.
+If set to FREE_SWITCH_REACTIVATION, switch skills that have been
+activated in a previous session will be reactivated when the
+character next logs in. A setting of PAY_SWITCH_COSTS results
+in all normal switch skill costs being paid during reactivation,
+in the numerical order of skill IDs ascending. Any switches
+whose costs could not be paid will not be activated. The
+default setting of NO_REACTIVATION is the normal behavior
+of switch skills not being turned back on during login.
 
 Example
 """""""
 
 .. code-block:: xml
 
-    <member name="SaveSwitchSkills">1</member>
+    <member name="SaveSwitchSkills">FREE_SWITCH_REACTIVATION</member>
 
 DeathPenaltyDisabled
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/guide/chapters/config.rst
+++ b/docs/guide/chapters/config.rst
@@ -1171,11 +1171,11 @@ SaveSwitchSkills
 
 If set to FREE_SWITCH_REACTIVATION, switch skills that have been
 activated in a previous session will be reactivated when the
-character next logs in. A setting of PAY_SWITCH_COSTS results
-in all normal switch skill costs being paid during reactivation,
-in the numerical order of skill IDs ascending. Any switches
-whose costs could not be paid will not be activated. The
-default setting of NO_REACTIVATION is the normal behavior
+character next logs in. A setting of PAY_SWITCH_REACTIVATION_COSTS
+results in all normal switch skill costs being paid during
+reactivation, in the numerical order of skill IDs ascending.
+Any switches whose costs could not be paid will not be activated.
+The default setting of NO_REACTIVATION is the normal behavior
 of switch skills not being turned back on during login.
 
 Example

--- a/docs/guide/chapters/config.rst
+++ b/docs/guide/chapters/config.rst
@@ -1162,6 +1162,27 @@ Example
 
     <member name="NRAStatusNull">false</member>
 
+SaveSwitchSkills
+^^^^^^^^^^^^^^^^
+
+**Type:** integer
+
+**Default:** 1
+
+If above 0, switch skills that have been activated in a previous
+session will be reactivated when the character next logs in. A
+setting of 2 results in all normal switch skill costs being
+paid in the process, in the numerical order of skill IDs
+ascending. Any switches whose costs could not be paid
+will not be activated.
+
+Example
+"""""""
+
+.. code-block:: xml
+
+    <member name="SaveSwitchSkills">1</member>
+
 DeathPenaltyDisabled
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/guide/chapters/config.rst
+++ b/docs/guide/chapters/config.rst
@@ -1167,7 +1167,7 @@ SaveSwitchSkills
 
 **Type:** integer
 
-**Default:** 1
+**Default:** 0
 
 If above 0, switch skills that have been activated in a previous
 session will be reactivated when the character next logs in. A

--- a/libhack/schema/character.xml
+++ b/libhack/schema/character.xml
@@ -45,6 +45,9 @@
         <member type="set" name="LearnedSkills">
             <element type="u32"/>
         </member>
+        <member type="set" name="SavedSwitchSkills">
+            <element type="u32"/>
+        </member>
         <member type="array" name="EquippedItems" size="15">
             <element type="Item*"/>
         </member>

--- a/libhack/schema/worldsharedconfig.xml
+++ b/libhack/schema/worldsharedconfig.xml
@@ -9,7 +9,7 @@
         <member type="bool" name="MoveCorrection" default="true"/>
         <member type="bool" name="AutoCompressCurrency"/>
         <member type="bool" name="NRAStatusNull" default="true"/>
-        <member type="u8" name="SaveSwitchSkills" default="1"/>
+        <member type="u8" name="SaveSwitchSkills" default="0"/>
         <member type="bool" name="DeathPenaltyDisabled"/>
         <member type="bool" name="DeadTokuseiDisabled"/>
         <member type="float" name="DropLuckScalingCap" default="-1.0"/>

--- a/libhack/schema/worldsharedconfig.xml
+++ b/libhack/schema/worldsharedconfig.xml
@@ -9,9 +9,9 @@
         <member type="bool" name="MoveCorrection" default="true"/>
         <member type="bool" name="AutoCompressCurrency"/>
         <member type="bool" name="NRAStatusNull" default="true"/>
-        <member type="enum" name="SaveSwitchSkills" default="NO_REACTIVATION" >>
+        <member type="enum" name="SaveSwitchSkills" default="NO_REACTIVATION">
             <value>NO_REACTIVATION</value>
-            <value>FREE_SWITCH_REACTIVATION</value>
+            <value>PAY_SWITCH_REACTIVATION_COSTS</value>
             <value>PAY_SWITCH_COSTS</value>
         </member>
         <member type="bool" name="DeathPenaltyDisabled"/>

--- a/libhack/schema/worldsharedconfig.xml
+++ b/libhack/schema/worldsharedconfig.xml
@@ -9,6 +9,7 @@
         <member type="bool" name="MoveCorrection" default="true"/>
         <member type="bool" name="AutoCompressCurrency"/>
         <member type="bool" name="NRAStatusNull" default="true"/>
+        <member type="u8" name="SaveSwitchSkills" default="1"/>
         <member type="bool" name="DeathPenaltyDisabled"/>
         <member type="bool" name="DeadTokuseiDisabled"/>
         <member type="float" name="DropLuckScalingCap" default="-1.0"/>

--- a/libhack/schema/worldsharedconfig.xml
+++ b/libhack/schema/worldsharedconfig.xml
@@ -9,7 +9,11 @@
         <member type="bool" name="MoveCorrection" default="true"/>
         <member type="bool" name="AutoCompressCurrency"/>
         <member type="bool" name="NRAStatusNull" default="true"/>
-        <member type="u8" name="SaveSwitchSkills" default="0"/>
+        <member type="enum" name="SaveSwitchSkills" default="NO_REACTIVATION" >>
+            <value>NO_REACTIVATION</value>
+            <value>FREE_SWITCH_REACTIVATION</value>
+            <value>PAY_SWITCH_COSTS</value>
+        </member>
         <member type="bool" name="DeathPenaltyDisabled"/>
         <member type="bool" name="DeadTokuseiDisabled"/>
         <member type="float" name="DropLuckScalingCap" default="-1.0"/>

--- a/server/channel/src/ChannelServer.cpp
+++ b/server/channel/src/ChannelServer.cpp
@@ -71,6 +71,7 @@ BaseScriptEngine& BaseScriptEngine::Using<ChannelServer>() {
     Using<AIManager>();
     Using<ChannelSyncManager>();
     Using<MatchManager>();
+    Using<SkillManager>();
     Using<WorldClock>();
     Using<ZoneManager>();
 
@@ -82,6 +83,7 @@ BaseScriptEngine& BaseScriptEngine::Using<ChannelServer>() {
         .Func("GetAIManager", &ChannelServer::GetAIManager)
         .Func("GetChannelSyncManager", &ChannelServer::GetChannelSyncManager)
         .Func("GetMatchManager", &ChannelServer::GetMatchManager)
+        .Func("GetSkillManager", &ChannelServer::GetSkillManager)
         .Func("GetZoneManager", &ChannelServer::GetZoneManager)
         .StaticFunc("GetServerTime", &ChannelServer::GetServerTime)
         .StaticFunc("GetExpirationInSeconds",

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -842,7 +842,7 @@ bool SkillManager::ReactivateSavedSwitchSkills(
 
   // Clear out saved switch skills and return if the server is set to not do
   // this.
-  if (!saveSwitchSkills) {
+  if (saveSwitchSkills == objects::WorldSharedConfig::SaveSwitchSkills_t::NO_REACTIVATION) {
     character->ClearSavedSwitchSkills();
     return true;
   }
@@ -862,7 +862,8 @@ bool SkillManager::ReactivateSavedSwitchSkills(
       continue;
     }
 
-    if (saveSwitchSkills == 2) {
+    if (saveSwitchSkills ==
+        objects::WorldSharedConfig::SaveSwitchSkills_t::PAY_SWITCH_COSTS) {
       // Determine and pay costs, else remove the unpayable skill.
       auto activated = std::make_shared<objects::ActivatedAbility>();
       activated->SetSourceEntity(source);

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -891,7 +891,6 @@ bool SkillManager::ReactivateSavedSwitchSkills(
 
         int64_t targetItem = activated->GetActivationObjectID();
         if (bulletCost > 0) {
-          auto character = state->GetCharacterState()->GetEntity();
           auto bullets = character->GetEquippedItems((
               size_t)objects::MiItemBasicData::EquipType_t::EQUIP_TYPE_BULLETS);
           if (bullets) {

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -842,7 +842,8 @@ bool SkillManager::ReactivateSavedSwitchSkills(
 
   // Clear out saved switch skills and return if the server is set to not do
   // this.
-  if (saveSwitchSkills == objects::WorldSharedConfig::SaveSwitchSkills_t::NO_REACTIVATION) {
+  if (saveSwitchSkills ==
+      objects::WorldSharedConfig::SaveSwitchSkills_t::NO_REACTIVATION) {
     character->ClearSavedSwitchSkills();
     return true;
   }

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -2456,7 +2456,6 @@ bool SkillManager::DetermineCosts(
   }
 
   auto server = mServer.lock();
-  server->GetSkillManager();
   auto characterManager = server->GetCharacterManager();
 
   int32_t hpCost = 0, mpCost = 0;

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -7949,11 +7949,11 @@ bool SkillManager::ToggleSwitchSkill(
     const std::shared_ptr<SkillExecutionContext>& ctx) {
   auto source = std::dynamic_pointer_cast<ActiveEntityState>(
       activated->GetSourceEntity());
-  auto sourceState = ClientState::GetEntityClientState(source->GetEntityID());
-  auto cState = sourceState->GetCharacterState();
+  auto state = client->GetClientState();
+  auto cState = state->GetCharacterState();
   auto character = cState->GetEntity();
-  auto saveSwitchSkills =
-      mServer.lock()->GetWorldSharedConfig()->GetSaveSwitchSkills();
+  auto server = mServer.lock();
+  auto saveSwitchSkills = server->GetWorldSharedConfig()->GetSaveSwitchSkills();
 
   auto skillData = activated->GetSkillData();
   uint32_t skillID = skillData->GetCommon()->GetID();
@@ -7984,12 +7984,10 @@ bool SkillManager::ToggleSwitchSkill(
 
     client->QueuePacket(p);
 
-    mServer.lock()->GetCharacterManager()->RecalculateTokuseiAndStats(source,
-                                                                      client);
+    server->GetCharacterManager()->RecalculateTokuseiAndStats(source, client);
 
     client->FlushOutgoing();
   } else {
-    auto server = mServer.lock();
     auto definitionManager = server->GetDefinitionManager();
 
     server->GetTokuseiManager()->Recalculate(source, false);

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -863,8 +863,8 @@ bool SkillManager::ReactivateSavedSwitchSkills(
       continue;
     }
 
-    if (saveSwitchSkills ==
-        objects::WorldSharedConfig::SaveSwitchSkills_t::PAY_SWITCH_COSTS) {
+    if (saveSwitchSkills == objects::WorldSharedConfig::SaveSwitchSkills_t::
+                                PAY_SWITCH_REACTIVATION_COSTS) {
       // Determine and pay costs, else remove the unpayable skill.
       auto activated = std::make_shared<objects::ActivatedAbility>();
       activated->SetSourceEntity(source);

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -361,6 +361,20 @@ class SkillManager {
       std::shared_ptr<objects::CalculatedEntityState> calcState = nullptr);
 
   /**
+   * Pay the costs required to execute a skill, after it was determined they
+   * could be paid.
+   * @param source Pointer to the state of the source entity
+   * @param activated Pointer to the activated ability instance
+   * @param client Pointer to the client connection, can be null if not coming
+   *  from a player entity
+   * @param ctx Special execution state for the skill
+   */
+  void PayCosts(std::shared_ptr<ActiveEntityState> source,
+                std::shared_ptr<objects::ActivatedAbility> activated,
+                const std::shared_ptr<ChannelClientConnection> client,
+                std::shared_ptr<SkillExecutionContext> ctx);
+
+  /**
    * Schedule automatic skill cancellation after a set amount of time
    * as defined by the skill definition. If the skill is mutli-use,
    * this should be called after each non-final execution.

--- a/server/channel/src/SkillManager.h
+++ b/server/channel/src/SkillManager.h
@@ -152,6 +152,13 @@ class SkillManager {
                      std::shared_ptr<SkillExecutionContext> ctx = 0);
 
   /**
+   * Reactivate switch skills that were toggled on in a previous login.
+   * @param source Pointer of the source entity
+   */
+  bool ReactivateSavedSwitchSkills(
+      const std::shared_ptr<ActiveEntityState>& source);
+
+  /**
    * Target/retarget the skill of a character or demon. No response is sent
    * to the clients from this request.
    * @param source Pointer of the entity that activated the skill


### PR DESCRIPTION
SaveSwitchSkills 0 in SharedWorldConfig disables the feature.

1 activates it, and is default.

2 adds a requirement to pay the skills' costs for reactivation.