### PR TITLE
Fast track instant skills.

### DIFF
--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -1043,6 +1043,12 @@ bool SkillManager::ExecuteSkill(
     ctx = std::make_shared<SkillExecutionContext>();
   }
 
+  // Fast track instant skills
+  if (skillData->GetBasic()->GetActivationType() ==
+      SkillActivationType_t::INSTANT) {
+    ctx->FastTrack = true;
+  }
+
   auto pSkill = GetProcessingSkill(activated, ctx);
   pSkill->SourceExecutionState =
       GetCalculatedState(source, pSkill, false, nullptr);


### PR DESCRIPTION
Fixes #1242 

By setting instant skills to use the FastTrack skill execution context flag, they skip delays in execution as well as ignore hitstun.