### PR TITLE
[ADD] Optional plugin requirement for Fusion Mistakes.

### DIFF
--- a/libhack/schema/fusion.xml
+++ b/libhack/schema/fusion.xml
@@ -6,6 +6,9 @@
         <member type="bool" name="TwoWaySpecialEnabled" default="true"/>
         <member type="bool" name="TrifusionEnabled" default="true"/>
         <member type="bool" name="TrifusionSoloEnabled" default="true"/>
+        <member type="set" name="RequiredPlugins">
+            <element type="u32"/>
+        </member>
         <member type="bool" name="OnSuccess"/>
         <member type="bool" name="OnMaxSuccess"/>
         <member type="bool" name="OnFailure"/>

--- a/server/channel/src/FusionManager.cpp
+++ b/server/channel/src/FusionManager.cpp
@@ -1126,10 +1126,9 @@ uint32_t FusionManager::GetMistakeResultType(
   auto state = client->GetClientState();
   auto cState = state->GetCharacterState();
   auto character = cState->GetEntity();
-  auto progress = character->GetProgress();
-
+  auto progress = character->GetProgress().Get();
   mistakeDefs.remove_if(
-      [character](const std::shared_ptr<objects::FusionMistake>& m) {
+      [progress](const std::shared_ptr<objects::FusionMistake>& m) {
         // Check that the player has all required plugins
         bool missingPlugin = false;
         for (auto plugin : m->GetRequiredPlugins()) {
@@ -1139,7 +1138,7 @@ uint32_t FusionManager::GetMistakeResultType(
           CharacterManager::ConvertIDToMaskValues((uint16_t)plugin, index,
                                                   shiftVal);
 
-          uint8_t indexVal = character->GetProgress()->GetPlugins(index);
+          uint8_t indexVal = progress->GetPlugins(index);
 
           if ((indexVal & shiftVal) == 0) {
             missingPlugin = true;

--- a/server/channel/src/FusionManager.cpp
+++ b/server/channel/src/FusionManager.cpp
@@ -1011,9 +1011,9 @@ uint32_t FusionManager::GetResultDemon(
 }
 
 uint32_t FusionManager::GetMistakeResultType(
-    uint32_t demonType1, uint32_t demonType2, uint32_t demonType3,
-    uint32_t targetType, bool success, bool specialFusion, bool specialTarget,
-    double successRate) {
+    const std::shared_ptr<ChannelClientConnection>& client, uint32_t demonType1,
+    uint32_t demonType2, uint32_t demonType3, uint32_t targetType, bool success,
+    bool specialFusion, bool specialTarget, double successRate) {
   auto server = mServer.lock();
   bool triFusion = demonType3 != 0;
 
@@ -1121,6 +1121,32 @@ uint32_t FusionManager::GetMistakeResultType(
     return m->TargetTypesCount() > 0 &&
            !m->TargetTypesContains(targetDef->GetBasic()->GetID()) &&
            !m->TargetTypesContains(targetDef->GetUnionData()->GetBaseDemonID());
+  });
+
+  auto state = client->GetClientState();
+  auto cState = state->GetCharacterState();
+  auto character = cState->GetEntity();
+  auto progress = character->GetProgress();
+  
+  mistakeDefs.remove_if([character](const std::shared_ptr<objects::FusionMistake>& m) {
+    // Check that the player has all required plugins
+    bool missingPlugin = false;
+    for (auto plugin : m->GetRequiredPlugins()) {
+      size_t index;
+      uint8_t shiftVal;
+
+      CharacterManager::ConvertIDToMaskValues((uint16_t)plugin, index,
+                                              shiftVal);
+
+      uint8_t indexVal = character->GetProgress()->GetPlugins(index);
+
+      if (indexVal & shiftVal == 0) {
+        missingPlugin = true;
+        break;
+      }
+    }
+
+    return missingPlugin;
   });
 
   mistakeDefs.remove_if([targetDef, targetLevel](
@@ -1612,8 +1638,9 @@ int8_t FusionManager::ProcessFusion(
     bool specialFusion = costItemType == SVR_CONST.ITEM_KREUZ;
 
     uint32_t mistakeType = GetMistakeResultType(
-        demon1->GetType(), demon2->GetType(), demon3 ? demon3->GetType() : 0,
-        resultDemonType, !failed, specialFusion, specialResult, successRate);
+        client, demon1->GetType(), demon2->GetType(),
+        demon3 ? demon3->GetType() : 0, resultDemonType, !failed, specialFusion,
+        specialResult, successRate);
     if (mistakeType) {
       if (demon3) {
         LogFusionManagerDebug([&]() {

--- a/server/channel/src/FusionManager.cpp
+++ b/server/channel/src/FusionManager.cpp
@@ -1127,27 +1127,28 @@ uint32_t FusionManager::GetMistakeResultType(
   auto cState = state->GetCharacterState();
   auto character = cState->GetEntity();
   auto progress = character->GetProgress();
-  
-  mistakeDefs.remove_if([character](const std::shared_ptr<objects::FusionMistake>& m) {
-    // Check that the player has all required plugins
-    bool missingPlugin = false;
-    for (auto plugin : m->GetRequiredPlugins()) {
-      size_t index;
-      uint8_t shiftVal;
 
-      CharacterManager::ConvertIDToMaskValues((uint16_t)plugin, index,
-                                              shiftVal);
+  mistakeDefs.remove_if(
+      [character](const std::shared_ptr<objects::FusionMistake>& m) {
+        // Check that the player has all required plugins
+        bool missingPlugin = false;
+        for (auto plugin : m->GetRequiredPlugins()) {
+          size_t index;
+          uint8_t shiftVal;
 
-      uint8_t indexVal = character->GetProgress()->GetPlugins(index);
+          CharacterManager::ConvertIDToMaskValues((uint16_t)plugin, index,
+                                                  shiftVal);
 
-      if (indexVal & shiftVal == 0) {
-        missingPlugin = true;
-        break;
-      }
-    }
+          uint8_t indexVal = character->GetProgress()->GetPlugins(index);
 
-    return missingPlugin;
-  });
+          if ((indexVal & shiftVal) == 0) {
+            missingPlugin = true;
+            break;
+          }
+        }
+
+        return missingPlugin;
+      });
 
   mistakeDefs.remove_if([targetDef, targetLevel](
                             const std::shared_ptr<objects::FusionMistake>& m) {

--- a/server/channel/src/FusionManager.h
+++ b/server/channel/src/FusionManager.h
@@ -164,6 +164,7 @@ class FusionManager {
    * Calculate the resulting mistake demon based upon the supplied demon
    * types and potential outcome already determined. Should be ignored
    * for mitama fusions.
+   * @param client Pointer to the client performing the fusion
    * @param demonType1 Type ID of the first demon being fused
    * @param demonType2 Type ID of the second demon being fused
    * @param demonType3 Type ID of the third demon being fused
@@ -175,10 +176,11 @@ class FusionManager {
    * @param successRate Fusion sucess rate checked to determine the result
    * @return Type ID of a mistake outcome
    */
-  uint32_t GetMistakeResultType(uint32_t demonType1, uint32_t demonType2,
-                                uint32_t demonType3, uint32_t targetType,
-                                bool success, bool specialFusion,
-                                bool specialTarget, double successRate);
+  uint32_t GetMistakeResultType(
+      const std::shared_ptr<ChannelClientConnection>& client,
+      uint32_t demonType1, uint32_t demonType2, uint32_t demonType3,
+      uint32_t targetType, bool success, bool specialFusion, bool specialTarget,
+      double successRate);
 
   /**
    * Utility function to check if any or all match set entries are present


### PR DESCRIPTION
Adds field RequiredPlugins to fusionmistake.xml, which is a set of unsigned 32-bit plugin IDs required for the mistake to happen.

Closes #1259 