### PR TITLE
Prevent the initial target nullifying a spin resulting in it actually being reflected.

### DIFF
--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -2994,7 +2994,7 @@ bool SkillManager::ProcessSkillResult(
 
   bool initialHitNull = pSkill->Nulled != 0;
   bool initialHitReflect = pSkill->Reflected != 0;
-  bool initialHitReflectNoAOECancel = false;
+  bool initialHitReflectWithoutAOECancel = false;
   if (pSkill->Nulled || pSkill->Reflected || pSkill->Absorbed) {
     // Apply original target NRA
     std::shared_ptr<ActiveEntityState> nraTarget;
@@ -3089,7 +3089,7 @@ bool SkillManager::ProcessSkillResult(
         // Ignore what happened to the primary target completely. This is a
         // special case that requires some handling later to prevent double
         // reflection onto the skill user.
-        initialHitReflectNoAOECancel = initialHitReflect;
+        initialHitReflectWithoutAOECancel = initialHitReflect;
         break;
       case objects::MiEffectiveRangeData::AreaType_t::TARGET_RADIUS:
       case objects::MiEffectiveRangeData::AreaType_t::FRONT_3:
@@ -3441,14 +3441,15 @@ bool SkillManager::ProcessSkillResult(
     // reflect cases, apply the initially calculated flags
     bool isSource = effectiveTarget == source;
     if (target.PrimaryTarget &&
-        (!initialHitReflect || initialHitReflectNoAOECancel)) {
+        (!initialHitReflect || initialHitReflectWithoutAOECancel)) {
       target.HitNull = skill.Nulled;
       target.HitReflect = skill.Reflected;
       target.HitAbsorb = skill.Absorbed;
-      target.HitAvoided = (skill.Nulled != 0 || initialHitReflectNoAOECancel);
+      target.HitAvoided =
+          (skill.Nulled != 0 || initialHitReflectWithoutAOECancel);
       target.NRAAffinity = skill.NRAAffinity;
 
-      if (initialHitReflectNoAOECancel && !isSource) {
+      if (initialHitReflectWithoutAOECancel && !isSource) {
         // This is a spin or other radial attack that the initial target
         // reflected, without canceling the AOE. Treat the initial
         // reflection as an additional AOE reflect.


### PR DESCRIPTION
Fixes #1276 harder.