### PR TITLE
Add new AIState of ENRAGED

### DIFF
--- a/server/channel/src/AIManager.cpp
+++ b/server/channel/src/AIManager.cpp
@@ -1015,7 +1015,7 @@ bool AIManager::UpdateState(const std::shared_ptr<ActiveEntityState>& eState,
         case AIStatus_t::ENRAGED: {
           auto skillActionType =
               activated->GetSkillData()->GetBasic()->GetActionType();
-              
+
           if (skillActionType == SkillActionType_t::COUNTER ||
               skillActionType == SkillActionType_t::DODGE ||
               skillActionType == SkillActionType_t::GUARD) {
@@ -1034,8 +1034,8 @@ bool AIManager::UpdateState(const std::shared_ptr<ActiveEntityState>& eState,
       }
     }
 
-    // If the status has been changed to or from ENRAGED, refresh the skill map so that
-    // appropriate skills are selectable.
+    // If the status has been changed to or from ENRAGED, refresh the skill map
+    // so that appropriate skills are selectable.
     if (aiState->IsEnraged() ||
         aiState->GetPreviousStatus() == AIStatus_t::ENRAGED) {
       aiState->ResetSkillsMapped();

--- a/server/channel/src/AIManager.cpp
+++ b/server/channel/src/AIManager.cpp
@@ -984,8 +984,8 @@ bool AIManager::UpdateState(const std::shared_ptr<ActiveEntityState>& eState,
   }
 
   if (aiState->StatusChanged()) {
-    // Do not clear actions if going from aggro to combat
-    if (!(aiState->GetStatus() == AIStatus_t::COMBAT &&
+    // Do not clear actions if going from aggro to a combat state
+    if (!(aiState->GetStatus() >= AIStatus_t::COMBAT &&
           aiState->GetPreviousStatus() == AIStatus_t::AGGRO)) {
       auto cmd = aiState->GetCurrentCommand();
       aiState->ClearCommands();
@@ -998,14 +998,34 @@ bool AIManager::UpdateState(const std::shared_ptr<ActiveEntityState>& eState,
     }
 
     auto activated = eState->GetActivatedAbility();
-    if (activated &&
-        (aiState->GetPreviousStatus() == AIStatus_t::AGGRO ||
-         aiState->GetPreviousStatus() == AIStatus_t::COMBAT) &&
-        (aiState->GetStatus() != AIStatus_t::AGGRO &&
-         aiState->GetStatus() != AIStatus_t::COMBAT)) {
-      // Leftover combat skill, cancel it now
-      mServer.lock()->GetSkillManager()->CancelSkill(
-          eState, activated->GetActivationID());
+    if (activated) {
+      bool cancelActivatedSkill = false;
+      auto skillActionType =
+          activated->GetSkillData()->GetBasic()->GetActionType();
+
+      // Nested for readability.
+      if (aiState->GetStatus() == AIStatus_t::ENRAGED &&
+          (skillActionType == SkillActionType_t::COUNTER ||
+           skillActionType == SkillActionType_t::DODGE ||
+           skillActionType == SkillActionType_t::GUARD)) {
+        // Target has been taunted, defensive skills
+        cancelActivatedSkill = true;
+      } else if (aiState->GetPreviousStatus() >= AIStatus_t::AGGRO &&
+                 aiState->GetStatus() < AIStatus_t::AGGRO) {
+        // Leftover combat skill, cancel it now
+        cancelActivatedSkill = true;
+      }
+
+      if (cancelActivatedSkill) {
+        mServer.lock()->GetSkillManager()->CancelSkill(
+            eState, activated->GetActivationID());
+      }
+    }
+
+    // If the status has been changed to or from ENRAGED, refresh the skill map.
+    if (aiState->GetStatus() == AIStatus_t::ENRAGED ||
+        aiState->GetPreviousStatus() == AIStatus_t::ENRAGED) {
+      aiState->ResetSkillsMapped();
     }
 
     aiState->ResetStatusChanged();
@@ -1029,6 +1049,9 @@ bool AIManager::UpdateState(const std::shared_ptr<ActiveEntityState>& eState,
         break;
       case AIStatus_t::COMBAT:
         actionName = "combat";
+        break;
+      case AIStatus_t::ENRAGED:
+        actionName = "enraged";
         break;
       default:
         break;
@@ -2100,7 +2123,9 @@ void AIManager::RefreshSkillMap(
         case objects::MiSkillBasicData::ActionType_t::GUARD:
         case objects::MiSkillBasicData::ActionType_t::COUNTER:
         case objects::MiSkillBasicData::ActionType_t::DODGE:
-          skillType = (int16_t)AI_SKILL_TYPE_DEF;
+          if (aiState->GetStatus() != AIStatus_t::ENRAGED) {
+            skillType = (int16_t)AI_SKILL_TYPE_DEF;
+          }
           break;
         case objects::MiSkillBasicData::ActionType_t::TALK:
         case objects::MiSkillBasicData::ActionType_t::INTIMIDATE:

--- a/server/channel/src/AIManager.cpp
+++ b/server/channel/src/AIManager.cpp
@@ -2137,7 +2137,7 @@ void AIManager::RefreshSkillMap(
         case objects::MiSkillBasicData::ActionType_t::GUARD:
         case objects::MiSkillBasicData::ActionType_t::COUNTER:
         case objects::MiSkillBasicData::ActionType_t::DODGE:
-          if (aiState->GetStatus() != AIStatus_t::ENRAGED) {
+          if (!aiState->IsEnraged()) {
             skillType = (int16_t)AI_SKILL_TYPE_DEF;
           }
           break;

--- a/server/channel/src/AIState.cpp
+++ b/server/channel/src/AIState.cpp
@@ -55,6 +55,7 @@ BaseScriptEngine& BaseScriptEngine::Using<AIState>() {
     e.Const("FOLLOWING", (int32_t)AIStatus_t::FOLLOWING);
     e.Const("AGGRO", (int32_t)AIStatus_t::AGGRO);
     e.Const("COMBAT", (int32_t)AIStatus_t::COMBAT);
+    e.Const("ENRAGED", (int32_t)AIStatus_t::ENRAGED);
 
     Sqrat::ConstTable(mVM).Enum("AIStatus_t", e);
 
@@ -91,7 +92,7 @@ bool AIState::SetStatus(AIStatus_t status, bool isDefault) {
   // Disallow default setting to target dependent status
   if (isDefault &&
       (status == AIStatus_t::AGGRO || status == AIStatus_t::COMBAT ||
-       status == AIStatus_t::FOLLOWING)) {
+       status == AIStatus_t::ENRAGED || status == AIStatus_t::FOLLOWING)) {
     return false;
   }
 
@@ -132,11 +133,14 @@ bool AIState::SetStatus(AIStatus_t status, bool isDefault) {
   return true;
 }
 
-bool AIState::InCombat() const { return mStatus == AIStatus_t::COMBAT; }
+bool AIState::IsEnraged() const { return mStatus == AIStatus_t::ENRAGED; }
+
+bool AIState::InCombat(bool includeEnraged) const {
+  return mStatus == AIStatus_t::COMBAT || (includeEnraged && IsEnraged());
+}
 
 bool AIState::IsAggro(bool includeCombat) const {
-  return mStatus == AIStatus_t::AGGRO ||
-         (includeCombat && mStatus == AIStatus_t::COMBAT);
+  return mStatus == AIStatus_t::AGGRO || (includeCombat && InCombat());
 }
 
 bool AIState::IsFollowing() const { return mStatus == AIStatus_t::FOLLOWING; }

--- a/server/channel/src/AIState.h
+++ b/server/channel/src/AIState.h
@@ -68,6 +68,7 @@ enum AIStatus_t : uint8_t {
   FOLLOWING,  //!< Entity is following its follow target (if possible)
   AGGRO,      //!< Entity is not in combat yet but is pursuing a target
   COMBAT,     //!< Entity is engaged in combat with one or more opponent
+  ENRAGED,     //!< Entity is engaged in combat and enraged by a skill such as Liberama or Mass Taunt
 };
 
 /**
@@ -109,14 +110,21 @@ class AIState : public objects::AIStateObject {
   bool SetStatus(AIStatus_t status, bool isDefault = false);
 
   /**
+   * Check if the status is set to enraged
+   * @return true if the status is set to enraged
+   */
+  bool IsEnraged() const;
+
+  /**
    * Check if the status is set to combat
+   * @param includeEnraged Optional parameter to include the emraged state too
    * @return true if the status is set to combat
    */
-  bool InCombat() const;
+  bool InCombat(bool includeEnraged = true) const;
 
   /**
    * Check if the status is set to aggro (or optionally combat)
-   * @param includeCombat Optional parameter to include the combat state too
+   * @param includeCombat Optional parameter to include combat states too
    * @return true if the status is set to aggro (or optionally combat)
    */
   bool IsAggro(bool includeCombat = true) const;

--- a/server/channel/src/AIState.h
+++ b/server/channel/src/AIState.h
@@ -68,7 +68,8 @@ enum AIStatus_t : uint8_t {
   FOLLOWING,  //!< Entity is following its follow target (if possible)
   AGGRO,      //!< Entity is not in combat yet but is pursuing a target
   COMBAT,     //!< Entity is engaged in combat with one or more opponent
-  ENRAGED,     //!< Entity is engaged in combat and enraged by a skill such as Liberama or Mass Taunt
+  ENRAGED,    //!< Entity is engaged in combat and enraged by a skill such as
+              //!< Liberama or Mass Taunt
 };
 
 /**

--- a/server/channel/src/CharacterManager.cpp
+++ b/server/channel/src/CharacterManager.cpp
@@ -5944,7 +5944,7 @@ bool CharacterManager::AddRemoveOpponent(
       }
 
       auto aiState = entity->GetAIState();
-      if (aiState && !aiState->IsEnraged()) {
+      if (aiState && !aiState->InCombat()) {
         aiState->SetStatus(AIStatus_t::COMBAT);
       }
 

--- a/server/channel/src/CharacterManager.cpp
+++ b/server/channel/src/CharacterManager.cpp
@@ -5944,7 +5944,7 @@ bool CharacterManager::AddRemoveOpponent(
       }
 
       auto aiState = entity->GetAIState();
-      if (aiState) {
+      if (aiState && !aiState->IsEnraged()) {
         aiState->SetStatus(AIStatus_t::COMBAT);
       }
 

--- a/server/channel/src/SkillManager.cpp
+++ b/server/channel/src/SkillManager.cpp
@@ -10580,6 +10580,7 @@ bool SkillManager::Liberama(
   for (SkillTargetResult& target : pSkill->Targets) {
     auto aiState = target.EntityState->GetAIState();
     if (aiState) {
+      aiState->SetStatus(AIStatus_t::ENRAGED);
       aiManager->UpdateAggro(target.EntityState, source->GetEntityID());
     }
   }


### PR DESCRIPTION
This new AIState is a combat state which suppresses the use of defensive Action Types. It can only be activated by the use of a taunting skill such as Riberama or Taunting Game/Mass Taunt.

Closes #1280 